### PR TITLE
Stop using the native executor

### DIFF
--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -17,7 +17,7 @@
 
 use crate::chain_spec;
 use crate::cli::{Cli, RelayChainCli, Subcommand};
-use crate::service::{new_partial, HydraDXNativeExecutor};
+use crate::service::new_partial;
 
 use codec::Encode;
 use cumulus_primitives_core::ParaId;
@@ -28,7 +28,7 @@ use sc_cli::{
 	ChainSpec, CliConfiguration, DefaultConfigurationValues, ImportParams, KeystoreParams, NetworkParams, Result,
 	RuntimeVersion, SharedParams, SubstrateCli,
 };
-use sc_executor::{sp_wasm_interface::ExtendedHostFunctions, NativeExecutionDispatch};
+use sc_executor::sp_wasm_interface::ExtendedHostFunctions;
 use sc_service::config::{BasePath, PrometheusConfig};
 use sp_core::hexdisplay::HexDisplay;
 use sp_runtime::{
@@ -197,7 +197,7 @@ pub fn run() -> sc_cli::Result<()> {
 						runner.sync_run(|config| {
 							cmd.run::<Block, ExtendedHostFunctions<
 								sp_io::SubstrateHostFunctions,
-								<HydraDXNativeExecutor as NativeExecutionDispatch>::ExtendHostFunctions,
+								frame_benchmarking::benchmarking::HostFunctions,
 							>>(config)
 						})
 					} else {


### PR DESCRIPTION
The native executor is deprecated and also doesn't work together with the new metadata hash (mentioned in the guide https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/guides/enable_metadata_hash/index.html).

<!--- Provide a general summary of your changes in the Title above -->
<!--- We are using semantinc pull request to make our lives easier -->
<!--- Please use prefixes for the title and use ! before : if breaking like below -->
<!--- build: ci: docs: feat: perf: refactor: fix: style: test: refactor!: -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue below using keyword like: Fixes: #0 -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation if necessary.
- [ ] I have added tests to cover my changes, regression test if fixing an issue.
- [ ] This is a breaking change.
