### PR TITLE
feat: add staking migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4897,7 +4897,7 @@ dependencies = [
  "pallet-referrals",
  "pallet-route-executor",
  "pallet-stableswap",
- "pallet-staking 4.0.0",
+ "pallet-staking 4.0.1",
  "pallet-transaction-multi-payment",
  "pallet-uniques",
  "pallet-xyk",
@@ -5009,7 +5009,7 @@ dependencies = [
  "pallet-scheduler",
  "pallet-session",
  "pallet-stableswap",
- "pallet-staking 4.0.0",
+ "pallet-staking 4.0.1",
  "pallet-state-trie-migration",
  "pallet-timestamp",
  "pallet-tips",
@@ -9166,7 +9166,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12314,7 +12314,7 @@ dependencies = [
  "pallet-scheduler",
  "pallet-session",
  "pallet-stableswap",
- "pallet-staking 4.0.0",
+ "pallet-staking 4.0.1",
  "pallet-timestamp",
  "pallet-tips",
  "pallet-transaction-multi-payment",
@@ -12378,7 +12378,7 @@ dependencies = [
  "pallet-asset-registry",
  "pallet-omnipool",
  "pallet-stableswap",
- "pallet-staking 4.0.0",
+ "pallet-staking 4.0.1",
  "primitives",
  "scraper",
  "serde",

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ format:
 .PHONY: try-runtime
 try-runtime:
 	$(cargo) build --release --features try-runtime
-	try-runtime --runtime ./target/release/wbuild/hydradx-runtime/hydradx_runtime.wasm on-runtime-upgrade --blocktime 12000 --checks all live --uri wss://archive.rpc.hydration.cloud
+	try-runtime --runtime ./target/release/wbuild/hydradx-runtime/hydradx_runtime.wasm on-runtime-upgrade --checks all live --uri wss://archive.rpc.hydration.cloud:443
 
 .PHONY: build-docs
 build-docs:

--- a/pallets/staking/Cargo.toml
+++ b/pallets/staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-staking"
-version = "4.0.0"
+version = "4.0.1"
 authors = ['GalacticCouncil']
 edition = "2021"
 license = "Apache-2.0"

--- a/pallets/staking/src/migration.rs
+++ b/pallets/staking/src/migration.rs
@@ -1,77 +1,47 @@
-use frame_support::migrations::VersionedMigration;
 use frame_support::{traits::Get, weights::Weight};
 
 use crate::*;
 
-pub mod versioned {
-	use super::*;
+const TARGET: &str = "runtime::staking::migration::v2";
 
-	pub type V1ToV2<T> = VersionedMigration<
-		1,
-		2,
-		v2::VersionUncheckedMigrateV1ToV2<T>,
-		crate::pallet::Pallet<T>,
-		<T as frame_system::Config>::DbWeight,
-	>;
-}
+pub fn migrate_to_v2<T: Config>() -> Weight {
+	let on_chain_storage_version = StorageVersion::get::<Pallet<T>>();
+	let mut weight: Weight = T::DbWeight::get().reads(1);
 
-// This migration clear existing staking votes.
-// It is necessary to clear the votes because staking supports opengov from v2.0.0.
-pub mod v2 {
-	use super::*;
-	use frame_support::traits::OnRuntimeUpgrade;
-	#[cfg(feature = "try-runtime")]
-	use sp_runtime::TryRuntimeError;
+	if on_chain_storage_version < 2 {
+		log::info!(
+			target: TARGET,
+			"Running migration storage v2 for pallet-staking with storage version {:?}",
+			on_chain_storage_version,
+		);
 
-	const TARGET: &str = "runtime::staking::migration::v2";
+		let existing_votes = PositionVotes::<T>::iter().count();
+		let processed_votes = ProcessedVotes::<T>::iter().count();
+		log::info!(
+			target: TARGET,
+			"Clearing '{}' existing votes and '{}' processed votes.",
+			existing_votes,
+			processed_votes
 
-	pub struct VersionUncheckedMigrateV1ToV2<T>(PhantomData<T>);
+		);
 
-	impl<T: Config> OnRuntimeUpgrade for VersionUncheckedMigrateV1ToV2<T> {
-		#[cfg(feature = "try-runtime")]
-		fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
-			let existing_votes = PositionVotes::<T>::iter().count();
-			let processed_votes = ProcessedVotes::<T>::iter().count();
-			log::info!(
-				target: TARGET,
-				"pre-upgrade state contains '{}' existing votes and '{} processed votes.",
-				existing_votes,
-				processed_votes
+		let existing_votes = PositionVotes::<T>::iter().count();
+		let processed_votes = ProcessedVotes::<T>::iter().count();
 
-			);
-			Ok(Vec::new())
-		}
+		weight.saturating_accrue(T::DbWeight::get().reads_writes(1, 1));
+		let _ = PositionVotes::<T>::clear(existing_votes as u32, None);
+		let _ = ProcessedVotes::<T>::clear(processed_votes as u32, None);
 
-		fn on_runtime_upgrade() -> Weight {
-			log::info!(
-				target: TARGET,
-				"running storage migration from version 1 to version 2."
-			);
-
-			let existing_votes = PositionVotes::<T>::iter().count();
-			let processed_votes = ProcessedVotes::<T>::iter().count();
-
-			let mut weight = T::DbWeight::get().reads_writes(1, 1);
-			let _ = PositionVotes::<T>::clear(existing_votes as u32, None);
-			let _ = ProcessedVotes::<T>::clear(processed_votes as u32, None);
-
-			weight.saturating_accrue(T::DbWeight::get().reads(existing_votes.saturating_add(processed_votes) as u64));
-			weight
-		}
-
-		#[cfg(feature = "try-runtime")]
-		fn post_upgrade(_state: Vec<u8>) -> Result<(), TryRuntimeError> {
-			assert_eq!(
-				PositionVotes::<T>::iter().count(),
-				0,
-				"PositionVotes storage is not empty"
-			);
-			assert_eq!(
-				ProcessedVotes::<T>::iter().count(),
-				0,
-				"ProcessedVotes storage is not empty"
-			);
-			Ok(())
-		}
+		weight.saturating_accrue(T::DbWeight::get().reads(existing_votes.saturating_add(processed_votes) as u64));
+		StorageVersion::new(1).put::<Pallet<T>>();
+		weight = weight.saturating_add(T::DbWeight::get().writes(1));
+	} else {
+		log::warn!(
+			target: TARGET,
+			"Attempted to apply migration to v2 but failed because storage version is {:?}",
+			on_chain_storage_version,
+		);
 	}
+
+	weight
 }

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "275.0.0"
+version = "276.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -113,7 +113,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 275,
+	spec_version: 276,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/hydradx/src/migration.rs
+++ b/runtime/hydradx/src/migration.rs
@@ -45,6 +45,7 @@ pub fn bind_pallet_account() -> Weight {
 
 impl OnRuntimeUpgrade for OnRuntimeUpgradeMigration {
 	fn on_runtime_upgrade() -> Weight {
-		bind_pallet_account()
+		let w = bind_pallet_account();
+		pallet_staking::migration::migrate_to_v2::<Runtime>().saturating_add(w)
 	}
 }


### PR DESCRIPTION
Add staking migration in prepare for opengov release.

This migration is clearing existing staking votes if there are any left. 