### PR TITLE
feat: stableswap audit minor findings 

### DIFF
--- a/integration-tests/src/aave_router.rs
+++ b/integration-tests/src/aave_router.rs
@@ -95,7 +95,7 @@ fn with_stablepool(execution: impl FnOnce(AssetId)) {
 		assert_ok!(Stableswap::create_pool(
 			hydradx_runtime::RuntimeOrigin::root(),
 			pool,
-			[DOT, ADOT].to_vec(),
+			BoundedVec::truncate_from([DOT, ADOT].to_vec()),
 			amplification,
 			fee,
 		));

--- a/integration-tests/src/dca.rs
+++ b/integration-tests/src/dca.rs
@@ -4406,7 +4406,13 @@ pub fn init_stableswap() -> Result<(AssetId, AssetId, AssetId), DispatchError> {
 	let asset_in: AssetId = *asset_ids.last().unwrap();
 	let asset_out: AssetId = *asset_ids.first().unwrap();
 
-	Stableswap::create_pool(RuntimeOrigin::root(), pool_id, asset_ids, amplification, fee)?;
+	Stableswap::create_pool(
+		RuntimeOrigin::root(),
+		pool_id,
+		BoundedVec::truncate_from(asset_ids),
+		amplification,
+		fee,
+	)?;
 
 	Stableswap::add_liquidity(
 		RuntimeOrigin::signed(BOB.into()),
@@ -4474,7 +4480,13 @@ pub fn init_stableswap_with_three_assets_having_different_decimals(
 	let asset_in: AssetId = asset_ids[1];
 	let asset_out: AssetId = asset_ids[2];
 
-	Stableswap::create_pool(RuntimeOrigin::root(), pool_id, asset_ids, amplification, fee)?;
+	Stableswap::create_pool(
+		RuntimeOrigin::root(),
+		pool_id,
+		BoundedVec::truncate_from(asset_ids),
+		amplification,
+		fee,
+	)?;
 
 	Stableswap::add_liquidity(
 		RuntimeOrigin::signed(BOB.into()),

--- a/integration-tests/src/driver/mod.rs
+++ b/integration-tests/src/driver/mod.rs
@@ -178,7 +178,7 @@ impl HydrationTestDriver {
 			assert_ok!(Stableswap::create_pool(
 				hydradx_runtime::RuntimeOrigin::root(),
 				pool_id,
-				asset_ids.iter().map(|(id, _)| *id).collect(),
+				BoundedVec::truncate_from(asset_ids.iter().map(|(id, _)| *id).collect()),
 				amplification,
 				fee,
 			));

--- a/integration-tests/src/omnipool_liquidity_mining.rs
+++ b/integration-tests/src/omnipool_liquidity_mining.rs
@@ -20,6 +20,7 @@ use crate::polkadot_test_net::*;
 use frame_support::assert_noop;
 use frame_support::assert_ok;
 use frame_support::storage::with_transaction;
+use frame_support::BoundedVec;
 use hydradx_runtime::Omnipool;
 use hydradx_runtime::{
 	AssetRegistry, Balance, Bonds, Currencies, Runtime, RuntimeEvent, RuntimeOrigin, Stableswap, Treasury,
@@ -2202,7 +2203,13 @@ pub fn init_stableswap() -> Result<(AssetId, AssetId, AssetId), DispatchError> {
 	let asset_in: AssetId = *asset_ids.last().unwrap();
 	let asset_out: AssetId = *asset_ids.first().unwrap();
 
-	Stableswap::create_pool(RuntimeOrigin::root(), pool_id, asset_ids, amplification, fee)?;
+	Stableswap::create_pool(
+		RuntimeOrigin::root(),
+		pool_id,
+		BoundedVec::truncate_from(asset_ids),
+		amplification,
+		fee,
+	)?;
 
 	Stableswap::add_liquidity(RuntimeOrigin::signed(BOB.into()), pool_id, initial.try_into().unwrap())?;
 

--- a/integration-tests/src/router.rs
+++ b/integration-tests/src/router.rs
@@ -5779,7 +5779,7 @@ pub fn init_stableswap_with_details(
 	Stableswap::create_pool(
 		hydradx_runtime::RuntimeOrigin::root(),
 		pool_id,
-		asset_ids,
+		BoundedVec::truncate_from(asset_ids),
 		amplification,
 		fee,
 	)?;

--- a/pallets/stableswap/src/benchmarks.rs
+++ b/pallets/stableswap/src/benchmarks.rs
@@ -61,7 +61,7 @@ benchmarks! {
 		let trade_fee = Permill::from_percent(1);
 		let caller: T::AccountId = account("caller", 0, 1);
 		let successful_origin = T::AuthorityOrigin::try_successful_origin().unwrap();
-	}: _<T::RuntimeOrigin>(successful_origin, pool_id.into(), asset_ids, amplification, trade_fee)
+	}: _<T::RuntimeOrigin>(successful_origin, pool_id.into(), BoundedVec::truncate_from(asset_ids), amplification, trade_fee)
 	verify {
 		assert!(<Pools<T>>::get::<T::AssetId>(pool_id.into()).is_some());
 	}
@@ -91,7 +91,7 @@ benchmarks! {
 		let trade_fee = Permill::from_percent(1);
 		let caller: T::AccountId = account("caller", 0, 1);
 		let successful_origin = T::AuthorityOrigin::try_successful_origin().unwrap();
-	}: _<T::RuntimeOrigin>(successful_origin, pool_id.into(), asset_ids, amplification, trade_fee, BoundedPegSources::truncate_from(peg_source), Permill::from_percent(100))
+	}: _<T::RuntimeOrigin>(successful_origin, pool_id.into(), BoundedVec::truncate_from(asset_ids), amplification, trade_fee, BoundedPegSources::truncate_from(peg_source), Permill::from_percent(100))
 	verify {
 		assert!(<Pools<T>>::get::<T::AssetId>(pool_id.into()).is_some());
 		assert!(<PoolPegs<T>>::get::<T::AssetId>(pool_id.into()).is_some());
@@ -123,7 +123,7 @@ benchmarks! {
 		let successful_origin = T::AuthorityOrigin::try_successful_origin().unwrap();
 		crate::Pallet::<T>::create_pool(successful_origin,
 			pool_id,
-			asset_ids,
+			BoundedVec::truncate_from(asset_ids),
 			amplification,
 			trade_fee,
 		)?;
@@ -165,7 +165,7 @@ benchmarks! {
 		let asset_id: T::AssetId = *asset_ids.last().unwrap();
 		crate::Pallet::<T>::create_pool(successful_origin,
 			pool_id,
-			asset_ids,
+			BoundedVec::truncate_from(asset_ids),
 			amplification,
 			trade_fee,
 		)?;
@@ -208,7 +208,7 @@ benchmarks! {
 		let successful_origin = T::AuthorityOrigin::try_successful_origin().unwrap();
 		crate::Pallet::<T>::create_pool(successful_origin,
 			pool_id,
-			asset_ids,
+			BoundedVec::truncate_from(asset_ids),
 			amplification,
 			trade_fee,
 		)?;
@@ -261,7 +261,7 @@ benchmarks! {
 		let successful_origin = T::AuthorityOrigin::try_successful_origin().unwrap();
 		crate::Pallet::<T>::create_pool(successful_origin,
 			pool_id,
-			asset_ids,
+			BoundedVec::truncate_from(asset_ids),
 			amplification,
 			trade_fee,
 		)?;
@@ -313,7 +313,7 @@ benchmarks! {
 		let successful_origin = T::AuthorityOrigin::try_successful_origin().unwrap();
 		crate::Pallet::<T>::create_pool(successful_origin,
 			pool_id,
-			asset_ids,
+			BoundedVec::truncate_from(asset_ids),
 			amplification,
 			trade_fee,
 		)?;
@@ -365,7 +365,7 @@ benchmarks! {
 		let successful_origin = T::AuthorityOrigin::try_successful_origin().unwrap();
 		crate::Pallet::<T>::create_pool(successful_origin,
 			pool_id,
-			asset_ids,
+			BoundedVec::truncate_from(asset_ids),
 			amplification,
 			trade_fee,
 		)?;
@@ -419,7 +419,7 @@ benchmarks! {
 		let successful_origin = T::AuthorityOrigin::try_successful_origin().unwrap();
 		crate::Pallet::<T>::create_pool(successful_origin,
 			pool_id,
-			asset_ids,
+			BoundedVec::truncate_from(asset_ids),
 			amplification,
 			trade_fee,
 		)?;
@@ -472,7 +472,7 @@ benchmarks! {
 		let successful_origin = T::AuthorityOrigin::try_successful_origin().unwrap();
 		crate::Pallet::<T>::create_pool(successful_origin.clone(),
 			pool_id,
-			asset_ids,
+			BoundedVec::truncate_from(asset_ids),
 			amplification,
 			trade_fee,
 		)?;
@@ -507,7 +507,7 @@ benchmarks! {
 		let successful_origin = T::AuthorityOrigin::try_successful_origin().unwrap();
 		crate::Pallet::<T>::create_pool(successful_origin.clone(),
 			pool_id,
-			asset_ids,
+			BoundedVec::truncate_from(asset_ids),
 			100u16,
 			Permill::from_percent(1),
 		)?;
@@ -542,7 +542,7 @@ benchmarks! {
 		let successful_origin = T::AuthorityOrigin::try_successful_origin().unwrap();
 		crate::Pallet::<T>::create_pool(successful_origin.clone(),
 			pool_id,
-			asset_ids,
+			BoundedVec::truncate_from(asset_ids),
 			100u16,
 			Permill::from_percent(1),
 		)?;
@@ -597,7 +597,7 @@ benchmarks! {
 		let successful_origin = T::AuthorityOrigin::try_successful_origin().unwrap();
 		crate::Pallet::<T>::create_pool(successful_origin,
 			pool_id,
-			asset_ids,
+			BoundedVec::truncate_from(asset_ids),
 			amplification,
 			trade_fee,
 		)?;
@@ -661,7 +661,7 @@ benchmarks! {
 		let successful_origin = T::AuthorityOrigin::try_successful_origin().unwrap();
 		crate::Pallet::<T>::create_pool(successful_origin,
 			pool_id,
-			asset_ids,
+			BoundedVec::truncate_from(asset_ids),
 			amplification,
 			trade_fee,
 		)?;
@@ -724,7 +724,7 @@ benchmarks! {
 		let successful_origin = T::AuthorityOrigin::try_successful_origin().unwrap();
 		crate::Pallet::<T>::create_pool(successful_origin,
 			pool_id,
-			asset_ids,
+			BoundedVec::truncate_from(asset_ids),
 			amplification,
 			trade_fee,
 		)?;

--- a/pallets/stableswap/src/tests/add_liquidity.rs
+++ b/pallets/stableswap/src/tests/add_liquidity.rs
@@ -1,4 +1,5 @@
 use crate::tests::mock::*;
+use crate::tests::to_bounded_asset_vec;
 use crate::types::PoolInfo;
 use crate::{assert_balance, to_precision, Error};
 use frame_support::{assert_noop, assert_ok, BoundedVec};
@@ -29,7 +30,7 @@ fn add_initial_liquidity_should_work_when_called_first_time() {
 			assert_ok!(Stableswap::create_pool(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b],
+				to_bounded_asset_vec(vec![asset_a, asset_b]),
 				amplification,
 				Permill::from_percent(0),
 			));
@@ -148,7 +149,7 @@ fn add_initial_liquidity_should_fail_when_lp_has_insufficient_balance() {
 			assert_ok!(Stableswap::create_pool(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b],
+				to_bounded_asset_vec(vec![asset_a, asset_b]),
 				amplification,
 				Permill::from_percent(0),
 			));
@@ -527,7 +528,7 @@ fn add_initial_liquidity_should_work_when_asset_have_different_decimals() {
 			assert_ok!(Stableswap::create_pool(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b],
+				to_bounded_asset_vec(vec![asset_a, asset_b]),
 				amplification,
 				Permill::from_percent(0),
 			));

--- a/pallets/stableswap/src/tests/amplification.rs
+++ b/pallets/stableswap/src/tests/amplification.rs
@@ -1,4 +1,5 @@
 use crate::tests::mock::*;
+use crate::tests::to_bounded_asset_vec;
 use crate::types::PoolInfo;
 use crate::{Error, Pools};
 use frame_support::{assert_noop, assert_ok};
@@ -22,7 +23,7 @@ fn update_amplification_should_work_when_correct_params_are_provided() {
 			assert_ok!(Stableswap::create_pool(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b],
+				to_bounded_asset_vec(vec![asset_a, asset_b]),
 				100,
 				Permill::from_percent(10),
 			));
@@ -67,7 +68,7 @@ fn update_amplification_should_fail_when_end_block_is_before_current_block() {
 			assert_ok!(Stableswap::create_pool(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b],
+				to_bounded_asset_vec(vec![asset_a, asset_b]),
 				100,
 				Permill::from_percent(10),
 			));
@@ -97,7 +98,7 @@ fn update_amplification_should_fail_when_end_block_is_smaller_than_start_block()
 			assert_ok!(Stableswap::create_pool(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b],
+				to_bounded_asset_vec(vec![asset_a, asset_b]),
 				100,
 				Permill::from_percent(10),
 			));
@@ -127,7 +128,7 @@ fn update_amplification_should_fail_when_start_block_before_current_block() {
 			assert_ok!(Stableswap::create_pool(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b],
+				to_bounded_asset_vec(vec![asset_a, asset_b]),
 				100,
 				Permill::from_percent(10),
 			));
@@ -157,7 +158,7 @@ fn update_amplification_should_work_when_current_change_is_in_progress() {
 			assert_ok!(Stableswap::create_pool(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b],
+				to_bounded_asset_vec(vec![asset_a, asset_b]),
 				100,
 				Permill::from_percent(10),
 			));
@@ -223,7 +224,7 @@ fn update_amplification_should_fail_when_new_value_is_same_as_previous_one() {
 			assert_ok!(Stableswap::create_pool(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b],
+				to_bounded_asset_vec(vec![asset_a, asset_b]),
 				100,
 				Permill::from_percent(10),
 			));
@@ -253,7 +254,7 @@ fn update_amplification_should_fail_when_new_value_is_zero_or_outside_allowed_ra
 			assert_ok!(Stableswap::create_pool(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b],
+				to_bounded_asset_vec(vec![asset_a, asset_b]),
 				100,
 				Permill::from_percent(10),
 			));
@@ -293,7 +294,7 @@ fn amplification_should_change_when_block_changes() {
 			assert_ok!(Stableswap::create_pool(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b],
+				to_bounded_asset_vec(vec![asset_a, asset_b]),
 				2000,
 				Permill::from_percent(10),
 			));

--- a/pallets/stableswap/src/tests/creation.rs
+++ b/pallets/stableswap/src/tests/creation.rs
@@ -1,4 +1,5 @@
 use crate::tests::mock::*;
+use crate::tests::to_bounded_asset_vec;
 use crate::types::PoolInfo;
 use crate::Error;
 use crate::Pools;
@@ -22,7 +23,7 @@ fn create_two_asset_pool_should_work_when_assets_are_registered() {
 			assert_ok!(Stableswap::create_pool(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b],
+				to_bounded_asset_vec(vec![asset_a, asset_b]),
 				100,
 				Permill::from_percent(0),
 			));
@@ -61,7 +62,7 @@ fn create_multi_asset_pool_should_work_when_assets_are_registered() {
 			assert_ok!(Stableswap::create_pool(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b, asset_c, asset_d],
+				to_bounded_asset_vec(vec![asset_a, asset_b, asset_c, asset_d]),
 				100,
 				Permill::from_percent(0),
 			));
@@ -91,7 +92,7 @@ fn create_pool_should_store_assets_correctly_when_input_is_not_sorted() {
 			assert_ok!(Stableswap::create_pool(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_c, asset_d, asset_b, asset_a],
+				to_bounded_asset_vec(vec![asset_c, asset_d, asset_b, asset_a]),
 				amplification,
 				Permill::from_percent(5),
 			));
@@ -124,7 +125,7 @@ fn create_pool_should_fail_when_same_assets_is_specified() {
 				Stableswap::create_pool(
 					RuntimeOrigin::root(),
 					pool_id,
-					vec![asset_a, 3, 4, asset_a],
+					to_bounded_asset_vec(vec![asset_a, 3, 4, asset_a]),
 					amplification,
 					Permill::from_percent(0),
 				),
@@ -146,7 +147,7 @@ fn create_pool_should_fail_when_same_assets_is_empty() {
 				Stableswap::create_pool(
 					RuntimeOrigin::root(),
 					pool_id,
-					vec![],
+					to_bounded_asset_vec(vec![]),
 					amplification,
 					Permill::from_percent(0),
 				),
@@ -169,7 +170,7 @@ fn create_pool_should_fail_when_single_asset_is_provided() {
 				Stableswap::create_pool(
 					RuntimeOrigin::root(),
 					pool_id,
-					vec![asset_a],
+					to_bounded_asset_vec(vec![asset_a]),
 					amplification,
 					Permill::from_percent(0),
 				),
@@ -189,7 +190,7 @@ fn create_pool_should_fail_when_share_asset_is_not_registered() {
 			Stableswap::create_pool(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, 3, 4],
+				to_bounded_asset_vec(vec![asset_a, 3, 4]),
 				amplification,
 				Permill::from_percent(0),
 			),
@@ -212,7 +213,7 @@ fn create_pool_should_fail_when_share_asset_is_among_assets() {
 				Stableswap::create_pool(
 					RuntimeOrigin::root(),
 					pool_id,
-					vec![asset_a, pool_id],
+					to_bounded_asset_vec(vec![asset_a, pool_id]),
 					amplification,
 					Permill::from_percent(0),
 				),
@@ -237,7 +238,7 @@ fn create_pool_should_fail_when_asset_is_not_registered() {
 				Stableswap::create_pool(
 					RuntimeOrigin::root(),
 					pool_id,
-					vec![not_registered, registered],
+					to_bounded_asset_vec(vec![not_registered, registered]),
 					amplification,
 					Permill::from_percent(0),
 				),
@@ -248,7 +249,7 @@ fn create_pool_should_fail_when_asset_is_not_registered() {
 				Stableswap::create_pool(
 					RuntimeOrigin::root(),
 					pool_id,
-					vec![registered, not_registered],
+					to_bounded_asset_vec(vec![registered, not_registered]),
 					amplification,
 					Permill::from_percent(0),
 				),
@@ -274,7 +275,7 @@ fn create_pool_should_fail_when_same_share_asset_pool_already_exists() {
 			assert_ok!(Stableswap::create_pool(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b],
+				to_bounded_asset_vec(vec![asset_a, asset_b]),
 				amplification,
 				Permill::from_percent(0),
 			));
@@ -283,7 +284,7 @@ fn create_pool_should_fail_when_same_share_asset_pool_already_exists() {
 				Stableswap::create_pool(
 					RuntimeOrigin::root(),
 					pool_id,
-					vec![asset_a, asset_b],
+					to_bounded_asset_vec(vec![asset_a, asset_b]),
 					amplification,
 					Permill::from_percent(0),
 				),
@@ -311,7 +312,7 @@ fn create_pool_should_fail_when_amplification_is_incorrect() {
 				Stableswap::create_pool(
 					RuntimeOrigin::root(),
 					pool_id,
-					vec![asset_a, asset_b],
+					to_bounded_asset_vec(vec![asset_a, asset_b]),
 					0,
 					Permill::from_percent(0),
 				),
@@ -322,7 +323,7 @@ fn create_pool_should_fail_when_amplification_is_incorrect() {
 				Stableswap::create_pool(
 					RuntimeOrigin::root(),
 					pool_id,
-					vec![asset_a, asset_b],
+					to_bounded_asset_vec(vec![asset_a, asset_b]),
 					amplification_min,
 					Permill::from_percent(0),
 				),
@@ -333,7 +334,7 @@ fn create_pool_should_fail_when_amplification_is_incorrect() {
 				Stableswap::create_pool(
 					RuntimeOrigin::root(),
 					pool_id,
-					vec![asset_a, asset_b],
+					to_bounded_asset_vec(vec![asset_a, asset_b]),
 					amplification_max,
 					Permill::from_percent(0),
 				),
@@ -358,42 +359,12 @@ fn create_pool_should_add_account_to_whitelist() {
 			assert_ok!(Stableswap::create_pool(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b],
+				to_bounded_asset_vec(vec![asset_a, asset_b]),
 				100,
 				Permill::from_percent(0),
 			));
 
 			let pool_account = pool_account(pool_id);
 			assert!(DUSTER_WHITELIST.with(|v| v.borrow().contains(&pool_account)));
-		});
-}
-
-#[test]
-fn create_pool_should_fail_when_number_of_assets_exceeds_maximum() {
-	let asset_a: AssetId = 1;
-	let asset_b: AssetId = 2;
-	let asset_c: AssetId = 3;
-	let asset_d: AssetId = 4;
-	let asset_e: AssetId = 5;
-	let asset_f: AssetId = 6;
-	let pool_id: AssetId = 100;
-
-	ExtBuilder::default()
-		.with_endowed_accounts(vec![(ALICE, 1, 200 * ONE), (ALICE, 2, 200 * ONE)])
-		.with_registered_asset("pool".as_bytes().to_vec(), pool_id, 12)
-		.with_registered_asset("one".as_bytes().to_vec(), asset_a, 12)
-		.with_registered_asset("two".as_bytes().to_vec(), asset_b, 12)
-		.build()
-		.execute_with(|| {
-			assert_noop!(
-				Stableswap::create_pool(
-					RuntimeOrigin::root(),
-					pool_id,
-					vec![asset_a, asset_b, asset_c, asset_d, asset_e, asset_f],
-					100,
-					Permill::from_percent(0),
-				),
-				Error::<Test>::MaxAssetsExceeded
-			);
 		});
 }

--- a/pallets/stableswap/src/tests/mock.rs
+++ b/pallets/stableswap/src/tests/mock.rs
@@ -302,7 +302,7 @@ impl ExtBuilder {
 				assert_ok!(Stableswap::create_pool(
 					RuntimeOrigin::root(),
 					pool_id,
-					pool.assets.clone().into(),
+					pool.assets.clone(),
 					pool.initial_amplification.get(),
 					pool.fee,
 				));

--- a/pallets/stableswap/src/tests/mod.rs
+++ b/pallets/stableswap/src/tests/mod.rs
@@ -1,5 +1,7 @@
 use crate::tests::mock::*;
 use crate::*;
+use frame_support::pallet_prelude::ConstU32;
+use frame_support::BoundedVec;
 use sp_runtime::FixedU128;
 
 mod add_liquidity;
@@ -83,4 +85,8 @@ pub(crate) fn spot_price(pool_id: AssetId, asset_id_a: AssetId, asset_id_b: Asse
 		&asset_pegs,
 	)
 	.unwrap()
+}
+
+pub(crate) fn to_bounded_asset_vec(vec: Vec<AssetId>) -> BoundedVec<AssetId, ConstU32<MAX_ASSETS_IN_POOL>> {
+	vec.try_into().unwrap()
 }

--- a/pallets/stableswap/src/tests/peg.rs
+++ b/pallets/stableswap/src/tests/peg.rs
@@ -3,7 +3,7 @@ use crate::tests::mock::*;
 use crate::types::{BoundedPegSources, PegSource};
 use hydradx_traits::stableswap::AssetAmount;
 
-use crate::tests::{get_share_price, spot_price};
+use crate::tests::{get_share_price, spot_price, to_bounded_asset_vec};
 use frame_support::{assert_ok, BoundedVec};
 use hydradx_traits::OraclePeriod;
 use num_traits::One;
@@ -51,7 +51,7 @@ fn sell_with_peg_should_work_different_pegs() {
 			assert_ok!(Stableswap::create_pool_with_pegs(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b, asset_c],
+				to_bounded_asset_vec(vec![asset_a, asset_b, asset_c]),
 				amp,
 				Permill::from_percent(0),
 				BoundedPegSources::truncate_from(vec![
@@ -128,7 +128,7 @@ fn buy_with_peg_should_work_different_pegs() {
 			assert_ok!(Stableswap::create_pool_with_pegs(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b, asset_c],
+				to_bounded_asset_vec(vec![asset_a, asset_b, asset_c]),
 				amp,
 				Permill::from_percent(0),
 				BoundedPegSources::truncate_from(vec![
@@ -208,7 +208,7 @@ fn sell_with_peg_with_fee_should_work_different_pegs() {
 			assert_ok!(Stableswap::create_pool_with_pegs(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b, asset_c],
+				to_bounded_asset_vec(vec![asset_a, asset_b, asset_c]),
 				amp,
 				trade_fee,
 				BoundedPegSources::truncate_from(vec![
@@ -286,7 +286,7 @@ fn buy_with_peg_with_fee_should_work_different_pegs() {
 			assert_ok!(Stableswap::create_pool_with_pegs(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b, asset_c],
+				to_bounded_asset_vec(vec![asset_a, asset_b, asset_c]),
 				amp,
 				trade_fee,
 				BoundedPegSources::truncate_from(vec![
@@ -365,7 +365,7 @@ fn sell_with_drifting_peg_should_work() {
 			assert_ok!(Stableswap::create_pool_with_pegs(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b, asset_c],
+				to_bounded_asset_vec(vec![asset_a, asset_b, asset_c]),
 				amp,
 				Permill::from_percent(0),
 				BoundedPegSources::truncate_from(vec![
@@ -448,7 +448,7 @@ fn sell_with_drifting_peg_should_not_exceed_max_peg_update() {
 			assert_ok!(Stableswap::create_pool_with_pegs(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b, asset_c],
+				to_bounded_asset_vec(vec![asset_a, asset_b, asset_c]),
 				amp,
 				Permill::from_percent(0),
 				BoundedPegSources::truncate_from(vec![
@@ -533,7 +533,7 @@ fn share_pries_should_be_correct_with_different_pegs() {
 			assert_ok!(Stableswap::create_pool_with_pegs(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b, asset_c],
+				to_bounded_asset_vec(vec![asset_a, asset_b, asset_c]),
 				amp,
 				Permill::from_percent(0),
 				BoundedPegSources::truncate_from(vec![
@@ -608,7 +608,7 @@ fn spot_prices_should_be_correct_with_different_pegs() {
 			assert_ok!(Stableswap::create_pool_with_pegs(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b, asset_c],
+				to_bounded_asset_vec(vec![asset_a, asset_b, asset_c]),
 				amp,
 				Permill::from_percent(0),
 				BoundedPegSources::truncate_from(vec![
@@ -696,7 +696,7 @@ fn add_liquidity_should_work_correctly_with_different_pegs() {
 			assert_ok!(Stableswap::create_pool_with_pegs(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b, asset_c],
+				to_bounded_asset_vec(vec![asset_a, asset_b, asset_c]),
 				amp,
 				Permill::from_percent(0),
 				BoundedPegSources::truncate_from(vec![
@@ -776,7 +776,7 @@ fn add_liquidity_shares_should_work_correctly_with_different_pegs() {
 			assert_ok!(Stableswap::create_pool_with_pegs(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b, asset_c],
+				to_bounded_asset_vec(vec![asset_a, asset_b, asset_c]),
 				amp,
 				Permill::from_percent(0),
 				BoundedPegSources::truncate_from(vec![
@@ -858,7 +858,7 @@ fn remove_liquidity_for_one_asset_should_work_correctly_with_different_pegs() {
 			assert_ok!(Stableswap::create_pool_with_pegs(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b, asset_c],
+				to_bounded_asset_vec(vec![asset_a, asset_b, asset_c]),
 				amp,
 				Permill::from_percent(0),
 				BoundedPegSources::truncate_from(vec![
@@ -951,7 +951,7 @@ fn remove_liquidity_given_asset_amount_should_work_correctly_with_different_pegs
 			assert_ok!(Stableswap::create_pool_with_pegs(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b, asset_c],
+				to_bounded_asset_vec(vec![asset_a, asset_b, asset_c]),
 				amp,
 				Permill::from_percent(0),
 				BoundedPegSources::truncate_from(vec![
@@ -1046,7 +1046,7 @@ fn remove_liquidity_uniform_should_work_correctly_with_different_pegs() {
 			assert_ok!(Stableswap::create_pool_with_pegs(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b, asset_c],
+				to_bounded_asset_vec(vec![asset_a, asset_b, asset_c]),
 				amp,
 				Permill::from_percent(0),
 				BoundedPegSources::truncate_from(vec![

--- a/pallets/stableswap/src/tests/peg_one.rs
+++ b/pallets/stableswap/src/tests/peg_one.rs
@@ -3,6 +3,7 @@ use crate::types::{BoundedPegSources, PegSource};
 use crate::{assert_balance, Error, Event};
 use hydradx_traits::stableswap::AssetAmount;
 
+use crate::tests::to_bounded_asset_vec;
 use frame_support::{assert_noop, assert_ok, BoundedVec};
 use hydradx_traits::OraclePeriod;
 use pallet_broadcast::types::{Asset, Destination, Fee};
@@ -26,7 +27,7 @@ fn sell_with_peg_should_work_as_before_when_all_pegs_are_one() {
 			assert_ok!(Stableswap::create_pool_with_pegs(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b],
+				to_bounded_asset_vec(vec![asset_a, asset_b]),
 				100,
 				Permill::from_percent(0),
 				BoundedPegSources::truncate_from(vec![PegSource::Value((1, 1)), PegSource::Value((1, 1))]),
@@ -78,7 +79,7 @@ fn buy_should_work_as_before_when_all_pegs_are_one() {
 			assert_ok!(Stableswap::create_pool_with_pegs(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b],
+				to_bounded_asset_vec(vec![asset_a, asset_b]),
 				100,
 				Permill::from_percent(0),
 				BoundedPegSources::truncate_from(vec![PegSource::Value((1, 1)), PegSource::Value((1, 1))]),
@@ -162,7 +163,7 @@ fn remove_liquidity_with_peg_should_work_as_before_when_pegs_are_one() {
 			assert_ok!(Stableswap::create_pool_with_pegs(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b, asset_c],
+				to_bounded_asset_vec(vec![asset_a, asset_b, asset_c]),
 				100,
 				Permill::from_percent(0),
 				BoundedPegSources::truncate_from(vec![
@@ -251,7 +252,7 @@ fn creating_pool_with_pegs_shoud_fails_when_assets_have_different_decimals() {
 				Stableswap::create_pool_with_pegs(
 					RuntimeOrigin::root(),
 					pool_id,
-					vec![asset_a, asset_b, asset_c],
+					to_bounded_asset_vec(vec![asset_a, asset_b, asset_c]),
 					2000,
 					Permill::from_percent(0),
 					BoundedPegSources::truncate_from(vec![
@@ -284,7 +285,7 @@ fn should_fail_when_called_by_invalid_origin() {
 				Stableswap::create_pool_with_pegs(
 					RuntimeOrigin::signed(BOB),
 					pool_id,
-					vec![asset_a, asset_b],
+					to_bounded_asset_vec(vec![asset_a, asset_b]),
 					100,
 					Permill::from_percent(0),
 					BoundedPegSources::truncate_from(vec![PegSource::Value((1, 1)), PegSource::Value((1, 1))]),
@@ -313,7 +314,7 @@ fn should_fail_when_invalid_amplification_specified() {
 				Stableswap::create_pool_with_pegs(
 					RuntimeOrigin::root(),
 					pool_id,
-					vec![asset_a, asset_b],
+					to_bounded_asset_vec(vec![asset_a, asset_b]),
 					0,
 					Permill::from_percent(0),
 					BoundedPegSources::truncate_from(vec![PegSource::Value((1, 1)), PegSource::Value((1, 1))]),
@@ -342,7 +343,7 @@ fn should_fail_when_asset_decimals_are_not_same() {
 				Stableswap::create_pool_with_pegs(
 					RuntimeOrigin::root(),
 					pool_id,
-					vec![asset_a, asset_b],
+					to_bounded_asset_vec(vec![asset_a, asset_b]),
 					100,
 					Permill::from_percent(0),
 					BoundedPegSources::truncate_from(vec![PegSource::Value((1, 1)), PegSource::Value((1, 1))]),
@@ -371,7 +372,7 @@ fn should_fail_when_no_target_peg_oracle() {
 				Stableswap::create_pool_with_pegs(
 					RuntimeOrigin::root(),
 					pool_id,
-					vec![asset_a, asset_b],
+					to_bounded_asset_vec(vec![asset_a, asset_b]),
 					100,
 					Permill::from_percent(0),
 					BoundedPegSources::truncate_from(vec![

--- a/pallets/stableswap/src/tests/remove_liquidity.rs
+++ b/pallets/stableswap/src/tests/remove_liquidity.rs
@@ -1,6 +1,7 @@
 use crate::tests::mock::*;
-use crate::types::PoolInfo;
-use crate::{assert_balance, Error, Event, Pools};
+use crate::tests::to_bounded_asset_vec;
+use crate::types::{BoundedPegSources, PegSource, PoolInfo};
+use crate::{assert_balance, Error, Event, PoolPegs, Pools};
 use frame_support::traits::Contains;
 use frame_support::{assert_noop, assert_ok, BoundedVec};
 use hydradx_traits::stableswap::AssetAmount;
@@ -1368,5 +1369,256 @@ fn remove_multi_asset_liquidity_should_work_when_withdrawing_all_remaining_share
 				}
 				.into(),
 			]);
+		});
+}
+
+#[test]
+fn remove_multi_asset_liquidity_fails_when_min_amounts_length_is_not_correct() {
+	let asset_a: AssetId = 1;
+	let asset_b: AssetId = 2;
+	let asset_c: AssetId = 3;
+
+	ExtBuilder::default()
+		.with_endowed_accounts(vec![
+			(BOB, asset_a, 200 * ONE),
+			(ALICE, asset_a, 100 * ONE),
+			(ALICE, asset_b, 200 * ONE),
+			(ALICE, asset_c, 300 * ONE),
+		])
+		.with_registered_asset("one".as_bytes().to_vec(), asset_a, 12)
+		.with_registered_asset("two".as_bytes().to_vec(), asset_b, 12)
+		.with_registered_asset("three".as_bytes().to_vec(), asset_c, 12)
+		.with_pool(
+			ALICE,
+			PoolInfo::<AssetId, u64> {
+				assets: vec![asset_a, asset_b, asset_c].try_into().unwrap(),
+				initial_amplification: NonZeroU16::new(100).unwrap(),
+				final_amplification: NonZeroU16::new(100).unwrap(),
+				initial_block: 0,
+				final_block: 0,
+				fee: Permill::from_percent(0),
+			},
+			InitialLiquidity {
+				account: ALICE,
+				assets: vec![
+					AssetAmount::new(asset_a, 100 * ONE),
+					AssetAmount::new(asset_b, 200 * ONE),
+					AssetAmount::new(asset_c, 300 * ONE),
+				],
+			},
+		)
+		.build()
+		.execute_with(|| {
+			System::set_block_number(1);
+
+			let pool_id = get_pool_id_at(0);
+
+			let amount_added = 200 * ONE;
+
+			assert_ok!(Stableswap::add_liquidity(
+				RuntimeOrigin::signed(BOB),
+				pool_id,
+				BoundedVec::truncate_from(vec![AssetAmount::new(asset_a, amount_added)])
+			));
+
+			let min_amounts = vec![
+				AssetAmount {
+					asset_id: asset_a,
+					amount: 0,
+				},
+				AssetAmount {
+					asset_id: asset_c,
+					amount: 0,
+				},
+			];
+
+			let shares = Tokens::free_balance(pool_id, &BOB);
+			assert_noop!(
+				Stableswap::remove_liquidity(
+					RuntimeOrigin::signed(BOB),
+					pool_id,
+					shares,
+					BoundedVec::try_from(min_amounts).unwrap(),
+				),
+				Error::<Test>::IncorrectAssets
+			);
+		});
+}
+
+#[test]
+fn remove_multi_asset_liquidity_fails_when_min_amounts_contains_duplicate_assets() {
+	let asset_a: AssetId = 1;
+	let asset_b: AssetId = 2;
+	let asset_c: AssetId = 3;
+
+	ExtBuilder::default()
+		.with_endowed_accounts(vec![
+			(BOB, asset_a, 200 * ONE),
+			(ALICE, asset_a, 100 * ONE),
+			(ALICE, asset_b, 200 * ONE),
+			(ALICE, asset_c, 300 * ONE),
+		])
+		.with_registered_asset("one".as_bytes().to_vec(), asset_a, 12)
+		.with_registered_asset("two".as_bytes().to_vec(), asset_b, 12)
+		.with_registered_asset("three".as_bytes().to_vec(), asset_c, 12)
+		.with_pool(
+			ALICE,
+			PoolInfo::<AssetId, u64> {
+				assets: vec![asset_a, asset_b, asset_c].try_into().unwrap(),
+				initial_amplification: NonZeroU16::new(100).unwrap(),
+				final_amplification: NonZeroU16::new(100).unwrap(),
+				initial_block: 0,
+				final_block: 0,
+				fee: Permill::from_percent(0),
+			},
+			InitialLiquidity {
+				account: ALICE,
+				assets: vec![
+					AssetAmount::new(asset_a, 100 * ONE),
+					AssetAmount::new(asset_b, 200 * ONE),
+					AssetAmount::new(asset_c, 300 * ONE),
+				],
+			},
+		)
+		.build()
+		.execute_with(|| {
+			System::set_block_number(1);
+
+			let pool_id = get_pool_id_at(0);
+
+			let amount_added = 200 * ONE;
+
+			assert_ok!(Stableswap::add_liquidity(
+				RuntimeOrigin::signed(BOB),
+				pool_id,
+				BoundedVec::truncate_from(vec![AssetAmount::new(asset_a, amount_added)])
+			));
+
+			let min_amounts = vec![
+				AssetAmount {
+					asset_id: asset_a,
+					amount: 0,
+				},
+				AssetAmount {
+					asset_id: asset_a,
+					amount: 0,
+				},
+				AssetAmount {
+					asset_id: asset_c,
+					amount: 0,
+				},
+			];
+
+			let shares = Tokens::free_balance(pool_id, &BOB);
+			assert_noop!(
+				Stableswap::remove_liquidity(
+					RuntimeOrigin::signed(BOB),
+					pool_id,
+					shares,
+					BoundedVec::try_from(min_amounts).unwrap(),
+				),
+				Error::<Test>::IncorrectAssets
+			);
+		});
+}
+
+#[test]
+fn remove_all_liquidity_should_correctly_destroy_pool_when_pool_has_pegs() {
+	let asset_a: AssetId = 1;
+	let asset_b: AssetId = 2;
+	let asset_c: AssetId = 3;
+	let pool_id: AssetId = 100;
+	let peg2 = (1, 2);
+	let peg3 = (1, 3);
+
+	let max_peg_update = Permill::from_percent(100);
+
+	ExtBuilder::default()
+		.with_endowed_accounts(vec![
+			(BOB, asset_a, 200 * ONE),
+			(ALICE, asset_a, 100 * ONE),
+			(ALICE, asset_b, 200 * ONE),
+			(ALICE, asset_c, 300 * ONE),
+		])
+		.with_registered_asset("one".as_bytes().to_vec(), asset_a, 12)
+		.with_registered_asset("two".as_bytes().to_vec(), asset_b, 12)
+		.with_registered_asset("three".as_bytes().to_vec(), asset_c, 12)
+		.with_registered_asset("pool".as_bytes().to_vec(), pool_id, 18)
+		.build()
+		.execute_with(|| {
+			System::set_block_number(1);
+
+			assert_ok!(Stableswap::create_pool_with_pegs(
+				RuntimeOrigin::root(),
+				pool_id,
+				to_bounded_asset_vec(vec![asset_a, asset_b, asset_c]),
+				100,
+				Permill::from_percent(0),
+				BoundedPegSources::truncate_from(vec![
+					PegSource::Value((1, 1)),
+					PegSource::Value(peg2),
+					PegSource::Value(peg3)
+				]),
+				max_peg_update,
+			));
+
+			assert_ok!(Stableswap::add_liquidity(
+				RuntimeOrigin::signed(ALICE),
+				pool_id,
+				BoundedVec::truncate_from(vec![
+					AssetAmount::new(asset_a, 100 * ONE),
+					AssetAmount::new(asset_b, 200 * ONE),
+					AssetAmount::new(asset_c, 300 * ONE),
+				])
+			));
+
+			let amount_added = 200 * ONE;
+
+			let pool_account = pool_account(pool_id);
+
+			assert_ok!(Stableswap::add_liquidity(
+				RuntimeOrigin::signed(BOB),
+				pool_id,
+				BoundedVec::truncate_from(vec![AssetAmount::new(asset_a, amount_added)])
+			));
+
+			let shares = Tokens::free_balance(pool_id, &BOB);
+
+			let min_amounts = vec![
+				AssetAmount {
+					asset_id: asset_a,
+					amount: 0,
+				},
+				AssetAmount {
+					asset_id: asset_b,
+					amount: 0,
+				},
+				AssetAmount {
+					asset_id: asset_c,
+					amount: 0,
+				},
+			];
+
+			assert_ok!(Stableswap::remove_liquidity(
+				RuntimeOrigin::signed(BOB),
+				pool_id,
+				shares,
+				BoundedVec::try_from(min_amounts.clone()).unwrap(),
+			));
+
+			// Alice has all remaining shares and should receive all remaining reserve amounts
+			let shares = Tokens::free_balance(pool_id, &ALICE);
+			assert_ok!(Stableswap::remove_liquidity(
+				RuntimeOrigin::signed(ALICE),
+				pool_id,
+				shares,
+				BoundedVec::try_from(min_amounts).unwrap(),
+			));
+
+			// Ensure that pool has been removed
+			// Ensure that pool account has been removed from dust list
+			assert!(Pools::<Test>::get(pool_id).is_none());
+			assert!(PoolPegs::<Test>::get(pool_id).is_none());
+			assert!(!Whitelist::contains(&pool_account));
 		});
 }

--- a/pallets/stableswap/src/tests/update_pool.rs
+++ b/pallets/stableswap/src/tests/update_pool.rs
@@ -1,4 +1,5 @@
 use crate::tests::mock::*;
+use crate::tests::to_bounded_asset_vec;
 use crate::types::{PoolInfo, Tradability};
 use crate::{AssetTradability, Error, Pools};
 use frame_support::{assert_noop, assert_ok};
@@ -21,7 +22,7 @@ fn update_pool_should_work_when_all_parames_are_updated() {
 			assert_ok!(Stableswap::create_pool(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b],
+				to_bounded_asset_vec(vec![asset_a, asset_b]),
 				100,
 				Permill::from_percent(0),
 			));
@@ -62,7 +63,7 @@ fn update_pool_should_work_when_only_fee_is_updated() {
 			assert_ok!(Stableswap::create_pool(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b],
+				to_bounded_asset_vec(vec![asset_a, asset_b]),
 				100,
 				Permill::from_percent(0),
 			));
@@ -123,7 +124,7 @@ fn set_tradable_state_should_work_when_asset_in_pool() {
 			assert_ok!(Stableswap::create_pool(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b],
+				to_bounded_asset_vec(vec![asset_a, asset_b]),
 				100,
 				Permill::from_percent(0),
 			));
@@ -154,7 +155,7 @@ fn set_tradable_state_should_fail_when_asset_not_in_pool() {
 			assert_ok!(Stableswap::create_pool(
 				RuntimeOrigin::root(),
 				pool_id,
-				vec![asset_a, asset_b],
+				to_bounded_asset_vec(vec![asset_a, asset_b]),
 				100,
 				Permill::from_percent(0),
 			));

--- a/pallets/stableswap/src/trade_execution.rs
+++ b/pallets/stableswap/src/trade_execution.rs
@@ -40,7 +40,7 @@ where
 
 					let amplification = Self::get_amplification(&pool);
 					let (trade_fee, asset_pegs) =
-						Self::get_updated_pegs(pool_id, &pool).map_err(|v| ExecutorError::Error(v.into()))?;
+						Self::get_updated_pegs(pool_id, &pool).map_err(ExecutorError::Error)?;
 					let (amount, _) =
 						hydra_dx_math::stableswap::calculate_withdraw_one_asset::<D_ITERATIONS, Y_ITERATIONS>(
 							&balances,
@@ -116,7 +116,7 @@ where
 					let amplification = Self::get_amplification(&pool);
 					let share_issuance = T::Currency::total_issuance(pool_id);
 					let (trade_fee, asset_pegs) =
-						Self::get_updated_pegs(pool_id, &pool).map_err(|v| ExecutorError::Error(v.into()))?;
+						Self::get_updated_pegs(pool_id, &pool).map_err(ExecutorError::Error)?;
 					let (share_amount, _) = hydra_dx_math::stableswap::calculate_shares::<D_ITERATIONS>(
 						&initial_reserves,
 						&updated_reserves[..],
@@ -160,7 +160,7 @@ where
 					let share_issuance = T::Currency::total_issuance(pool_id);
 					let amplification = Self::get_amplification(&pool);
 					let (trade_fee, asset_pegs) =
-						Self::get_updated_pegs(pool_id, &pool).map_err(|v| ExecutorError::Error(v.into()))?;
+						Self::get_updated_pegs(pool_id, &pool).map_err(ExecutorError::Error)?;
 
 					let liqudity = hydra_dx_math::stableswap::calculate_add_one_asset::<D_ITERATIONS, Y_ITERATIONS>(
 						&balances,
@@ -190,7 +190,7 @@ where
 					let pool = Pools::<T>::get(pool_id)
 						.ok_or_else(|| ExecutorError::Error(Error::<T>::PoolNotFound.into()))?;
 					let (trade_fee, asset_pegs) =
-						Self::get_updated_pegs(pool_id, &pool).map_err(|v| ExecutorError::Error(v.into()))?;
+						Self::get_updated_pegs(pool_id, &pool).map_err(ExecutorError::Error)?;
 
 					let (shares_amount, _fees) =
 						hydra_dx_math::stableswap::calculate_shares_for_amount::<D_ITERATIONS>(
@@ -308,8 +308,7 @@ where
 				let amp = Pallet::<T>::get_amplification(&pool);
 				let share_issuance = T::Currency::total_issuance(pool_id);
 				let min_trade_limit = T::MinTradingLimit::get();
-				let (trade_fee, asset_pegs) =
-					Self::get_updated_pegs(pool_id, &pool).map_err(|v| ExecutorError::Error(v.into()))?;
+				let (trade_fee, asset_pegs) = Self::get_updated_pegs(pool_id, &pool).map_err(ExecutorError::Error)?;
 
 				let spot_price = hydra_dx_math::stableswap::calculate_spot_price(
 					pool_id.into(),

--- a/runtime-mock/src/stableswap.rs
+++ b/runtime-mock/src/stableswap.rs
@@ -78,7 +78,7 @@ impl Stablepools {
 			.map(|pool| {
 				RuntimeCall::Stableswap(pallet_stableswap::Call::create_pool {
 					share_asset: pool.pool_id,
-					assets: pool.get_assets(),
+					assets: BoundedVec::try_from(pool.get_assets()).unwrap(),
 					amplification: pool.final_amplification as u16,
 					fee: pool.fee,
 				})


### PR DESCRIPTION
This PR address minor findings in stableswap pallet.

1. Doc/comment update
2. Vec -> boundedvec
3. remove liquidity min amounts check
4. destroy pool removes peg info
5. added invariant check to withdraw_asset_amount to be consistent with others