### PR TITLE
feat: stableswap - add liquidity limit

### DIFF
--- a/pallets/stableswap/src/lib.rs
+++ b/pallets/stableswap/src/lib.rs
@@ -1181,6 +1181,24 @@ pub mod pallet {
 			Ok(())
 		}
 
+		/// Add liquidity to selected pool.
+		///
+		/// First call of `add_assets_liquidity` must provide "initial liquidity" of all assets.
+		///
+		/// If there is liquidity already in the pool, LP can provide liquidity of any number of pool assets.
+		///
+		/// LP must have sufficient amount of each asset.
+		///
+		/// Origin is given corresponding amount of shares.
+		///
+		/// Parameters:
+		/// - `origin`: liquidity provider
+		/// - `pool_id`: Pool Id
+		/// - `assets`: asset id and liquidity amount provided
+		/// - `min_shares`: minimum amount of shares to receive
+		///
+		/// Emits `LiquidityAdded` event when successful.
+		/// Emits `pallet_broadcast::Swapped` event when successful.
 		#[pallet::call_index(12)]
 		#[pallet::weight(<T as Config>::WeightInfo::add_assets_liquidity()
 							.saturating_add(T::Hooks::on_liquidity_changed_weight(MAX_ASSETS_IN_POOL as usize)))]

--- a/pallets/stableswap/src/lib.rs
+++ b/pallets/stableswap/src/lib.rs
@@ -48,7 +48,7 @@
 //!
 //! First LP to provide liquidity must add initial liquidity of all pool assets. Subsequent calls to add_liquidity, LP can provide only 1 asset.
 //!
-//! Initial liquidity is first liquidity added to the pool (that is first call of `add_liquidity`).
+//! Initial liquidity is first liquidity added to the pool (that is first call of `add_assets_liquidity`).
 //!
 //! LP is given certain amount of shares by minting a pool's share token.
 //!
@@ -363,7 +363,7 @@ pub mod pallet {
 		/// Create a stable pool with given list of assets.
 		///
 		/// All assets must be correctly registered in `T::AssetRegistry`.
-		/// Note that this does not seed the pool with liquidity. Use `add_liquidity` to provide
+		/// Note that this does not seed the pool with liquidity. Use `add_assets_liquidity` to provide
 		/// initial liquidity.
 		///
 		/// Parameters:
@@ -516,6 +516,7 @@ pub mod pallet {
 		#[pallet::weight(<T as Config>::WeightInfo::add_liquidity()
 							.saturating_add(T::Hooks::on_liquidity_changed_weight(MAX_ASSETS_IN_POOL as usize)))]
 		#[transactional]
