### PR TITLE
feat: add force_remove_vote to pallet-conviction-voting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "15.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "hash-db",
  "log",
@@ -979,7 +979,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.14.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1802,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1819,7 +1819,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1842,7 +1842,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -1887,7 +1887,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -1917,7 +1917,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1932,7 +1932,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -1958,7 +1958,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.12.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1980,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2006,7 +2006,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -2043,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -2060,7 +2060,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.17.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -2096,7 +2096,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -2107,7 +2107,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -2147,7 +2147,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.15.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -2156,7 +2156,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2172,7 +2172,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2196,7 +2196,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.10.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2222,7 +2222,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -2232,7 +2232,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2249,7 +2249,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2273,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2292,7 +2292,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -2327,7 +2327,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2366,7 +2366,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -3459,7 +3459,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3587,7 +3587,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3611,7 +3611,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "43.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -3661,7 +3661,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "14.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3688,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "array-bytes",
  "docify",
@@ -3733,7 +3733,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.46.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "futures",
  "indicatif",
@@ -3755,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "38.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -3796,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "30.0.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3816,7 +3816,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.1.0",
@@ -3828,7 +3828,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3838,7 +3838,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "cfg-if",
  "docify",
@@ -3858,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3872,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -3882,7 +3882,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6503,7 +6503,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "futures",
  "log",
@@ -6522,7 +6522,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -7395,7 +7395,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-asset-conversion"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7413,7 +7413,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7455,7 +7455,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7472,7 +7472,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7488,7 +7488,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7504,7 +7504,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7519,7 +7519,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7532,7 +7532,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7555,7 +7555,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "aquamarine",
  "docify",
