### PR TITLE
chore: lower staking min. slash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4919,7 +4919,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "283.0.0"
+version = "284.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -12301,7 +12301,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-integration-tests"
-version = "1.32.0"
+version = "1.32.1"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "1.32.0"
+version = "1.32.1"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/src/staking.rs
+++ b/integration-tests/src/staking.rs
@@ -526,7 +526,7 @@ fn increase_should_slash_min_amount_when_increase_is_low() {
 
 		let stake_position =
 			pallet_staking::Pallet::<hydradx_runtime::Runtime>::get_position(alice_position_id).unwrap();
-		assert_eq!(stake_position.accumulated_slash_points, 50);
+		assert_eq!(stake_position.accumulated_slash_points, 5);
 	});
 }
 

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "283.0.0"
+version = "284.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/assets.rs
+++ b/runtime/hydradx/src/assets.rs
@@ -1460,7 +1460,7 @@ pub struct StakingMinSlash;
 
 impl GetByKey<FixedU128, Point> for StakingMinSlash {
 	fn get(_k: &FixedU128) -> Point {
-		50_u128
+		5_u128
 	}
 }
 

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -113,7 +113,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 283,
+	spec_version: 284,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
This PR is lowering staking's min. slash to 5 points from 50.