+		#[deprecated(note = "Use add_assets_liquidity instead")]
 		pub fn add_liquidity(
 			origin: OriginFor<T>,
 			pool_id: T::AssetId,

--- a/pallets/stableswap/src/tests/add_liquidity.rs
+++ b/pallets/stableswap/src/tests/add_liquidity.rs
@@ -924,8 +924,6 @@ fn add_assets_liquidity_should_fail_when_min_required_amount_is_not_reached() {
 
 			let amount_added = 100 * ONE;
 
-			let pool_account = pool_account(pool_id);
-
 			assert_noop!(
 				Stableswap::add_assets_liquidity(
 					RuntimeOrigin::signed(BOB),

--- a/pallets/stableswap/src/tests/add_liquidity.rs
+++ b/pallets/stableswap/src/tests/add_liquidity.rs
@@ -176,6 +176,7 @@ fn add_initial_liquidity_should_fail_when_lp_has_insufficient_balance() {
 			assert_balance!(pool_account, asset_b, 0u128);
 		});
 }
+
 #[test]
 fn add_liquidity_should_work_when_initial_liquidity_has_been_provided() {
 	let asset_a: AssetId = 1;
@@ -823,6 +824,119 @@ fn add_liquidity_shares_should_fail_when_pool_is_empty() {
 					amount + 3, // add liquidity for shares uses slightly more
 				),
 				Error::<Test>::InvalidInitialLiquidity
+			);
+		});
+}
+
+#[test]
+fn add_assets_liquidity_should_work_when_initial_liquidity_has_been_provided() {
+	let asset_a: AssetId = 1;
+	let asset_b: AssetId = 2;
+
+	ExtBuilder::default()
+		.with_endowed_accounts(vec![
+			(BOB, 1, 200 * ONE),
+			(BOB, 2, 200 * ONE),
+			(ALICE, 1, 200 * ONE),
+			(ALICE, 2, 200 * ONE),
+		])
+		.with_registered_asset("one".as_bytes().to_vec(), asset_a, 12)
+		.with_registered_asset("two".as_bytes().to_vec(), asset_b, 12)
+		.with_pool(
+			ALICE,
+			PoolInfo::<AssetId, u64> {
+				assets: vec![asset_a, asset_b].try_into().unwrap(),
+				initial_amplification: NonZeroU16::new(100).unwrap(),
+				final_amplification: NonZeroU16::new(100).unwrap(),
+				initial_block: 0,
+				final_block: 0,
+				fee: Permill::from_percent(0),
+			},
+			InitialLiquidity {
+				account: ALICE,
+				assets: vec![
+					AssetAmount::new(asset_a, 100 * ONE),
+					AssetAmount::new(asset_b, 100 * ONE),
+				],
+			},
+		)
+		.build()
+		.execute_with(|| {
+			let pool_id = get_pool_id_at(0);
+
+			let amount_added = 100 * ONE;
+
+			let pool_account = pool_account(pool_id);
+
+			assert_ok!(Stableswap::add_assets_liquidity(
+				RuntimeOrigin::signed(BOB),
+				pool_id,
+				BoundedVec::truncate_from(vec![
+					AssetAmount::new(asset_a, amount_added),
+					AssetAmount::new(asset_b, amount_added),
+				]),
+				0u128,
+			));
+
+			assert_balance!(BOB, asset_a, 100 * ONE);
+			assert_balance!(BOB, asset_b, 100 * ONE);
+			assert_balance!(BOB, pool_id, 199999999999999999998);
+			assert_balance!(pool_account, asset_a, 200 * ONE);
+			assert_balance!(pool_account, asset_b, 200 * ONE);
+		});
+}
+
+#[test]
+fn add_assets_liquidity_should_fail_when_min_required_amount_is_not_reached() {
+	let asset_a: AssetId = 1;
+	let asset_b: AssetId = 2;
+
+	ExtBuilder::default()
+		.with_endowed_accounts(vec![
+			(BOB, 1, 200 * ONE),
+			(BOB, 2, 200 * ONE),
+			(ALICE, 1, 200 * ONE),
+			(ALICE, 2, 200 * ONE),
+		])
+		.with_registered_asset("one".as_bytes().to_vec(), asset_a, 12)
+		.with_registered_asset("two".as_bytes().to_vec(), asset_b, 12)
+		.with_pool(
+			ALICE,
+			PoolInfo::<AssetId, u64> {
+				assets: vec![asset_a, asset_b].try_into().unwrap(),
+				initial_amplification: NonZeroU16::new(100).unwrap(),
+				final_amplification: NonZeroU16::new(100).unwrap(),
+				initial_block: 0,
+				final_block: 0,
+				fee: Permill::from_percent(0),
+			},
+			InitialLiquidity {
+				account: ALICE,
+				assets: vec![
+					AssetAmount::new(asset_a, 100 * ONE),
+					AssetAmount::new(asset_b, 100 * ONE),
+				],
+			},
+		)
+		.build()
+		.execute_with(|| {
+			let pool_id = get_pool_id_at(0);
+
+			let amount_added = 100 * ONE;
+
+			let pool_account = pool_account(pool_id);
+
+			assert_noop!(
+				Stableswap::add_assets_liquidity(
+					RuntimeOrigin::signed(BOB),
+					pool_id,
+					BoundedVec::truncate_from(vec![
+						AssetAmount::new(asset_a, amount_added),
+						AssetAmount::new(asset_b, amount_added),
+					]),
+					299999999999999999998u128,
+				),
+				Error::<Test>::SlippageLimit
 			);
 		});
 }