@@ -7576,7 +7576,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7591,7 +7591,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7610,7 +7610,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -7659,7 +7659,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7696,7 +7696,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.17.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -7714,7 +7714,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7804,7 +7804,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7823,7 +7823,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7839,7 +7839,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -7926,7 +7926,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "5.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7961,7 +7961,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8068,7 +8068,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8090,7 +8090,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8103,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8310,7 +8310,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8346,7 +8346,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8368,7 +8368,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -8384,7 +8384,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8403,7 +8403,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8509,7 +8509,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8525,7 +8525,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "41.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -8544,7 +8544,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8561,7 +8561,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8596,7 +8596,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8611,7 +8611,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "35.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8629,7 +8629,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "36.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8649,7 +8649,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "33.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -8659,7 +8659,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8813,7 +8813,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.9.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8830,7 +8830,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8846,7 +8846,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8860,7 +8860,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "38.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8878,7 +8878,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8892,7 +8892,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8946,7 +8946,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8987,7 +8987,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9025,7 +9025,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9041,7 +9041,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9111,7 +9111,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9133,7 +9133,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "22.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -9142,7 +9142,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9152,7 +9152,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9168,7 +9168,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9183,7 +9183,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9202,7 +9202,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9269,7 +9269,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "38.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9284,7 +9284,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -9300,7 +9300,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -9312,7 +9312,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9330,7 +9330,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9344,7 +9344,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9360,7 +9360,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9374,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -9412,7 +9412,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9482,7 +9482,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -9835,7 +9835,7 @@ dependencies = [
 [[package]]
 name = "polkadot-approval-distribution"
 version = "18.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "bitvec",
  "futures",
@@ -9855,7 +9855,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "always-assert",
  "futures",
@@ -9871,7 +9871,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "derive_more",
  "fatality",
@@ -9895,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "fatality",
@@ -9928,7 +9928,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "cfg-if",
  "clap",
@@ -9956,7 +9956,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "bitvec",
  "fatality",
@@ -9979,7 +9979,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "15.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9990,7 +9990,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "derive_more",
  "fatality",
@@ -10015,7 +10015,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -10029,7 +10029,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10051,7 +10051,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -10074,7 +10074,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -10092,7 +10092,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "18.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -10125,7 +10125,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "bitvec",
  "futures",
@@ -10147,7 +10147,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10167,7 +10167,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -10182,7 +10182,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "futures",
@@ -10204,7 +10204,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -10218,7 +10218,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10235,7 +10235,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "fatality",
  "futures",
@@ -10254,7 +10254,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "futures",
@@ -10271,7 +10271,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "fatality",
  "futures",
@@ -10285,7 +10285,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10303,7 +10303,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "always-assert",
  "array-bytes",
@@ -10332,7 +10332,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -10348,7 +10348,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "cpu-time",
  "futures",
@@ -10374,7 +10374,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -10389,7 +10389,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "lazy_static",
  "log",
@@ -10408,7 +10408,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "bs58 0.5.1",
  "futures",
@@ -10427,7 +10427,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "18.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -10453,7 +10453,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -10479,7 +10479,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -10489,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -10519,7 +10519,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -10555,7 +10555,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "futures",
@@ -10577,7 +10577,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "bounded-collections",
  "derive_more",
@@ -10593,7 +10593,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -10619,7 +10619,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -10654,7 +10654,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -10704,7 +10704,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "bs58 0.5.1",
  "frame-benchmarking",
@@ -10716,7 +10716,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -10765,7 +10765,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -10872,7 +10872,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
@@ -10895,7 +10895,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -11963,7 +11963,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -12063,7 +12063,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -12561,7 +12561,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "29.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "log",
  "sp-core",
@@ -12572,7 +12572,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "futures",
@@ -12602,7 +12602,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12624,7 +12624,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.42.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -12639,7 +12639,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "array-bytes",
  "docify",
@@ -12666,7 +12666,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -12677,7 +12677,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.47.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -12718,7 +12718,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "fnv",
  "futures",
@@ -12745,7 +12745,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -12771,7 +12771,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "futures",
@@ -12795,7 +12795,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "futures",
@@ -12824,7 +12824,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -12860,7 +12860,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -12882,7 +12882,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -12918,7 +12918,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -12938,7 +12938,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -12951,7 +12951,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.30.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -12995,7 +12995,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.30.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -13015,7 +13015,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "futures",
@@ -13038,7 +13038,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.40.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -13061,7 +13061,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.35.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -13074,7 +13074,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.32.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "log",
  "polkavm",
@@ -13085,7 +13085,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.35.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -13103,7 +13103,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "console",
  "futures",
@@ -13120,7 +13120,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "33.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -13134,7 +13134,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.15.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.4",
@@ -13163,7 +13163,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.45.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13214,7 +13214,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -13232,7 +13232,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "ahash",
  "futures",
@@ -13251,7 +13251,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13272,7 +13272,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13309,7 +13309,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "array-bytes",
  "futures",
@@ -13328,7 +13328,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.12.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "bs58 0.5.1",
  "ed25519-dalek",
@@ -13345,7 +13345,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -13379,7 +13379,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -13388,7 +13388,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -13420,7 +13420,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13440,7 +13440,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "17.1.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -13464,7 +13464,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "array-bytes",
  "futures",
@@ -13496,7 +13496,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.46.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "directories",
@@ -13560,7 +13560,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.36.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -13571,7 +13571,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.22.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "clap",
  "fs4",
@@ -13584,7 +13584,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13603,7 +13603,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "derive_more",
  "futures",
@@ -13624,7 +13624,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "25.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "chrono",
  "futures",
@@ -13644,7 +13644,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "37.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "chrono",
  "console",
@@ -13673,7 +13673,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -13684,7 +13684,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "futures",
@@ -13711,7 +13711,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "futures",
@@ -13727,7 +13727,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -14268,7 +14268,7 @@ dependencies = [
 [[package]]
 name = "slot-range-helper"
 version = "15.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -14475,7 +14475,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "docify",
  "hash-db",
@@ -14497,7 +14497,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -14511,7 +14511,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14523,7 +14523,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -14537,7 +14537,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14549,7 +14549,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -14559,7 +14559,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "37.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -14578,7 +14578,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "futures",
@@ -14593,7 +14593,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14609,7 +14609,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14627,7 +14627,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "22.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -14648,7 +14648,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "21.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -14665,7 +14665,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.40.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14676,7 +14676,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "array-bytes",
  "bitflags 1.3.2",
@@ -14722,7 +14722,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -14735,7 +14735,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
@@ -14745,7 +14745,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -14754,7 +14754,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14764,7 +14764,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.29.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -14774,7 +14774,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.15.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14786,7 +14786,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -14799,7 +14799,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "bytes",
  "docify",
@@ -14825,7 +14825,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -14835,7 +14835,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -14846,7 +14846,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -14855,7 +14855,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.7.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -14865,7 +14865,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.12.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14876,7 +14876,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "34.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -14893,7 +14893,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14906,7 +14906,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -14916,7 +14916,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -14926,7 +14926,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "32.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -14936,7 +14936,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "39.0.5"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "docify",
  "either",
@@ -14962,7 +14962,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "28.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -14981,7 +14981,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "Inflector",
  "expander",
@@ -14994,7 +14994,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "36.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -15008,7 +15008,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "36.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -15021,7 +15021,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.43.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "hash-db",
  "log",
@@ -15041,7 +15041,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -15065,12 +15065,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 
 [[package]]
 name = "sp-storage"
 version = "21.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -15082,7 +15082,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -15094,7 +15094,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -15105,7 +15105,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -15114,7 +15114,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -15128,7 +15128,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "ahash",
  "hash-db",
@@ -15151,7 +15151,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -15168,7 +15168,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -15179,7 +15179,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -15191,7 +15191,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -15268,7 +15268,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-parachain-info"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -15281,7 +15281,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "14.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -15300,7 +15300,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "17.0.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -15322,7 +15322,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -15465,7 +15465,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -15490,12 +15490,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -15515,7 +15515,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "http-body-util",
  "hyper 1.5.1",
@@ -15529,7 +15529,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -15542,7 +15542,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15559,7 +15559,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "24.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "array-bytes",
  "build-helper",
@@ -16168,7 +16168,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -16179,7 +16179,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "expander",
  "proc-macro-crate 3.1.0",
@@ -17008,7 +17008,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "18.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -17116,7 +17116,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -17506,7 +17506,7 @@ dependencies = [
 [[package]]
 name = "xcm-emulator"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "array-bytes",
  "cumulus-pallet-parachain-system",
@@ -17541,7 +17541,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "10.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -17552,7 +17552,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.4.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
 dependencies = [
  "frame-support",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "15.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "hash-db",
  "log",
@@ -979,7 +979,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.14.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1802,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1819,7 +1819,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1842,7 +1842,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -1887,7 +1887,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -1917,7 +1917,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1932,7 +1932,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -1958,7 +1958,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.12.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1980,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2006,7 +2006,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -2043,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -2060,7 +2060,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.17.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -2096,7 +2096,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -2107,7 +2107,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -2147,7 +2147,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.15.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -2156,7 +2156,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2172,7 +2172,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2196,7 +2196,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.10.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2222,7 +2222,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -2232,7 +2232,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2249,7 +2249,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2273,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2292,7 +2292,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -2327,7 +2327,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2366,7 +2366,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -3459,7 +3459,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3587,7 +3587,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3611,7 +3611,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "43.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -3661,7 +3661,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "14.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3688,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "array-bytes",
  "docify",
@@ -3733,7 +3733,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.46.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "futures",
  "indicatif",
@@ -3755,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "38.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -3796,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "30.0.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3816,7 +3816,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.1.0",
@@ -3828,7 +3828,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3838,7 +3838,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "cfg-if",
  "docify",
@@ -3858,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3872,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -3882,7 +3882,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6503,7 +6503,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "futures",
  "log",
@@ -6522,7 +6522,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -7395,7 +7395,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-asset-conversion"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7413,7 +7413,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7455,7 +7455,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7472,7 +7472,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7488,7 +7488,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7504,7 +7504,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7519,7 +7519,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7532,7 +7532,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7555,7 +7555,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "aquamarine",
  "docify",
@@ -7576,7 +7576,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7591,7 +7591,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7610,7 +7610,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -7659,7 +7659,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7696,7 +7696,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.17.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -7714,7 +7714,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7804,7 +7804,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7823,7 +7823,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7839,7 +7839,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -7926,7 +7926,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "5.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7961,7 +7961,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8068,7 +8068,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8090,7 +8090,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8103,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8310,7 +8310,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8346,7 +8346,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8368,7 +8368,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -8384,7 +8384,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8403,7 +8403,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8509,7 +8509,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8525,7 +8525,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "41.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -8544,7 +8544,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8561,7 +8561,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8596,7 +8596,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8611,7 +8611,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "35.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8629,7 +8629,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "36.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8649,7 +8649,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "33.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -8659,7 +8659,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8813,7 +8813,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.9.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8830,7 +8830,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8846,7 +8846,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8860,7 +8860,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "38.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8878,7 +8878,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8892,7 +8892,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8946,7 +8946,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8987,7 +8987,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9025,7 +9025,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9041,7 +9041,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9111,7 +9111,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9133,7 +9133,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "22.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -9142,7 +9142,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9152,7 +9152,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9168,7 +9168,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9183,7 +9183,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9202,7 +9202,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9269,7 +9269,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "38.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9284,7 +9284,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -9300,7 +9300,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -9312,7 +9312,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9330,7 +9330,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9344,7 +9344,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9360,7 +9360,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9374,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -9412,7 +9412,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9482,7 +9482,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -9835,7 +9835,7 @@ dependencies = [
 [[package]]
 name = "polkadot-approval-distribution"
 version = "18.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "bitvec",
  "futures",
@@ -9855,7 +9855,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "always-assert",
  "futures",
@@ -9871,7 +9871,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "derive_more",
  "fatality",
@@ -9895,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "fatality",
@@ -9928,7 +9928,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "cfg-if",
  "clap",
@@ -9956,7 +9956,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "bitvec",
  "fatality",
@@ -9979,7 +9979,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "15.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9990,7 +9990,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "derive_more",
  "fatality",
@@ -10015,7 +10015,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -10029,7 +10029,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10051,7 +10051,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -10074,7 +10074,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -10092,7 +10092,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "18.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -10125,7 +10125,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "bitvec",
  "futures",
@@ -10147,7 +10147,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10167,7 +10167,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -10182,7 +10182,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "futures",
@@ -10204,7 +10204,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -10218,7 +10218,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10235,7 +10235,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "fatality",
  "futures",
@@ -10254,7 +10254,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "futures",
@@ -10271,7 +10271,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "fatality",
  "futures",
@@ -10285,7 +10285,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10303,7 +10303,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "always-assert",
  "array-bytes",
@@ -10332,7 +10332,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -10348,7 +10348,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "cpu-time",
  "futures",
@@ -10374,7 +10374,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -10389,7 +10389,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "lazy_static",
  "log",
@@ -10408,7 +10408,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "bs58 0.5.1",
  "futures",
@@ -10427,7 +10427,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "18.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -10453,7 +10453,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -10479,7 +10479,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -10489,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -10519,7 +10519,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -10555,7 +10555,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "futures",
@@ -10577,7 +10577,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "bounded-collections",
  "derive_more",
@@ -10593,7 +10593,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -10619,7 +10619,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -10654,7 +10654,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -10704,7 +10704,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "bs58 0.5.1",
  "frame-benchmarking",
@@ -10716,7 +10716,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -10765,7 +10765,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -10872,7 +10872,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
@@ -10895,7 +10895,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -11963,7 +11963,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -12063,7 +12063,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -12561,7 +12561,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "29.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "log",
  "sp-core",
@@ -12572,7 +12572,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "futures",
@@ -12602,7 +12602,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12624,7 +12624,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.42.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -12639,7 +12639,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "array-bytes",
  "docify",
@@ -12666,7 +12666,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -12677,7 +12677,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.47.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -12718,7 +12718,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "fnv",
  "futures",
@@ -12745,7 +12745,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -12771,7 +12771,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "futures",
@@ -12795,7 +12795,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "futures",
@@ -12824,7 +12824,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -12860,7 +12860,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -12882,7 +12882,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -12918,7 +12918,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -12938,7 +12938,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -12951,7 +12951,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.30.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -12995,7 +12995,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.30.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -13015,7 +13015,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "futures",
@@ -13038,7 +13038,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.40.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -13061,7 +13061,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.35.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -13074,7 +13074,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.32.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "log",
  "polkavm",
@@ -13085,7 +13085,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.35.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -13103,7 +13103,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "console",
  "futures",
@@ -13120,7 +13120,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "33.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -13134,7 +13134,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.15.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.4",
@@ -13163,7 +13163,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.45.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13214,7 +13214,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -13232,7 +13232,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "ahash",
  "futures",
@@ -13251,7 +13251,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13272,7 +13272,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13309,7 +13309,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "array-bytes",
  "futures",
@@ -13328,7 +13328,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.12.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "bs58 0.5.1",
  "ed25519-dalek",
@@ -13345,7 +13345,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -13379,7 +13379,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -13388,7 +13388,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -13420,7 +13420,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13440,7 +13440,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "17.1.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -13464,7 +13464,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "array-bytes",
  "futures",
@@ -13496,7 +13496,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.46.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "directories",
@@ -13560,7 +13560,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.36.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -13571,7 +13571,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.22.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "clap",
  "fs4",
@@ -13584,7 +13584,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13603,7 +13603,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "derive_more",
  "futures",
@@ -13624,7 +13624,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "25.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "chrono",
  "futures",
@@ -13644,7 +13644,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "37.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "chrono",
  "console",
@@ -13673,7 +13673,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -13684,7 +13684,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "futures",
@@ -13711,7 +13711,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "futures",
@@ -13727,7 +13727,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -14268,7 +14268,7 @@ dependencies = [
 [[package]]
 name = "slot-range-helper"
 version = "15.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -14475,7 +14475,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "docify",
  "hash-db",
@@ -14497,7 +14497,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -14511,7 +14511,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14523,7 +14523,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -14537,7 +14537,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14549,7 +14549,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -14559,7 +14559,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "37.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -14578,7 +14578,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "futures",
@@ -14593,7 +14593,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14609,7 +14609,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14627,7 +14627,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "22.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -14648,7 +14648,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "21.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -14665,7 +14665,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.40.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14676,7 +14676,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "array-bytes",
  "bitflags 1.3.2",
@@ -14722,7 +14722,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -14735,7 +14735,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
@@ -14745,7 +14745,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -14754,7 +14754,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14764,7 +14764,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.29.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -14774,7 +14774,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.15.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14786,7 +14786,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -14799,7 +14799,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "bytes",
  "docify",
@@ -14825,7 +14825,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -14835,7 +14835,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -14846,7 +14846,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -14855,7 +14855,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.7.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -14865,7 +14865,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.12.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14876,7 +14876,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "34.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -14893,7 +14893,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14906,7 +14906,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -14916,7 +14916,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -14926,7 +14926,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "32.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -14936,7 +14936,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "39.0.5"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "docify",
  "either",
@@ -14962,7 +14962,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "28.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -14981,7 +14981,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "Inflector",
  "expander",
@@ -14994,7 +14994,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "36.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -15008,7 +15008,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "36.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -15021,7 +15021,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.43.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "hash-db",
  "log",
@@ -15041,7 +15041,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -15065,12 +15065,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 
 [[package]]
 name = "sp-storage"
 version = "21.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -15082,7 +15082,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -15094,7 +15094,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -15105,7 +15105,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -15114,7 +15114,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -15128,7 +15128,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "ahash",
  "hash-db",
@@ -15151,7 +15151,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -15168,7 +15168,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -15179,7 +15179,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -15191,7 +15191,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -15268,7 +15268,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-parachain-info"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -15281,7 +15281,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "14.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -15300,7 +15300,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "17.0.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -15322,7 +15322,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -15465,7 +15465,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -15490,12 +15490,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -15515,7 +15515,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "http-body-util",
  "hyper 1.5.1",
@@ -15529,7 +15529,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -15542,7 +15542,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15559,7 +15559,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "24.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "array-bytes",
  "build-helper",
@@ -16168,7 +16168,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -16179,7 +16179,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "expander",
  "proc-macro-crate 3.1.0",
@@ -17008,7 +17008,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "18.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -17116,7 +17116,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -17506,7 +17506,7 @@ dependencies = [
 [[package]]
 name = "xcm-emulator"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "array-bytes",
  "cumulus-pallet-parachain-system",
@@ -17541,7 +17541,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "10.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -17552,7 +17552,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.4.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#abf8e84942f95ba0150e1b80982ff567eab821fc"
 dependencies = [
  "frame-support",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4670,7 +4670,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "288.0.0"
+version = "289.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "15.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "hash-db",
  "log",
@@ -979,7 +979,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.14.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1802,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1819,7 +1819,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1842,7 +1842,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -1887,7 +1887,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -1917,7 +1917,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1932,7 +1932,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -1958,7 +1958,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.12.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1980,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2006,7 +2006,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -2043,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -2060,7 +2060,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.17.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -2096,7 +2096,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -2107,7 +2107,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -2147,7 +2147,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.15.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -2156,7 +2156,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2172,7 +2172,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2196,7 +2196,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.10.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2222,7 +2222,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -2232,7 +2232,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2249,7 +2249,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2273,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2292,7 +2292,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -2327,7 +2327,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2366,7 +2366,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -3459,7 +3459,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3587,7 +3587,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3611,7 +3611,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "43.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -3661,7 +3661,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "14.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3688,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "array-bytes",
  "docify",
@@ -3733,7 +3733,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.46.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "futures",
  "indicatif",
@@ -3755,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "38.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -3796,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "30.0.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3816,7 +3816,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.1.0",
@@ -3828,7 +3828,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3838,7 +3838,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "cfg-if",
  "docify",
@@ -3858,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3872,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -3882,7 +3882,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6503,7 +6503,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "futures",
  "log",
@@ -6522,7 +6522,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -7395,7 +7395,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-asset-conversion"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7413,7 +7413,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7455,7 +7455,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7472,7 +7472,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7488,7 +7488,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7504,7 +7504,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7519,7 +7519,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7532,7 +7532,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7555,7 +7555,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "aquamarine",
  "docify",
@@ -7576,7 +7576,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7591,7 +7591,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7610,7 +7610,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -7659,7 +7659,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7696,7 +7696,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.17.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -7714,7 +7714,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7804,7 +7804,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7823,7 +7823,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7839,7 +7839,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -7926,7 +7926,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "5.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7961,7 +7961,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8068,7 +8068,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8090,7 +8090,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8103,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8310,7 +8310,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8346,7 +8346,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8368,7 +8368,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -8384,7 +8384,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8403,7 +8403,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8509,7 +8509,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8525,7 +8525,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "41.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -8544,7 +8544,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8561,7 +8561,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8596,7 +8596,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8611,7 +8611,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "35.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8629,7 +8629,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "36.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8649,7 +8649,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "33.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -8659,7 +8659,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8813,7 +8813,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.9.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8830,7 +8830,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8846,7 +8846,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8860,7 +8860,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "38.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8878,7 +8878,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8892,7 +8892,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8946,7 +8946,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8987,7 +8987,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9025,7 +9025,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9041,7 +9041,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9111,7 +9111,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9133,7 +9133,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "22.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -9142,7 +9142,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9152,7 +9152,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9168,7 +9168,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9183,7 +9183,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9202,7 +9202,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9269,7 +9269,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "38.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9284,7 +9284,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -9300,7 +9300,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -9312,7 +9312,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9330,7 +9330,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9344,7 +9344,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9360,7 +9360,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9374,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -9412,7 +9412,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9482,7 +9482,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -9835,7 +9835,7 @@ dependencies = [
 [[package]]
 name = "polkadot-approval-distribution"
 version = "18.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "bitvec",
  "futures",
@@ -9855,7 +9855,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "always-assert",
  "futures",
@@ -9871,7 +9871,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "derive_more",
  "fatality",
@@ -9895,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "fatality",
@@ -9928,7 +9928,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "cfg-if",
  "clap",
@@ -9956,7 +9956,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "bitvec",
  "fatality",
@@ -9979,7 +9979,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "15.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9990,7 +9990,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "derive_more",
  "fatality",
@@ -10015,7 +10015,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -10029,7 +10029,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10051,7 +10051,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -10074,7 +10074,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -10092,7 +10092,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "18.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -10125,7 +10125,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "bitvec",
  "futures",
@@ -10147,7 +10147,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10167,7 +10167,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -10182,7 +10182,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "futures",
@@ -10204,7 +10204,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -10218,7 +10218,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10235,7 +10235,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "fatality",
  "futures",
@@ -10254,7 +10254,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "futures",
@@ -10271,7 +10271,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "fatality",
  "futures",
@@ -10285,7 +10285,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10303,7 +10303,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "always-assert",
  "array-bytes",
@@ -10332,7 +10332,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -10348,7 +10348,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "cpu-time",
  "futures",
@@ -10374,7 +10374,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -10389,7 +10389,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "lazy_static",
  "log",
@@ -10408,7 +10408,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "bs58 0.5.1",
  "futures",
@@ -10427,7 +10427,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "18.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -10453,7 +10453,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -10479,7 +10479,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -10489,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -10519,7 +10519,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -10555,7 +10555,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "futures",
@@ -10577,7 +10577,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "bounded-collections",
  "derive_more",
@@ -10593,7 +10593,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -10619,7 +10619,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -10654,7 +10654,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -10704,7 +10704,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "bs58 0.5.1",
  "frame-benchmarking",
@@ -10716,7 +10716,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -10765,7 +10765,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -10872,7 +10872,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
@@ -10895,7 +10895,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -11963,7 +11963,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -12063,7 +12063,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -12561,7 +12561,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "29.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "log",
  "sp-core",
@@ -12572,7 +12572,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "futures",
@@ -12602,7 +12602,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12624,7 +12624,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.42.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -12639,7 +12639,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "array-bytes",
  "docify",
@@ -12666,7 +12666,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -12677,7 +12677,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.47.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -12718,7 +12718,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "fnv",
  "futures",
@@ -12745,7 +12745,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -12771,7 +12771,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "futures",
@@ -12795,7 +12795,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "futures",
@@ -12824,7 +12824,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -12860,7 +12860,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -12882,7 +12882,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -12918,7 +12918,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -12938,7 +12938,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -12951,7 +12951,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.30.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -12995,7 +12995,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.30.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -13015,7 +13015,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "futures",
@@ -13038,7 +13038,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.40.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -13061,7 +13061,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.35.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -13074,7 +13074,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.32.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "log",
  "polkavm",
@@ -13085,7 +13085,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.35.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -13103,7 +13103,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "console",
  "futures",
@@ -13120,7 +13120,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "33.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -13134,7 +13134,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.15.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.4",
@@ -13163,7 +13163,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.45.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13214,7 +13214,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -13232,7 +13232,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "ahash",
  "futures",
@@ -13251,7 +13251,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13272,7 +13272,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13309,7 +13309,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "array-bytes",
  "futures",
@@ -13328,7 +13328,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.12.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "bs58 0.5.1",
  "ed25519-dalek",
@@ -13345,7 +13345,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -13379,7 +13379,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -13388,7 +13388,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -13420,7 +13420,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13440,7 +13440,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "17.1.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -13464,7 +13464,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "array-bytes",
  "futures",
@@ -13496,7 +13496,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.46.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "directories",
@@ -13560,7 +13560,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.36.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -13571,7 +13571,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.22.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "clap",
  "fs4",
@@ -13584,7 +13584,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13603,7 +13603,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "derive_more",
  "futures",
@@ -13624,7 +13624,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "25.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "chrono",
  "futures",
@@ -13644,7 +13644,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "37.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "chrono",
  "console",
@@ -13673,7 +13673,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -13684,7 +13684,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "futures",
@@ -13711,7 +13711,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "futures",
@@ -13727,7 +13727,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -14268,7 +14268,7 @@ dependencies = [
 [[package]]
 name = "slot-range-helper"
 version = "15.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -14475,7 +14475,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "docify",
  "hash-db",
@@ -14497,7 +14497,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -14511,7 +14511,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14523,7 +14523,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -14537,7 +14537,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14549,7 +14549,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -14559,7 +14559,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "37.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -14578,7 +14578,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "futures",
@@ -14593,7 +14593,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14609,7 +14609,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14627,7 +14627,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "22.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -14648,7 +14648,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "21.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -14665,7 +14665,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.40.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14676,7 +14676,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "array-bytes",
  "bitflags 1.3.2",
@@ -14722,7 +14722,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -14735,7 +14735,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
@@ -14745,7 +14745,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -14754,7 +14754,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14764,7 +14764,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.29.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -14774,7 +14774,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.15.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14786,7 +14786,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -14799,7 +14799,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "bytes",
  "docify",
@@ -14825,7 +14825,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -14835,7 +14835,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -14846,7 +14846,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -14855,7 +14855,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.7.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -14865,7 +14865,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.12.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14876,7 +14876,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "34.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -14893,7 +14893,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14906,7 +14906,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -14916,7 +14916,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -14926,7 +14926,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "32.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -14936,7 +14936,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "39.0.5"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "docify",
  "either",
@@ -14962,7 +14962,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "28.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -14981,7 +14981,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "Inflector",
  "expander",
@@ -14994,7 +14994,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "36.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -15008,7 +15008,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "36.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -15021,7 +15021,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.43.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "hash-db",
  "log",
@@ -15041,7 +15041,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -15065,12 +15065,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 
 [[package]]
 name = "sp-storage"
 version = "21.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -15082,7 +15082,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -15094,7 +15094,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -15105,7 +15105,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -15114,7 +15114,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -15128,7 +15128,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "ahash",
  "hash-db",
@@ -15151,7 +15151,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -15168,7 +15168,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -15179,7 +15179,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -15191,7 +15191,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -15268,7 +15268,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-parachain-info"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -15281,7 +15281,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "14.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -15300,7 +15300,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "17.0.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -15322,7 +15322,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -15465,7 +15465,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -15490,12 +15490,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -15515,7 +15515,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "http-body-util",
  "hyper 1.5.1",
@@ -15529,7 +15529,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -15542,7 +15542,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15559,7 +15559,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "24.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "array-bytes",
  "build-helper",
@@ -16168,7 +16168,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -16179,7 +16179,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "expander",
  "proc-macro-crate 3.1.0",
@@ -17008,7 +17008,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "18.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -17116,7 +17116,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -17506,7 +17506,7 @@ dependencies = [
 [[package]]
 name = "xcm-emulator"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "array-bytes",
  "cumulus-pallet-parachain-system",
@@ -17541,7 +17541,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "10.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -17552,7 +17552,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.4.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3223af8de92676eed778d2792c9d0e8d149919c4"
 dependencies = [
  "frame-support",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "15.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "hash-db",
  "log",
@@ -979,7 +979,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.14.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1802,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1819,7 +1819,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1842,7 +1842,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -1887,7 +1887,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -1917,7 +1917,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1932,7 +1932,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -1958,7 +1958,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.12.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1980,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2006,7 +2006,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -2014,7 +2014,7 @@ dependencies = [
  "cumulus-client-network",
  "cumulus-client-pov-recovery",
  "cumulus-primitives-core",
- "cumulus-primitives-proof-size-hostfunction 0.10.0 (git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch)",
+ "cumulus-primitives-proof-size-hostfunction 0.10.0 (git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2)",
  "cumulus-relay-chain-inprocess-interface",
  "cumulus-relay-chain-interface",
  "cumulus-relay-chain-minimal-node",
@@ -2043,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -2060,13 +2060,13 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.17.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
  "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",
- "cumulus-primitives-proof-size-hostfunction 0.10.0 (git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch)",
+ "cumulus-primitives-proof-size-hostfunction 0.10.0 (git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2)",
  "environmental",
  "frame-benchmarking",
  "frame-support",
@@ -2096,7 +2096,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -2107,7 +2107,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -2147,7 +2147,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.15.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -2156,7 +2156,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2172,7 +2172,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2196,7 +2196,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.10.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2222,7 +2222,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -2232,7 +2232,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2249,7 +2249,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2273,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2292,7 +2292,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -2327,7 +2327,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2366,7 +2366,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -3459,7 +3459,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3587,7 +3587,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3611,7 +3611,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "43.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -3661,7 +3661,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "14.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3688,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "array-bytes",
  "docify",
@@ -3733,7 +3733,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.46.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "futures",
  "indicatif",
@@ -3755,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "38.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -3796,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "30.0.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3816,7 +3816,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.1.0",
@@ -3828,7 +3828,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3838,7 +3838,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "cfg-if",
  "docify",
@@ -3858,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3872,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -3882,7 +3882,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6503,7 +6503,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "futures",
  "log",
@@ -6522,7 +6522,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -7395,7 +7395,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-asset-conversion"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7413,7 +7413,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7455,7 +7455,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7472,7 +7472,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7488,7 +7488,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7504,7 +7504,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7519,7 +7519,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7532,7 +7532,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7555,7 +7555,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "aquamarine",
  "docify",
@@ -7576,7 +7576,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7591,7 +7591,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7610,7 +7610,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -7659,7 +7659,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7696,7 +7696,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.17.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -7714,7 +7714,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7804,7 +7804,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7823,7 +7823,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7839,7 +7839,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -7926,7 +7926,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "5.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7961,7 +7961,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8068,7 +8068,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8090,7 +8090,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8103,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8310,7 +8310,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8346,7 +8346,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8368,7 +8368,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -8384,7 +8384,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8403,7 +8403,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8509,7 +8509,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8525,7 +8525,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "41.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -8544,7 +8544,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8561,7 +8561,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8596,7 +8596,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8611,7 +8611,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "35.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8629,7 +8629,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "36.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8649,7 +8649,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "33.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -8659,7 +8659,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8813,7 +8813,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.9.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8830,7 +8830,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8846,7 +8846,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8860,7 +8860,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "38.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8878,7 +8878,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8892,7 +8892,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8946,7 +8946,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8987,7 +8987,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9025,7 +9025,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9041,7 +9041,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9111,7 +9111,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9133,7 +9133,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "22.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -9142,7 +9142,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9152,7 +9152,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9168,7 +9168,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9183,7 +9183,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9202,7 +9202,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9269,7 +9269,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "38.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9284,7 +9284,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -9300,7 +9300,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -9312,7 +9312,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9330,7 +9330,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9344,7 +9344,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9360,7 +9360,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9374,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -9412,7 +9412,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9482,7 +9482,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -9835,7 +9835,7 @@ dependencies = [
 [[package]]
 name = "polkadot-approval-distribution"
 version = "18.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "bitvec",
  "futures",
@@ -9855,7 +9855,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "always-assert",
  "futures",
@@ -9871,7 +9871,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "derive_more",
  "fatality",
@@ -9895,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "fatality",
@@ -9928,7 +9928,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "cfg-if",
  "clap",
@@ -9956,7 +9956,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "bitvec",
  "fatality",
@@ -9979,7 +9979,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "15.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9990,7 +9990,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "derive_more",
  "fatality",
@@ -10015,7 +10015,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -10029,7 +10029,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10051,7 +10051,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -10074,7 +10074,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -10092,7 +10092,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "18.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -10125,7 +10125,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "bitvec",
  "futures",
@@ -10147,7 +10147,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10167,7 +10167,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -10182,7 +10182,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "futures",
@@ -10204,7 +10204,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -10218,7 +10218,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10235,7 +10235,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "fatality",
  "futures",
@@ -10254,7 +10254,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "futures",
@@ -10271,7 +10271,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "fatality",
  "futures",
@@ -10285,7 +10285,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10303,7 +10303,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "always-assert",
  "array-bytes",
@@ -10332,7 +10332,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -10348,7 +10348,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "cpu-time",
  "futures",
@@ -10374,7 +10374,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -10389,7 +10389,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "lazy_static",
  "log",
@@ -10408,7 +10408,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "bs58 0.5.1",
  "futures",
@@ -10427,7 +10427,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "18.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -10453,7 +10453,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -10479,7 +10479,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -10489,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -10519,7 +10519,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -10555,7 +10555,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "futures",
@@ -10577,7 +10577,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "bounded-collections",
  "derive_more",
@@ -10593,7 +10593,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -10619,7 +10619,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -10654,7 +10654,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -10704,7 +10704,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "bs58 0.5.1",
  "frame-benchmarking",
@@ -10716,7 +10716,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -10765,7 +10765,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -10872,7 +10872,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
@@ -10895,7 +10895,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -11963,7 +11963,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -12063,7 +12063,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -12561,7 +12561,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "29.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "log",
  "sp-core",
@@ -12572,7 +12572,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "futures",
@@ -12602,7 +12602,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12624,7 +12624,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.42.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -12639,7 +12639,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "array-bytes",
  "docify",
@@ -12666,7 +12666,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -12677,7 +12677,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.47.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -12718,7 +12718,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "fnv",
  "futures",
@@ -12745,7 +12745,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -12771,7 +12771,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "futures",
@@ -12795,7 +12795,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "futures",
@@ -12824,7 +12824,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -12860,7 +12860,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -12882,7 +12882,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -12918,7 +12918,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -12938,7 +12938,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -12951,7 +12951,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.30.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -12995,7 +12995,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.30.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -13015,7 +13015,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "futures",
@@ -13038,7 +13038,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.40.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -13061,7 +13061,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.35.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -13074,7 +13074,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.32.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "log",
  "polkavm",
@@ -13085,7 +13085,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.35.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -13103,7 +13103,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "console",
  "futures",
@@ -13120,7 +13120,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "33.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -13134,7 +13134,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.15.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.4",
@@ -13163,7 +13163,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.45.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13214,7 +13214,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -13232,7 +13232,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "ahash",
  "futures",
@@ -13251,7 +13251,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13272,7 +13272,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13309,7 +13309,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "array-bytes",
  "futures",
@@ -13328,7 +13328,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.12.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "bs58 0.5.1",
  "ed25519-dalek",
@@ -13345,7 +13345,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -13379,7 +13379,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -13388,7 +13388,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -13420,7 +13420,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13440,7 +13440,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "17.1.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -13464,7 +13464,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "array-bytes",
  "futures",
@@ -13496,7 +13496,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.46.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "directories",
@@ -13560,7 +13560,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.36.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -13571,7 +13571,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.22.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "clap",
  "fs4",
@@ -13584,7 +13584,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13603,7 +13603,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "derive_more",
  "futures",
@@ -13624,7 +13624,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "25.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "chrono",
  "futures",
@@ -13644,7 +13644,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "37.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "chrono",
  "console",
@@ -13673,7 +13673,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -13684,7 +13684,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "futures",
@@ -13711,7 +13711,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "futures",
@@ -13727,7 +13727,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -14268,7 +14268,7 @@ dependencies = [
 [[package]]
 name = "slot-range-helper"
 version = "15.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -14475,7 +14475,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "docify",
  "hash-db",
@@ -14497,7 +14497,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -14511,7 +14511,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14523,7 +14523,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -14537,7 +14537,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14549,7 +14549,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -14559,7 +14559,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "37.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -14578,7 +14578,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "futures",
@@ -14593,7 +14593,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14609,7 +14609,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14627,7 +14627,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "22.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -14648,7 +14648,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "21.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -14665,7 +14665,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.40.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14676,7 +14676,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "array-bytes",
  "bitflags 1.3.2",
@@ -14722,7 +14722,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -14735,7 +14735,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
@@ -14745,7 +14745,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -14754,7 +14754,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14764,7 +14764,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.29.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -14774,7 +14774,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.15.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14786,7 +14786,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -14799,7 +14799,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "bytes",
  "docify",
@@ -14825,7 +14825,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -14835,7 +14835,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -14846,7 +14846,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -14855,7 +14855,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.7.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -14865,7 +14865,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.12.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14876,7 +14876,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "34.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -14893,7 +14893,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14906,7 +14906,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -14916,7 +14916,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -14926,7 +14926,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "32.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -14936,7 +14936,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "39.0.5"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "docify",
  "either",
@@ -14962,7 +14962,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "28.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -14981,7 +14981,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "Inflector",
  "expander",
@@ -14994,7 +14994,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "36.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -15008,7 +15008,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "36.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -15021,7 +15021,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.43.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "hash-db",
  "log",
@@ -15041,7 +15041,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -15065,12 +15065,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 
 [[package]]
 name = "sp-storage"
 version = "21.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -15082,7 +15082,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -15094,7 +15094,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -15105,7 +15105,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -15114,7 +15114,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -15128,7 +15128,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "ahash",
  "hash-db",
@@ -15151,7 +15151,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -15168,7 +15168,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -15179,7 +15179,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -15191,7 +15191,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -15268,7 +15268,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-parachain-info"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -15281,7 +15281,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "14.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -15300,7 +15300,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "17.0.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -15322,7 +15322,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -15465,7 +15465,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -15490,12 +15490,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -15515,7 +15515,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "http-body-util",
  "hyper 1.5.1",
@@ -15529,7 +15529,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -15542,7 +15542,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15559,7 +15559,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "24.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "array-bytes",
  "build-helper",
@@ -16168,7 +16168,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -16179,7 +16179,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "expander",
  "proc-macro-crate 3.1.0",
@@ -17008,7 +17008,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "18.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -17116,7 +17116,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -17506,7 +17506,7 @@ dependencies = [
 [[package]]
 name = "xcm-emulator"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "array-bytes",
  "cumulus-pallet-parachain-system",
@@ -17541,7 +17541,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "10.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -17552,7 +17552,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.4.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch#21d2b5ea4035c4d0f74e286ba6bf61cfd6b44df4"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
 dependencies = [
  "frame-support",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "15.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "hash-db",
  "log",
@@ -979,7 +979,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.14.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1802,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1819,7 +1819,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1842,7 +1842,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -1887,7 +1887,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -1917,7 +1917,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1932,7 +1932,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -1958,7 +1958,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.12.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1980,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2006,7 +2006,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -2043,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -2060,7 +2060,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.17.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -2096,7 +2096,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -2107,7 +2107,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -2147,7 +2147,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.15.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -2156,7 +2156,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2172,7 +2172,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2196,7 +2196,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.10.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2222,7 +2222,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -2232,7 +2232,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2249,7 +2249,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2273,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2292,7 +2292,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -2327,7 +2327,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2366,7 +2366,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -3459,7 +3459,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3587,7 +3587,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3611,7 +3611,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "43.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -3661,7 +3661,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "14.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3688,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "array-bytes",
  "docify",
@@ -3733,7 +3733,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.46.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "futures",
  "indicatif",
@@ -3755,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "38.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -3796,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "30.0.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3816,7 +3816,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.1.0",
@@ -3828,7 +3828,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3838,7 +3838,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "cfg-if",
  "docify",
@@ -3858,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3872,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -3882,7 +3882,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6503,7 +6503,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "futures",
  "log",
@@ -6522,7 +6522,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -7395,7 +7395,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-asset-conversion"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7413,7 +7413,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7455,7 +7455,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7472,7 +7472,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7488,7 +7488,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7504,7 +7504,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7519,7 +7519,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7532,7 +7532,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7555,7 +7555,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "aquamarine",
  "docify",
@@ -7576,7 +7576,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7591,7 +7591,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7610,7 +7610,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -7659,7 +7659,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7696,7 +7696,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.17.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -7714,7 +7714,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7804,7 +7804,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7823,7 +7823,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7839,7 +7839,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -7926,7 +7926,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "5.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7961,7 +7961,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8068,7 +8068,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8090,7 +8090,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8103,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8310,7 +8310,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8346,7 +8346,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8368,7 +8368,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -8384,7 +8384,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8403,7 +8403,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8509,7 +8509,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8525,7 +8525,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "41.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -8544,7 +8544,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8561,7 +8561,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8596,7 +8596,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8611,7 +8611,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "35.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8629,7 +8629,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "36.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8649,7 +8649,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "33.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -8659,7 +8659,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8813,7 +8813,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.9.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8830,7 +8830,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8846,7 +8846,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8860,7 +8860,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "38.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8878,7 +8878,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8892,7 +8892,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8946,7 +8946,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8987,7 +8987,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9025,7 +9025,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9041,7 +9041,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9111,7 +9111,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9133,7 +9133,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "22.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -9142,7 +9142,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9152,7 +9152,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9168,7 +9168,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9183,7 +9183,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9202,7 +9202,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9269,7 +9269,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "38.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9284,7 +9284,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -9300,7 +9300,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -9312,7 +9312,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9330,7 +9330,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9344,7 +9344,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9360,7 +9360,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9374,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -9412,7 +9412,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9482,7 +9482,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -9835,7 +9835,7 @@ dependencies = [
 [[package]]
 name = "polkadot-approval-distribution"
 version = "18.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "bitvec",
  "futures",
@@ -9855,7 +9855,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "always-assert",
  "futures",
@@ -9871,7 +9871,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "derive_more",
  "fatality",
@@ -9895,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "fatality",
@@ -9928,7 +9928,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "cfg-if",
  "clap",
@@ -9956,7 +9956,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "bitvec",
  "fatality",
@@ -9979,7 +9979,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "15.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9990,7 +9990,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "derive_more",
  "fatality",
@@ -10015,7 +10015,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -10029,7 +10029,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10051,7 +10051,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -10074,7 +10074,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -10092,7 +10092,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "18.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -10125,7 +10125,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "bitvec",
  "futures",
@@ -10147,7 +10147,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10167,7 +10167,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -10182,7 +10182,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "futures",
@@ -10204,7 +10204,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -10218,7 +10218,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10235,7 +10235,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "fatality",
  "futures",
@@ -10254,7 +10254,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "futures",
@@ -10271,7 +10271,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "fatality",
  "futures",
@@ -10285,7 +10285,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10303,7 +10303,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "always-assert",
  "array-bytes",
@@ -10332,7 +10332,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -10348,7 +10348,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "cpu-time",
  "futures",
@@ -10374,7 +10374,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -10389,7 +10389,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "lazy_static",
  "log",
@@ -10408,7 +10408,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "bs58 0.5.1",
  "futures",
@@ -10427,7 +10427,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "18.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -10453,7 +10453,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -10479,7 +10479,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -10489,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -10519,7 +10519,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -10555,7 +10555,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "futures",
@@ -10577,7 +10577,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "bounded-collections",
  "derive_more",
@@ -10593,7 +10593,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -10619,7 +10619,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -10654,7 +10654,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -10704,7 +10704,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "bs58 0.5.1",
  "frame-benchmarking",
@@ -10716,7 +10716,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -10765,7 +10765,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -10872,7 +10872,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
@@ -10895,7 +10895,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -11963,7 +11963,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -12063,7 +12063,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -12561,7 +12561,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "29.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "log",
  "sp-core",
@@ -12572,7 +12572,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "futures",
@@ -12602,7 +12602,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12624,7 +12624,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.42.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -12639,7 +12639,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "array-bytes",
  "docify",
@@ -12666,7 +12666,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -12677,7 +12677,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.47.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -12718,7 +12718,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "fnv",
  "futures",
@@ -12745,7 +12745,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -12771,7 +12771,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "futures",
@@ -12795,7 +12795,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "futures",
@@ -12824,7 +12824,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -12860,7 +12860,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -12882,7 +12882,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -12918,7 +12918,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -12938,7 +12938,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -12951,7 +12951,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.30.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -12995,7 +12995,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.30.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -13015,7 +13015,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "futures",
@@ -13038,7 +13038,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.40.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -13061,7 +13061,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.35.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -13074,7 +13074,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.32.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "log",
  "polkavm",
@@ -13085,7 +13085,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.35.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -13103,7 +13103,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "console",
  "futures",
@@ -13120,7 +13120,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "33.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -13134,7 +13134,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.15.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.4",
@@ -13163,7 +13163,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.45.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13214,7 +13214,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -13232,7 +13232,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "ahash",
  "futures",
@@ -13251,7 +13251,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13272,7 +13272,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13309,7 +13309,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "array-bytes",
  "futures",
@@ -13328,7 +13328,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.12.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "bs58 0.5.1",
  "ed25519-dalek",
@@ -13345,7 +13345,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -13379,7 +13379,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -13388,7 +13388,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -13420,7 +13420,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13440,7 +13440,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "17.1.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -13464,7 +13464,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "array-bytes",
  "futures",
@@ -13496,7 +13496,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.46.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "directories",
@@ -13560,7 +13560,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.36.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -13571,7 +13571,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.22.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "clap",
  "fs4",
@@ -13584,7 +13584,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13603,7 +13603,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "derive_more",
  "futures",
@@ -13624,7 +13624,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "25.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "chrono",
  "futures",
@@ -13644,7 +13644,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "37.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "chrono",
  "console",
@@ -13673,7 +13673,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -13684,7 +13684,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "futures",
@@ -13711,7 +13711,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "futures",
@@ -13727,7 +13727,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -14268,7 +14268,7 @@ dependencies = [
 [[package]]
 name = "slot-range-helper"
 version = "15.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -14475,7 +14475,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "docify",
  "hash-db",
@@ -14497,7 +14497,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -14511,7 +14511,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14523,7 +14523,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -14537,7 +14537,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14549,7 +14549,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -14559,7 +14559,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "37.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -14578,7 +14578,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "futures",
@@ -14593,7 +14593,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14609,7 +14609,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14627,7 +14627,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "22.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -14648,7 +14648,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "21.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -14665,7 +14665,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.40.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14676,7 +14676,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "array-bytes",
  "bitflags 1.3.2",
@@ -14722,7 +14722,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -14735,7 +14735,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
@@ -14745,7 +14745,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -14754,7 +14754,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14764,7 +14764,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.29.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -14774,7 +14774,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.15.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14786,7 +14786,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -14799,7 +14799,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "bytes",
  "docify",
@@ -14825,7 +14825,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -14835,7 +14835,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -14846,7 +14846,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -14855,7 +14855,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.7.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -14865,7 +14865,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.12.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14876,7 +14876,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "34.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -14893,7 +14893,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14906,7 +14906,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -14916,7 +14916,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -14926,7 +14926,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "32.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -14936,7 +14936,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "39.0.5"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "docify",
  "either",
@@ -14962,7 +14962,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "28.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -14981,7 +14981,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "Inflector",
  "expander",
@@ -14994,7 +14994,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "36.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -15008,7 +15008,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "36.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -15021,7 +15021,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.43.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "hash-db",
  "log",
@@ -15041,7 +15041,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -15065,12 +15065,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 
 [[package]]
 name = "sp-storage"
 version = "21.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -15082,7 +15082,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -15094,7 +15094,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -15105,7 +15105,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -15114,7 +15114,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -15128,7 +15128,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "ahash",
  "hash-db",
@@ -15151,7 +15151,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -15168,7 +15168,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -15179,7 +15179,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -15191,7 +15191,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -15268,7 +15268,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-parachain-info"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -15281,7 +15281,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "14.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -15300,7 +15300,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "17.0.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -15322,7 +15322,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -15465,7 +15465,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -15490,12 +15490,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -15515,7 +15515,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "http-body-util",
  "hyper 1.5.1",
@@ -15529,7 +15529,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -15542,7 +15542,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15559,7 +15559,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "24.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "array-bytes",
  "build-helper",
@@ -16168,7 +16168,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -16179,7 +16179,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "expander",
  "proc-macro-crate 3.1.0",
@@ -17008,7 +17008,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "18.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -17116,7 +17116,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -17506,7 +17506,7 @@ dependencies = [
 [[package]]
 name = "xcm-emulator"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "array-bytes",
  "cumulus-pallet-parachain-system",
@@ -17541,7 +17541,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "10.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -17552,7 +17552,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.4.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#3d72b3c931bfc341727f06756a3e98db3a3d2fbb"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
 dependencies = [
  "frame-support",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "15.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "hash-db",
  "log",
@@ -979,7 +979,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.14.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1802,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1819,7 +1819,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1842,7 +1842,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -1887,7 +1887,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -1917,7 +1917,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1932,7 +1932,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -1958,7 +1958,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.12.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1980,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2006,7 +2006,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -2043,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -2060,7 +2060,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.17.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -2096,7 +2096,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -2107,7 +2107,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -2147,7 +2147,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.15.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -2156,7 +2156,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2172,7 +2172,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2196,7 +2196,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.10.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2222,7 +2222,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -2232,7 +2232,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2249,7 +2249,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2273,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2292,7 +2292,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -2327,7 +2327,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2366,7 +2366,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -3459,7 +3459,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3587,7 +3587,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3611,7 +3611,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "43.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -3661,7 +3661,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "14.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3688,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "array-bytes",
  "docify",
@@ -3733,7 +3733,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.46.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "futures",
  "indicatif",
@@ -3755,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "38.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -3796,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "30.0.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3816,7 +3816,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.1.0",
@@ -3828,7 +3828,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3838,7 +3838,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "cfg-if",
  "docify",
@@ -3858,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3872,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -3882,7 +3882,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6503,7 +6503,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "futures",
  "log",
@@ -6522,7 +6522,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -7395,7 +7395,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-asset-conversion"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7413,7 +7413,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7455,7 +7455,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7472,7 +7472,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7488,7 +7488,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7504,7 +7504,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7519,7 +7519,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7532,7 +7532,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7555,7 +7555,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "aquamarine",
  "docify",
@@ -7576,7 +7576,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7591,7 +7591,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7610,7 +7610,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -7659,7 +7659,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7696,7 +7696,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.17.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -7714,7 +7714,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7804,7 +7804,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7823,7 +7823,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7839,7 +7839,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -7926,7 +7926,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "5.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7961,7 +7961,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8068,7 +8068,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8090,7 +8090,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8103,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8310,7 +8310,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8346,7 +8346,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8368,7 +8368,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -8384,7 +8384,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8403,7 +8403,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8509,7 +8509,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8525,7 +8525,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "41.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -8544,7 +8544,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8561,7 +8561,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8596,7 +8596,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8611,7 +8611,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "35.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8629,7 +8629,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "36.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8649,7 +8649,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "33.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -8659,7 +8659,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8813,7 +8813,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.9.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8830,7 +8830,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8846,7 +8846,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8860,7 +8860,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "38.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8878,7 +8878,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8892,7 +8892,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8946,7 +8946,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8987,7 +8987,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9025,7 +9025,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9041,7 +9041,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9111,7 +9111,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9133,7 +9133,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "22.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -9142,7 +9142,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9152,7 +9152,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9168,7 +9168,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9183,7 +9183,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9202,7 +9202,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9269,7 +9269,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "38.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9284,7 +9284,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -9300,7 +9300,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -9312,7 +9312,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9330,7 +9330,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9344,7 +9344,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9360,7 +9360,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9374,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -9412,7 +9412,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9482,7 +9482,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -9835,7 +9835,7 @@ dependencies = [
 [[package]]
 name = "polkadot-approval-distribution"
 version = "18.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "bitvec",
  "futures",
@@ -9855,7 +9855,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "always-assert",
  "futures",
@@ -9871,7 +9871,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "derive_more",
  "fatality",
@@ -9895,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "fatality",
@@ -9928,7 +9928,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "cfg-if",
  "clap",
@@ -9956,7 +9956,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "bitvec",
  "fatality",
@@ -9979,7 +9979,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "15.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9990,7 +9990,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "derive_more",
  "fatality",
@@ -10015,7 +10015,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -10029,7 +10029,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10051,7 +10051,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -10074,7 +10074,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -10092,7 +10092,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "18.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -10125,7 +10125,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "bitvec",
  "futures",
@@ -10147,7 +10147,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10167,7 +10167,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -10182,7 +10182,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "futures",
@@ -10204,7 +10204,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -10218,7 +10218,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10235,7 +10235,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "fatality",
  "futures",
@@ -10254,7 +10254,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "futures",
@@ -10271,7 +10271,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "fatality",
  "futures",
@@ -10285,7 +10285,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10303,7 +10303,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "always-assert",
  "array-bytes",
@@ -10332,7 +10332,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -10348,7 +10348,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "cpu-time",
  "futures",
@@ -10374,7 +10374,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -10389,7 +10389,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "lazy_static",
  "log",
@@ -10408,7 +10408,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "bs58 0.5.1",
  "futures",
@@ -10427,7 +10427,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "18.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -10453,7 +10453,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -10479,7 +10479,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -10489,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -10519,7 +10519,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -10555,7 +10555,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "futures",
@@ -10577,7 +10577,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "bounded-collections",
  "derive_more",
@@ -10593,7 +10593,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -10619,7 +10619,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -10654,7 +10654,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -10704,7 +10704,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "bs58 0.5.1",
  "frame-benchmarking",
@@ -10716,7 +10716,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -10765,7 +10765,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -10872,7 +10872,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
@@ -10895,7 +10895,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -11963,7 +11963,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -12063,7 +12063,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -12561,7 +12561,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "29.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "log",
  "sp-core",
@@ -12572,7 +12572,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "futures",
@@ -12602,7 +12602,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12624,7 +12624,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.42.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -12639,7 +12639,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "array-bytes",
  "docify",
@@ -12666,7 +12666,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -12677,7 +12677,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.47.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -12718,7 +12718,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "fnv",
  "futures",
@@ -12745,7 +12745,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -12771,7 +12771,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "futures",
@@ -12795,7 +12795,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "futures",
@@ -12824,7 +12824,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -12860,7 +12860,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -12882,7 +12882,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -12918,7 +12918,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -12938,7 +12938,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -12951,7 +12951,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.30.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -12995,7 +12995,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.30.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -13015,7 +13015,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "futures",
@@ -13038,7 +13038,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.40.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -13061,7 +13061,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.35.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -13074,7 +13074,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.32.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "log",
  "polkavm",
@@ -13085,7 +13085,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.35.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -13103,7 +13103,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "console",
  "futures",
@@ -13120,7 +13120,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "33.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -13134,7 +13134,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.15.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.4",
@@ -13163,7 +13163,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.45.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13214,7 +13214,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -13232,7 +13232,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "ahash",
  "futures",
@@ -13251,7 +13251,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13272,7 +13272,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13309,7 +13309,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "array-bytes",
  "futures",
@@ -13328,7 +13328,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.12.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "bs58 0.5.1",
  "ed25519-dalek",
@@ -13345,7 +13345,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -13379,7 +13379,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -13388,7 +13388,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -13420,7 +13420,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13440,7 +13440,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "17.1.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -13464,7 +13464,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "array-bytes",
  "futures",
@@ -13496,7 +13496,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.46.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "directories",
@@ -13560,7 +13560,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.36.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -13571,7 +13571,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.22.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "clap",
  "fs4",
@@ -13584,7 +13584,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13603,7 +13603,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "derive_more",
  "futures",
@@ -13624,7 +13624,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "25.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "chrono",
  "futures",
@@ -13644,7 +13644,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "37.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "chrono",
  "console",
@@ -13673,7 +13673,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -13684,7 +13684,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "futures",
@@ -13711,7 +13711,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "futures",
@@ -13727,7 +13727,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -14268,7 +14268,7 @@ dependencies = [
 [[package]]
 name = "slot-range-helper"
 version = "15.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -14475,7 +14475,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "docify",
  "hash-db",
@@ -14497,7 +14497,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -14511,7 +14511,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14523,7 +14523,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -14537,7 +14537,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14549,7 +14549,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -14559,7 +14559,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "37.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -14578,7 +14578,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "futures",
@@ -14593,7 +14593,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14609,7 +14609,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14627,7 +14627,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "22.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -14648,7 +14648,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "21.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -14665,7 +14665,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.40.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14676,7 +14676,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "array-bytes",
  "bitflags 1.3.2",
@@ -14722,7 +14722,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -14735,7 +14735,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
@@ -14745,7 +14745,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -14754,7 +14754,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14764,7 +14764,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.29.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -14774,7 +14774,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.15.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14786,7 +14786,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -14799,7 +14799,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "bytes",
  "docify",
@@ -14825,7 +14825,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -14835,7 +14835,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -14846,7 +14846,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -14855,7 +14855,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.7.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -14865,7 +14865,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.12.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14876,7 +14876,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "34.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -14893,7 +14893,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14906,7 +14906,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -14916,7 +14916,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -14926,7 +14926,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "32.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -14936,7 +14936,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "39.0.5"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "docify",
  "either",
@@ -14962,7 +14962,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "28.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -14981,7 +14981,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "Inflector",
  "expander",
@@ -14994,7 +14994,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "36.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -15008,7 +15008,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "36.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -15021,7 +15021,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.43.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "hash-db",
  "log",
@@ -15041,7 +15041,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -15065,12 +15065,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 
 [[package]]
 name = "sp-storage"
 version = "21.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -15082,7 +15082,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -15094,7 +15094,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -15105,7 +15105,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -15114,7 +15114,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -15128,7 +15128,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "ahash",
  "hash-db",
@@ -15151,7 +15151,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -15168,7 +15168,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -15179,7 +15179,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -15191,7 +15191,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -15268,7 +15268,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-parachain-info"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -15281,7 +15281,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "14.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -15300,7 +15300,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "17.0.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -15322,7 +15322,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -15465,7 +15465,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -15490,12 +15490,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -15515,7 +15515,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "http-body-util",
  "hyper 1.5.1",
@@ -15529,7 +15529,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -15542,7 +15542,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15559,7 +15559,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "24.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "array-bytes",
  "build-helper",
@@ -16168,7 +16168,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -16179,7 +16179,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "expander",
  "proc-macro-crate 3.1.0",
@@ -17008,7 +17008,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "18.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -17116,7 +17116,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -17506,7 +17506,7 @@ dependencies = [
 [[package]]
 name = "xcm-emulator"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "array-bytes",
  "cumulus-pallet-parachain-system",
@@ -17541,7 +17541,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "10.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -17552,7 +17552,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.4.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#b742c6f0464ea9a63ea7d92f94990fca464a1548"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#2fb5f7a02c31a712bb64a6ad1bd9b527d3592816"
 dependencies = [
  "frame-support",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,111 +160,111 @@ pallet-evm-precompile-call-permit = { path = "precompiles/call-permit", default-
 precompile-utils = { path = "precompiles/utils", default-features = false }
 
 # Frame
-frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-frame-benchmarking-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-frame-executive = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-frame-remote-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-frame-support = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false, features = ["tuples-96"] }
-frame-support-procedural = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false, features = ["tuples-96"] }
-frame-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-frame-system-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-frame-try-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-frame-metadata-hash-extension = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-arithmetic = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-authority-discovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-block-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-genesis-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-blockchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-consensus-babe = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-consensus-beefy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-inherents = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-io = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-npos-elections = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sc-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-runtime-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-runtime-interface-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-staking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-std = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-storage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-state-machine = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-trie = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-version = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-weights = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-crypto-hashing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-crypto-ec-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sp-wasm-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
+frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+frame-benchmarking-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+frame-executive = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+frame-remote-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+frame-support = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false, features = ["tuples-96"] }
+frame-support-procedural = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false, features = ["tuples-96"] }
+frame-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+frame-system-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+frame-try-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+frame-metadata-hash-extension = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-arithmetic = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-authority-discovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-block-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-genesis-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-blockchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-consensus-babe = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-consensus-beefy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-inherents = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-io = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-npos-elections = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sc-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-runtime-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-runtime-interface-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-staking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-std = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-storage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-state-machine = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-trie = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-version = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-weights = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-crypto-hashing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-crypto-ec-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sp-wasm-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
 
-sc-basic-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sc-chain-spec = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sc-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sc-client-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sc-client-db = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sc-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sc-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sc-consensus-grandpa = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sc-executor = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sc-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sc-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sc-network-sync = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sc-network-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sc-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sc-rpc-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sc-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sc-telemetry = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sc-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sc-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sc-transaction-pool-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-sc-sysinfo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
+sc-basic-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sc-chain-spec = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sc-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sc-client-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sc-client-db = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sc-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sc-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sc-consensus-grandpa = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sc-executor = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sc-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sc-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sc-network-sync = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sc-network-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sc-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sc-rpc-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sc-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sc-telemetry = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sc-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sc-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sc-transaction-pool-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sc-sysinfo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
 
 # Substrate Pallets
-pallet-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-balances = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-bags-list = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-collective = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-conviction-voting = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-elections-phragmen = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-identity = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-multisig = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-preimage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-proxy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-referenda = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-scheduler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-sudo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-tips = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-transaction-payment-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-treasury = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-uniques = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-im-online = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-message-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-state-trie-migration = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-whitelist = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
+pallet-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-balances = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-bags-list = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-collective = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-conviction-voting = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-elections-phragmen = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-identity = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-multisig = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-preimage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-proxy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-referenda = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-scheduler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-sudo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-tips = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-transaction-payment-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-treasury = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-uniques = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-im-online = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-message-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-state-trie-migration = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-whitelist = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
 
-substrate-build-script-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-substrate-frame-rpc-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-substrate-prometheus-endpoint = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-substrate-rpc-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-substrate-wasm-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-substrate-state-trie-migration-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
+substrate-build-script-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+substrate-frame-rpc-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+substrate-prometheus-endpoint = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+substrate-rpc-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+substrate-wasm-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+substrate-state-trie-migration-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
 
 #TODO: We use our custom ORML as it contains the fix of bug for reducible_balance check, for Preserve mode. Once the official ORML pushes a new version with the fix, we can use that again
 # ORML dependencies
@@ -282,30 +282,30 @@ orml-xcm-support = { git = "https://github.com/galacticcouncil/open-runtime-modu
 orml-xtokens = { git = "https://github.com/galacticcouncil/open-runtime-module-library", branch = "polkadot-stable2409", default-features = false }
 
 # Cumulus dependencies
-cumulus-client-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-cumulus-client-collator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-cumulus-client-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-cumulus-client-consensus-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-cumulus-client-consensus-proposer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-cumulus-client-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-cumulus-client-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-cumulus-pallet-aura-ext = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-cumulus-pallet-parachain-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-cumulus-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-cumulus-pallet-xcmp-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-cumulus-primitives-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-cumulus-primitives-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-cumulus-primitives-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-cumulus-relay-chain-inprocess-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-cumulus-relay-chain-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-cumulus-relay-chain-minimal-node = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-pallet-collator-selection = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-staging-parachain-info = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-xcm-emulator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-xcm-runtime-apis = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-parachains-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
+cumulus-client-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+cumulus-client-collator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+cumulus-client-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+cumulus-client-consensus-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+cumulus-client-consensus-proposer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+cumulus-client-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+cumulus-client-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+cumulus-pallet-aura-ext = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+cumulus-pallet-parachain-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+cumulus-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+cumulus-primitives-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+cumulus-primitives-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+cumulus-relay-chain-inprocess-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+cumulus-relay-chain-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+cumulus-relay-chain-minimal-node = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-collator-selection = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+staging-parachain-info = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+xcm-emulator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+xcm-runtime-apis = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+parachains-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
 
 # Frontier
 fc-consensus = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-stable2409", default-features = false }
@@ -338,35 +338,35 @@ module-evm-utility-macro = { path = "runtime/hydradx/src/evm/evm-utility/macro",
 ethereum = { version = "0.15.0", default-features = false, features = ["with-codec"] }
 
 # Polkadot dependencies
-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-polkadot-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-core-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-polkadot-parachain = { package = "polkadot-parachain-primitives", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false, features = [
+pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+polkadot-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-core-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+polkadot-parachain = { package = "polkadot-parachain-primitives", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false, features = [
     "wasm-api",
 ] }
-polkadot-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-polkadot-runtime-parachains = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-polkadot-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-polkadot-xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
+polkadot-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+polkadot-runtime-parachains = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+polkadot-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+polkadot-xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
 
-polkadot-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-node-core-pvf = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-node-network-protocol = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-node-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-node-subsystem = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-node-subsystem-util = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-overseer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-runtime-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch", default-features = false }
-polkadot-statement-table = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-rococo-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
+polkadot-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-node-core-pvf = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-node-network-protocol = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-node-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-node-subsystem = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-node-subsystem-util = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-overseer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-runtime-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+polkadot-statement-table = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+rococo-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
 
-cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
+cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
 
 [patch."https://github.com/moonbeam-foundation/open-runtime-module-library"]
 # ORML dependencies
@@ -381,313 +381,313 @@ orml-xcm-support = { git = "https://github.com/galacticcouncil/open-runtime-modu
 orml-xtokens = { git = "https://github.com/galacticcouncil/open-runtime-module-library", branch = "polkadot-stable2409" }
 
 [patch."https://github.com/moonbeam-foundation/polkadot-sdk"]
-frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-frame-benchmarking-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-frame-executive = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-frame-remote-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-frame-support = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-frame-support-procedural = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-frame-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-frame-system-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-frame-system-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-frame-try-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-frame-metadata-hash-extension = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-arithmetic = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-authority-discovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-block-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-genesis-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-blockchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-consensus-babe = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-inherents = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-io = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-npos-elections = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-runtime-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-runtime-interface-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-wasm-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-panic-handler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-database = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-staking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-std = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-storage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-trie = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-version = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-basic-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-chain-spec = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-client-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-client-db = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-consensus-grandpa = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-executor = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-network-sync = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-network-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-rpc-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-telemetry = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-transaction-pool-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-sysinfo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-state-machine = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-weights = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-crypto-hashing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
+frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+frame-benchmarking-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+frame-executive = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+frame-remote-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+frame-support = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+frame-support-procedural = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+frame-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+frame-system-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+frame-system-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+frame-try-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+frame-metadata-hash-extension = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-arithmetic = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-authority-discovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-block-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-genesis-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-blockchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-consensus-babe = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-inherents = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-io = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-npos-elections = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-runtime-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-runtime-interface-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-wasm-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-panic-handler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-database = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-staking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-std = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-storage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-trie = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-version = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-basic-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-chain-spec = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-client-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-client-db = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-consensus-grandpa = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-executor = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-network-sync = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-network-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-rpc-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-telemetry = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-transaction-pool-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-sysinfo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-state-machine = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-weights = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-crypto-hashing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
 
 # Substrate Pallets
-pallet-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-balances = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-collective = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-elections-phragmen = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-identity = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-multisig = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-preimage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-proxy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-scheduler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-sudo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-tips = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-transaction-payment = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-transaction-payment-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-treasury = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-uniques = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-im-online = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-message-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-state-trie-migration = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
+pallet-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-balances = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-collective = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-elections-phragmen = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-identity = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-multisig = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-preimage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-proxy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-scheduler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-sudo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-tips = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-transaction-payment = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-transaction-payment-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-treasury = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-uniques = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-im-online = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-message-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-state-trie-migration = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
 
-substrate-build-script-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-substrate-frame-rpc-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-substrate-prometheus-endpoint = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-substrate-rpc-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-substrate-wasm-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-substrate-state-trie-migration-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
+substrate-build-script-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+substrate-frame-rpc-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+substrate-prometheus-endpoint = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+substrate-rpc-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+substrate-wasm-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+substrate-state-trie-migration-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
 
 # Cumulus dependencies
-cumulus-client-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-client-collator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-client-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-client-consensus-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-client-consensus-proposer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-client-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-client-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-pallet-aura-ext = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-pallet-parachain-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-pallet-xcmp-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-primitives-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-primitives-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-primitives-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-relay-chain-inprocess-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-relay-chain-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-relay-chain-minimal-node = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-collator-selection = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-staging-parachain-info = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-xcm-emulator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-parachains-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-xcm-runtime-apis = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
+cumulus-client-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-client-collator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-client-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-client-consensus-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-client-consensus-proposer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-client-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-client-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-pallet-aura-ext = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-pallet-parachain-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-primitives-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-primitives-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-primitives-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-relay-chain-inprocess-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-relay-chain-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-relay-chain-minimal-node = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-collator-selection = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+staging-parachain-info = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+xcm-emulator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+parachains-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+xcm-runtime-apis = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
 
 # Polkadot dependencies
-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-core-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-parachain = { package = "polkadot-parachain-primitives", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-runtime-parachains = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
+pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-core-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-parachain = { package = "polkadot-parachain-primitives", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-runtime-parachains = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
 
-polkadot-node-core-pvf = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-node-network-protocol = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-node-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-node-subsystem = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-node-subsystem-util = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-overseer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-runtime-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-statement-table = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-rococo-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
+polkadot-node-core-pvf = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-node-network-protocol = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-node-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-node-subsystem = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-node-subsystem-util = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-overseer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-runtime-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-statement-table = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+rococo-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
 
-cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
+cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
 
 [patch."https://github.com/paritytech/polkadot-sdk"]
-frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-frame-benchmarking-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-frame-executive = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-frame-remote-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-frame-support = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-frame-support-procedural = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-frame-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-frame-system-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-frame-system-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-frame-try-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-frame-metadata-hash-extension = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-arithmetic = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-authority-discovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-block-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-genesis-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-blockchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-consensus-babe = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-inherents = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-io = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-npos-elections = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-runtime-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-runtime-interface-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-wasm-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-panic-handler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-database = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-staking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-std = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-storage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-trie = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-version = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-basic-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-chain-spec = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-client-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-client-db = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-consensus-grandpa = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-executor = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-network-sync = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-network-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-rpc-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-telemetry = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-transaction-pool-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-sysinfo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sc-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-state-machine = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-weights = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-sp-crypto-hashing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
+frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+frame-benchmarking-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+frame-executive = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+frame-remote-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+frame-support = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+frame-support-procedural = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+frame-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+frame-system-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+frame-system-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+frame-try-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+frame-metadata-hash-extension = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-arithmetic = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-authority-discovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-block-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-genesis-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-blockchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-consensus-babe = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-inherents = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-io = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-npos-elections = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-runtime-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-runtime-interface-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-wasm-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-panic-handler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-database = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-staking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-std = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-storage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-trie = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-version = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-basic-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-chain-spec = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-client-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-client-db = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-consensus-grandpa = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-executor = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-network-sync = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-network-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-rpc-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-telemetry = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-transaction-pool-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-sysinfo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sc-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-state-machine = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-weights = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+sp-crypto-hashing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
 
 # Substrate Pallets
-pallet-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-balances = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-collective = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-elections-phragmen = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-identity = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-multisig = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-preimage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-proxy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-scheduler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-sudo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-tips = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-transaction-payment = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-transaction-payment-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-treasury = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-uniques = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-im-online = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-message-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-state-trie-migration = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
+pallet-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-balances = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-collective = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-elections-phragmen = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-identity = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-multisig = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-preimage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-proxy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-scheduler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-sudo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-tips = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-transaction-payment = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-transaction-payment-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-treasury = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-uniques = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-im-online = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-message-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-state-trie-migration = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
 
-substrate-build-script-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-substrate-frame-rpc-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-substrate-prometheus-endpoint = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-substrate-rpc-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-substrate-wasm-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-substrate-state-trie-migration-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
+substrate-build-script-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+substrate-frame-rpc-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+substrate-prometheus-endpoint = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+substrate-rpc-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+substrate-wasm-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+substrate-state-trie-migration-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
 
 # Cumulus dependencies
-cumulus-client-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-client-collator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-client-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-client-consensus-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-client-consensus-proposer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-client-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-client-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-pallet-aura-ext = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-pallet-parachain-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-pallet-xcmp-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-primitives-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-primitives-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-primitives-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-relay-chain-inprocess-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-relay-chain-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-relay-chain-minimal-node = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-pallet-collator-selection = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-staging-parachain-info = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-xcm-emulator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-parachains-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-xcm-runtime-apis = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
+cumulus-client-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-client-collator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-client-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-client-consensus-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-client-consensus-proposer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-client-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-client-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-pallet-aura-ext = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-pallet-parachain-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-primitives-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-primitives-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-primitives-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-relay-chain-inprocess-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-relay-chain-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-relay-chain-minimal-node = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-collator-selection = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+staging-parachain-info = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+xcm-emulator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+parachains-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+xcm-runtime-apis = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
 
 # Polkadot dependencies
-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-core-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-parachain = { package = "polkadot-parachain-primitives", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-runtime-parachains = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
+pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-core-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-parachain = { package = "polkadot-parachain-primitives", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-runtime-parachains = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
 
-polkadot-node-core-pvf = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-node-network-protocol = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-node-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-node-subsystem = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-node-subsystem-util = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-overseer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-runtime-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-polkadot-statement-table = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-rococo-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
+polkadot-node-core-pvf = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-node-network-protocol = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-node-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-node-subsystem = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-node-subsystem-util = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-overseer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-runtime-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-statement-table = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+rococo-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
 
-cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
-cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch" }
+cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "288.0.0"
+version = "289.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/governance/mod.rs
+++ b/runtime/hydradx/src/governance/mod.rs
@@ -183,6 +183,8 @@ impl pallet_conviction_voting::Config for Runtime {
 	type MaxTurnout = frame_support::traits::tokens::currency::ActiveIssuanceOf<Balances, Self::AccountId>;
 	type Polls = Referenda;
 	type VotingHooks = pallet_staking::integrations::conviction_voting::StakingConvictionVoting<Runtime>;
+	// Any single technical committee member may remove a vote.
+	type VoteRemovalOrigin = pallet_collective::EnsureMember<AccountId, TechnicalCollective>;
 }
 
 parameter_types! {

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -113,7 +113,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 288,
+	spec_version: 289,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
This extrinsic can be called by any TechnicalCommittee member in order to remove the votes of a user, and calculate the total lock. This is a prerequisite for async backing (https://github.com/galacticcouncil/hydration-node/pull/982)

For the changes in pallet-conviction-voting see https://github.com/galacticcouncil/polkadot-sdk/pull/10