### PR TITLE
fix: remove stableswap ed check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4919,7 +4919,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "282.0.0"
+version = "283.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -9195,7 +9195,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-stableswap"
-version = "4.2.0"
+version = "4.3.0"
 dependencies = [
  "bitflags 1.3.2",
  "frame-benchmarking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12301,7 +12301,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-integration-tests"
-version = "1.31.0"
+version = "1.32.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "1.31.0"
+version = "1.32.0"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/src/router.rs
+++ b/integration-tests/src/router.rs
@@ -775,13 +775,11 @@ mod router_different_pools_tests {
 					pool_id,
 					(100 * UNITS + some_dust) as i128,
 				));
-				let trades = vec![
-					Trade {
-						pool: PoolType::Stableswap(pool_id),
-						asset_in: pool_id,
-						asset_out: stable_asset_1,
-					},
-				];
+				let trades = vec![Trade {
+					pool: PoolType::Stableswap(pool_id),
+					asset_in: pool_id,
+					asset_out: stable_asset_1,
+				}];
 
 				//Act
 				let amount_to_sell = 100 * UNITS;

--- a/integration-tests/src/router.rs
+++ b/integration-tests/src/router.rs
@@ -760,6 +760,51 @@ mod router_different_pools_tests {
 	}
 
 	#[test]
