### PR TITLE
fix: Stop using the native executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4795,7 +4795,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx"
-version = "13.1.1"
+version = "13.1.2"
 dependencies = [
  "async-trait",
  "clap 4.5.4",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx"
-version = "13.1.1"
+version = "13.1.2"
 description = "Hydration node"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -17,7 +17,7 @@
 
 use crate::chain_spec;
 use crate::cli::{Cli, RelayChainCli, Subcommand};
-use crate::service::{new_partial, HydraDXNativeExecutor};
+use crate::service::new_partial;
 
 use codec::Encode;
 use cumulus_primitives_core::ParaId;
@@ -28,7 +28,7 @@ use sc_cli::{
 	ChainSpec, CliConfiguration, DefaultConfigurationValues, ImportParams, KeystoreParams, NetworkParams, Result,
 	RuntimeVersion, SharedParams, SubstrateCli,
 };
-use sc_executor::{sp_wasm_interface::ExtendedHostFunctions, NativeExecutionDispatch};
+use sc_executor::sp_wasm_interface::ExtendedHostFunctions;
 use sc_service::config::{BasePath, PrometheusConfig};
 use sp_core::hexdisplay::HexDisplay;
 use sp_runtime::{
@@ -197,7 +197,7 @@ pub fn run() -> sc_cli::Result<()> {
 						runner.sync_run(|config| {
 							cmd.run::<Block, ExtendedHostFunctions<
 								sp_io::SubstrateHostFunctions,
-								<HydraDXNativeExecutor as NativeExecutionDispatch>::ExtendHostFunctions,
+								frame_benchmarking::benchmarking::HostFunctions,
 							>>(config)
 						})
 					} else {


### PR DESCRIPTION
Work done in https://github.com/galacticcouncil/hydration-node/pull/878, prepared for a release.