### PR TITLE
Issue 954 fee estimation api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11318,8 +11318,11 @@ dependencies = [
  "polkadot-primitives",
  "scale-info",
  "serde",
+ "sp-api",
  "sp-core",
+ "sp-runtime",
  "sp-std",
+ "sp-weights",
  "static_assertions",
 ]
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -16,6 +16,9 @@ static_assertions = { workspace = true }
 frame-support = { workspace = true }
 sp-core = { workspace = true }
 sp-std = { workspace = true }
+sp-api = { workspace = true }
+sp-runtime = { workspace = true }
+sp-weights = { workspace = true }
 
 # Polkadot dependencies
 polkadot-primitives = { workspace = true }

--- a/primitives/src/constants.rs
+++ b/primitives/src/constants.rs
@@ -78,6 +78,14 @@ pub mod time {
 	}
 }
 
+pub mod transaction {
+	use frame_support::parameter_types;
+
+	parameter_types! {
+		/// Maximum size of an encoded extrinsic, derived from the max block size
+		pub const MaxExtrinsicSize: u32 = 2 * 1024 * 1024;
+	}
+}
 pub mod chain {
 	pub use crate::{AssetId, Balance};
 	pub use frame_support::weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight};

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -29,7 +29,7 @@ use frame_support::sp_runtime::{
 use sp_core::H160;
 
 pub mod constants;
-
+pub mod runtime_api;
 /// An index to a block.
 pub type BlockNumber = u32;
 

--- a/primitives/src/runtime_api.rs
+++ b/primitives/src/runtime_api.rs
@@ -1,0 +1,20 @@
+use crate::constants::transaction::MaxExtrinsicSize;
+use codec::Codec;
+use frame_support::BoundedVec;
+use sp_weights::Weight;
+
+sp_api::decl_runtime_apis! {
+	pub trait FeeEstimationApi<AccountId, AssetId, Balance>
+	where
+		AccountId: Codec,
+		AssetId: Codec,
+		Balance: Codec,
+	{
+		fn estimate_fee_payment(weight: Weight, account_id: AccountId) -> (AssetId, Balance);
+
+		fn estimate_fee_payment_for_extrinsic(
+			uxt: BoundedVec<u8, MaxExtrinsicSize>,
+			account_id: AccountId
+		) -> (AssetId, Balance);
+	}
+}


### PR DESCRIPTION
Hi @jak-pan,

I’ve opened a draft PR that addresses #954 by introducing a runtime API for fee estimation. The API provides two key methods:

    estimate_fee_payment(weight, account_id): Returns the correct asset and fee amount based on the given weight and the account’s configured currency.
    estimate_fee_payment_for_extrinsic(encoded_extrinsic, account_id): Decodes the extrinsic, determines the applicable fees, and then provides the correct asset and amount.

I’ve also included extensive test coverage covering fallback scenarios (no price available), invalid extrinsic inputs, minimal weight fees, large extrinsics near max size, and account currency switching.

I made it a draft PR since there are only a few days left in the Kudos Carnival, and I wanted to ensure you have a chance to review and provide feedback before finalizing. Please let me know if any changes are needed. Thank you!