+	fn account_should_not_have_dust_when_selling_share_asset() {
+		TestNet::reset();
+
+		Hydra::execute_with(|| {
+			let _ = with_transaction(|| {
+				//Arrange
+				let (pool_id, stable_asset_1, stable_asset_2) = init_stableswap().unwrap();
+
+				assert_ok!(Currencies::update_balance(
+					hydradx_runtime::RuntimeOrigin::root(),
+					ALICE.into(),
+					pool_id,
+					(100 * UNITS + 1) as i128,
+				));
+				let trades = vec![
+					Trade {
+						pool: PoolType::Stableswap(pool_id),
+						asset_in: pool_id,
+						asset_out: stable_asset_1,
+					},
+				];
+
+				//Act
+				let amount_to_sell = 100 * UNITS;
+				assert_ok!(Router::sell(
+					hydradx_runtime::RuntimeOrigin::signed(ALICE.into()),
+					pool_id,
+					stable_asset_1,
+					amount_to_sell,
+					0,
+					trades
+				));
+
+				//Assert
+				assert_eq!(
+					hydradx_runtime::Currencies::free_balance(pool_id, &AccountId::from(ALICE)),
+					1
+				);
+				TransactionOutcome::Commit(DispatchResult::Ok(()))
+			});
+		});
+	}
+
+
+	#[test]
 	fn router_should_work_for_hopping_from_omnipool_to_stableswap() {
 		TestNet::reset();
 

--- a/integration-tests/src/router.rs
+++ b/integration-tests/src/router.rs
@@ -760,7 +760,7 @@ mod router_different_pools_tests {
 	}
 
 	#[test]
-	fn account_should_not_have_dust_when_selling_share_asset() {
+	fn account_should_not_have_dust_when_selling_share_asset_with_dust_leftover() {
 		TestNet::reset();
 
 		Hydra::execute_with(|| {
@@ -768,11 +768,12 @@ mod router_different_pools_tests {
 				//Arrange
 				let (pool_id, stable_asset_1, stable_asset_2) = init_stableswap().unwrap();
 
+				let some_dust = 9;
 				assert_ok!(Currencies::update_balance(
 					hydradx_runtime::RuntimeOrigin::root(),
 					ALICE.into(),
 					pool_id,
-					(100 * UNITS + 1) as i128,
+					(100 * UNITS + some_dust) as i128,
 				));
 				let trades = vec![
 					Trade {
@@ -793,16 +794,22 @@ mod router_different_pools_tests {
 					trades
 				));
 
-				//Assert
+				//Assert that no dust left on account
 				assert_eq!(
 					hydradx_runtime::Currencies::free_balance(pool_id, &AccountId::from(ALICE)),
-					1
+					0
 				);
+
+				//Assert that dust is transferred to treasury
+				assert_eq!(
+					hydradx_runtime::Currencies::free_balance(pool_id, &Treasury::account_id()),
+					some_dust
+				);
+
 				TransactionOutcome::Commit(DispatchResult::Ok(()))
 			});
 		});
 	}
-
 
 	#[test]
 	fn router_should_work_for_hopping_from_omnipool_to_stableswap() {
@@ -6193,7 +6200,7 @@ pub fn init_stableswap_with_details(
 		None,
 		Some(b"pool".to_vec().try_into().unwrap()),
 		AssetKind::Token,
-		1u128,
+		1000u128,
 		None,
 		None,
 		None,

--- a/pallets/stableswap/Cargo.toml
+++ b/pallets/stableswap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-stableswap"
-version = "4.2.0"
+version = "4.3.0"
 description = "AMM for correlated assets"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/pallets/stableswap/src/lib.rs
+++ b/pallets/stableswap/src/lib.rs
@@ -694,11 +694,6 @@ pub mod pallet {
 			ensure!(shares <= max_share_amount, Error::<T>::SlippageLimit);
 
 			let current_share_balance = T::Currency::free_balance(pool_id, &who);
-			ensure!(
-				current_share_balance == shares
-					|| current_share_balance.saturating_sub(shares) >= T::MinPoolLiquidity::get(),
-				Error::<T>::InsufficientShareBalance
-			);
 
 			// Burn shares and transfer asset to user.
 			T::Currency::withdraw(pool_id, &who, shares)?;

--- a/pallets/stableswap/src/lib.rs
+++ b/pallets/stableswap/src/lib.rs
@@ -572,7 +572,6 @@ pub mod pallet {
 			let current_share_balance = T::Currency::free_balance(pool_id, &who);
 			ensure!(current_share_balance >= share_amount, Error::<T>::InsufficientShares);
 
-
 			// Retrive pool state.
 			let pool = Pools::<T>::get(pool_id).ok_or(Error::<T>::PoolNotFound)?;
 			let asset_idx = pool.find_asset(asset_id).ok_or(Error::<T>::AssetNotInPool)?;

--- a/pallets/stableswap/src/lib.rs
+++ b/pallets/stableswap/src/lib.rs
@@ -571,11 +571,7 @@ pub mod pallet {
 
 			let current_share_balance = T::Currency::free_balance(pool_id, &who);
 			ensure!(current_share_balance >= share_amount, Error::<T>::InsufficientShares);
-			ensure!(
-				current_share_balance == share_amount
-					|| current_share_balance.saturating_sub(share_amount) >= T::MinPoolLiquidity::get(),
-				Error::<T>::InsufficientShareBalance
-			);
+
 
 			// Retrive pool state.
 			let pool = Pools::<T>::get(pool_id).ok_or(Error::<T>::PoolNotFound)?;

--- a/pallets/stableswap/src/tests/remove_liquidity.rs
+++ b/pallets/stableswap/src/tests/remove_liquidity.rs
@@ -303,15 +303,13 @@ fn remove_liquidity_should_pass_when_remaining_shares_below_min_liquidity() {
 
 			let shares = Tokens::free_balance(pool_id, &BOB);
 
-			assert_ok!(
-				Stableswap::remove_liquidity_one_asset(
-					RuntimeOrigin::signed(BOB),
-					pool_id,
-					asset_c,
-					shares - MinimumLiquidity::get() + 1,
-					0,
-				),
-			);
+			assert_ok!(Stableswap::remove_liquidity_one_asset(
+				RuntimeOrigin::signed(BOB),
+				pool_id,
+				asset_c,
+				shares - MinimumLiquidity::get() + 1,
+				0,
+			),);
 		});
 }
 

--- a/pallets/stableswap/src/tests/remove_liquidity.rs
+++ b/pallets/stableswap/src/tests/remove_liquidity.rs
@@ -851,6 +851,76 @@ fn removing_liquidity_with_exact_amount_should_work() {
 }
 
 #[test]
+fn removing_liquidity_with_exact_amount_should_work_when_dust_left() {
+	let asset_a: AssetId = 1;
+	let asset_b: AssetId = 2;
+	let asset_c: AssetId = 3;
+
+	ExtBuilder::default()
+		.with_endowed_accounts(vec![
+			(BOB, asset_a, 2_000_000_000_000_000_003),
+			(ALICE, asset_a, 52425995641788588073263117),
+			(ALICE, asset_b, 52033213790329),
+			(ALICE, asset_c, 119135337044269),
+		])
+		.with_registered_asset("one".as_bytes().to_vec(), asset_a, 18)
+		.with_registered_asset("two".as_bytes().to_vec(), asset_b, 6)
+		.with_registered_asset("three".as_bytes().to_vec(), asset_c, 6)
+		.with_pool(
+			ALICE,
+			PoolInfo::<AssetId, u64> {
+				assets: vec![asset_a, asset_b, asset_c].try_into().unwrap(),
+				initial_amplification: NonZeroU16::new(2000).unwrap(),
+				final_amplification: NonZeroU16::new(2000).unwrap(),
+				initial_block: 0,
+				final_block: 0,
+				fee: Permill::zero(),
+			},
+			InitialLiquidity {
+				account: ALICE,
+				assets: vec![
+					AssetAmount::new(asset_a, 52425995641788588073263117),
+					AssetAmount::new(asset_b, 52033213790329),
+					AssetAmount::new(asset_c, 119135337044269),
+				],
+			},
+		)
+		.build()
+		.execute_with(|| {
+			let pool_id = get_pool_id_at(0);
+			let amount = 2_000_000_000_000_000_000;
+			Tokens::withdraw(pool_id, &ALICE, 5906657405945079804575283).unwrap();
+			let desired_shares = 1947597621401945851;
+			assert_ok!(Stableswap::add_liquidity_shares(
+				RuntimeOrigin::signed(BOB),
+				pool_id,
+				desired_shares,
+				asset_a,
+				amount + 3, // add liquidity for shares uses slightly more
+			));
+			let received = Tokens::free_balance(pool_id, &BOB);
+			assert_eq!(received, desired_shares);
+			let balance = Tokens::free_balance(asset_a, &BOB);
+			assert_eq!(balance, 0);
+			// ACT
+			assert_ok!(Stableswap::withdraw_asset_amount(
+				RuntimeOrigin::signed(BOB),
+				pool_id,
+				asset_a,
+				amount - 1, maybe here remove more or so
+				desired_shares,
+			));
+
+			// ASSERT
+
+			let received = Tokens::free_balance(pool_id, &BOB);
+			assert_eq!(received, 0);
+			let balance = Tokens::free_balance(asset_a, &BOB);
+			assert_eq!(balance, 1_999_999_999_999_999_999);
+		});
+}
+
+#[test]
 fn removing_liquidity_should_not_give_more_assets() {
 	let asset_a: AssetId = 1;
 	let asset_b: AssetId = 2;

--- a/pallets/stableswap/src/tests/remove_liquidity.rs
+++ b/pallets/stableswap/src/tests/remove_liquidity.rs
@@ -4,10 +4,10 @@ use crate::{assert_balance, Error, Event, Pools};
 use frame_support::traits::Contains;
 use frame_support::{assert_noop, assert_ok, BoundedVec};
 use hydradx_traits::stableswap::AssetAmount;
+use orml_traits::MultiCurrencyExtended;
 use pallet_broadcast::types::{Asset, Destination, Fee};
 use sp_runtime::Permill;
 use std::num::NonZeroU16;
-use orml_traits::MultiCurrencyExtended;
 
 #[test]
 fn remove_liquidity_should_work_when_withdrawing_all_shares() {

--- a/pallets/stableswap/src/tests/remove_liquidity.rs
+++ b/pallets/stableswap/src/tests/remove_liquidity.rs
@@ -907,16 +907,16 @@ fn removing_liquidity_with_exact_amount_should_work_when_dust_left() {
 				RuntimeOrigin::signed(BOB),
 				pool_id,
 				asset_a,
-				amount - 1, maybe here remove more or so
+				amount - 100,
 				desired_shares,
 			));
 
 			// ASSERT
 
-			let received = Tokens::free_balance(pool_id, &BOB);
-			assert_eq!(received, 0);
+			let leftover = Tokens::free_balance(pool_id, &BOB);
+			assert_eq!(leftover, 96);
 			let balance = Tokens::free_balance(asset_a, &BOB);
-			assert_eq!(balance, 1_999_999_999_999_999_999);
+			assert_eq!(balance, 1_999_999_999_999_999_900);
 		});
 }
 

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "282.0.0"
+version = "283.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -113,7 +113,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 282,
+	spec_version: 283,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
We should not do this check as we can have accounts with balance less than `T::MinPoolLiquidity` then the following check prevents the shares withdrawal

https://github.com/galacticcouncil/hydration-node/blob/ea4e622fe5adb0dda12dd4000ac6b55849ff7649/pallets/stableswap/src/lib.rs#L574-L578


TODO:
- [x] check on chopsticks the wasm if works