--- a/pallets/stableswap/src/trade_execution.rs
+++ b/pallets/stableswap/src/trade_execution.rs
@@ -230,13 +230,14 @@ where
 					Self::remove_liquidity_one_asset(who, pool_id, asset_out, amount_in, min_limit)
 						.map_err(ExecutorError::Error)
 				} else if asset_out == pool_id {
-					Self::add_liquidity(
+					Self::add_assets_liquidity(
 						who,
 						pool_id,
 						BoundedVec::truncate_from(vec![AssetAmount {
 							asset_id: asset_in,
 							amount: amount_in,
 						}]),
+						min_limit,
 					)
 					.map_err(ExecutorError::Error)
 				} else {

--- a/pallets/stableswap/src/weights.rs
+++ b/pallets/stableswap/src/weights.rs
@@ -14,6 +14,7 @@ pub trait WeightInfo {
 	fn create_pool() -> Weight;
 	fn create_pool_with_pegs() -> Weight;
 	fn add_liquidity() -> Weight;
+	fn add_assets_liquidity() -> Weight;
 	fn add_liquidity_shares() -> Weight;
 	fn remove_liquidity_one_asset() -> Weight;
 	fn remove_liquidity() -> Weight;
@@ -70,6 +71,39 @@ impl WeightInfo for () {
 	/// Storage: `EmaOracle::Accumulator` (r:1 w:1)
 	/// Proof: `EmaOracle::Accumulator` (`max_values`: Some(1), `max_size`: Some(5921), added: 6416, mode: `MaxEncodedLen`)
 	fn add_liquidity() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `3746`
+		//  Estimated: `29403`
+		// Minimum execution time: 1_421_812_000 picoseconds.
+		Weight::from_parts(1_425_672_000, 29403)
+			.saturating_add(RocksDbWeight::get().reads(36_u64))
+			.saturating_add(RocksDbWeight::get().writes(14_u64))
+	}
+	/// Storage: `Stableswap::Pools` (r:1 w:0)
+	/// Proof: `Stableswap::Pools` (`max_values`: None, `max_size`: Some(57), added: 2532, mode: `MaxEncodedLen`)
+	/// Storage: `Stableswap::AssetTradability` (r:5 w:0)
+	/// Proof: `Stableswap::AssetTradability` (`max_values`: None, `max_size`: Some(41), added: 2516, mode: `MaxEncodedLen`)
+	/// Storage: `AssetRegistry::Assets` (r:6 w:0)
+	/// Proof: `AssetRegistry::Assets` (`max_values`: None, `max_size`: Some(125), added: 2600, mode: `MaxEncodedLen`)
+	/// Storage: `Tokens::Accounts` (r:11 w:11)
+	/// Proof: `Tokens::Accounts` (`max_values`: None, `max_size`: Some(108), added: 2583, mode: `MaxEncodedLen`)
+	/// Storage: `Tokens::TotalIssuance` (r:1 w:1)
+	/// Proof: `Tokens::TotalIssuance` (`max_values`: None, `max_size`: Some(28), added: 2503, mode: `MaxEncodedLen`)
+	/// Storage: `AssetRegistry::BannedAssets` (r:6 w:0)
+	/// Proof: `AssetRegistry::BannedAssets` (`max_values`: None, `max_size`: Some(20), added: 2495, mode: `MaxEncodedLen`)
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	/// Storage: `MultiTransactionPayment::AccountCurrencyMap` (r:1 w:0)
+	/// Proof: `MultiTransactionPayment::AccountCurrencyMap` (`max_values`: None, `max_size`: Some(52), added: 2527, mode: `MaxEncodedLen`)
+	/// Storage: `MultiTransactionPayment::AcceptedCurrencies` (r:1 w:0)
+	/// Proof: `MultiTransactionPayment::AcceptedCurrencies` (`max_values`: None, `max_size`: Some(28), added: 2503, mode: `MaxEncodedLen`)
+	/// Storage: `Router::SkipEd` (r:1 w:0)
+	/// Proof: `Router::SkipEd` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)
+	/// Storage: `Duster::AccountBlacklist` (r:1 w:0)
+	/// Proof: `Duster::AccountBlacklist` (`max_values`: None, `max_size`: Some(48), added: 2523, mode: `MaxEncodedLen`)
+	/// Storage: `EmaOracle::Accumulator` (r:1 w:1)
+	/// Proof: `EmaOracle::Accumulator` (`max_values`: Some(1), `max_size`: Some(5921), added: 6416, mode: `MaxEncodedLen`)
+	fn add_assets_liquidity() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `3746`
 		//  Estimated: `29403`

--- a/runtime/hydradx/src/weights/pallet_stableswap.rs
+++ b/runtime/hydradx/src/weights/pallet_stableswap.rs
@@ -120,6 +120,39 @@ impl<T: frame_system::Config> pallet_stableswap::WeightInfo for HydraWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(36_u64))
 			.saturating_add(T::DbWeight::get().writes(14_u64))
 	}
+	/// Storage: `Stableswap::Pools` (r:1 w:0)
+	/// Proof: `Stableswap::Pools` (`max_values`: None, `max_size`: Some(57), added: 2532, mode: `MaxEncodedLen`)
+	/// Storage: `Stableswap::AssetTradability` (r:5 w:0)
+	/// Proof: `Stableswap::AssetTradability` (`max_values`: None, `max_size`: Some(41), added: 2516, mode: `MaxEncodedLen`)
+	/// Storage: `AssetRegistry::Assets` (r:6 w:0)
+	/// Proof: `AssetRegistry::Assets` (`max_values`: None, `max_size`: Some(125), added: 2600, mode: `MaxEncodedLen`)
+	/// Storage: `Tokens::Accounts` (r:11 w:11)
+	/// Proof: `Tokens::Accounts` (`max_values`: None, `max_size`: Some(108), added: 2583, mode: `MaxEncodedLen`)
+	/// Storage: `Tokens::TotalIssuance` (r:1 w:1)
+	/// Proof: `Tokens::TotalIssuance` (`max_values`: None, `max_size`: Some(28), added: 2503, mode: `MaxEncodedLen`)
+	/// Storage: `AssetRegistry::BannedAssets` (r:6 w:0)
+	/// Proof: `AssetRegistry::BannedAssets` (`max_values`: None, `max_size`: Some(20), added: 2495, mode: `MaxEncodedLen`)
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	/// Storage: `MultiTransactionPayment::AccountCurrencyMap` (r:1 w:0)
+	/// Proof: `MultiTransactionPayment::AccountCurrencyMap` (`max_values`: None, `max_size`: Some(52), added: 2527, mode: `MaxEncodedLen`)
+	/// Storage: `MultiTransactionPayment::AcceptedCurrencies` (r:1 w:0)
+	/// Proof: `MultiTransactionPayment::AcceptedCurrencies` (`max_values`: None, `max_size`: Some(28), added: 2503, mode: `MaxEncodedLen`)
+	/// Storage: `Router::SkipEd` (r:1 w:0)
+	/// Proof: `Router::SkipEd` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)
+	/// Storage: `Duster::AccountBlacklist` (r:1 w:0)
+	/// Proof: `Duster::AccountBlacklist` (`max_values`: None, `max_size`: Some(48), added: 2523, mode: `MaxEncodedLen`)
+	/// Storage: `EmaOracle::Accumulator` (r:1 w:1)
+	/// Proof: `EmaOracle::Accumulator` (`max_values`: Some(1), `max_size`: Some(5921), added: 6416, mode: `MaxEncodedLen`)
+	fn add_assets_liquidity() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `3746`
+		//  Estimated: `29403`
+		// Minimum execution time: 1_424_528_000 picoseconds.
+		Weight::from_parts(1_430_156_000, 29403)
+			.saturating_add(T::DbWeight::get().reads(36_u64))
+			.saturating_add(T::DbWeight::get().writes(14_u64))
+	}
 	/// Storage: `Stableswap::AssetTradability` (r:1 w:0)
 	/// Proof: `Stableswap::AssetTradability` (`max_values`: None, `max_size`: Some(41), added: 2516, mode: `MaxEncodedLen`)
 	/// Storage: `Stableswap::Pools` (r:1 w:0)


### PR DESCRIPTION
This PR adds new extrinsic that adds liquidity `add_assets_liquidity`. 

The difference between add_liquidity and add_assets_liquidity is that this new extrisnics allows to specify min shares that LP expects to receive. 