### PR TITLE
feat: support for migrations to async_backing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4660,7 +4660,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "304.0.0"
+version = "305.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -4715,7 +4715,7 @@ dependencies = [
  "pallet-currencies",
  "pallet-currencies-rpc-runtime-api",
  "pallet-dca",
- "pallet-democracy 4.3.3",
+ "pallet-democracy 4.3.4",
  "pallet-dispatcher",
  "pallet-duster",
  "pallet-dynamic-evm-fee",
@@ -7932,7 +7932,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-democracy"
-version = "4.3.3"
+version = "4.3.4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9089,7 +9089,7 @@ dependencies = [
  "orml-traits",
  "pallet-balances",
  "pallet-conviction-voting",
- "pallet-democracy 4.3.3",
+ "pallet-democracy 4.3.4",
  "pallet-referenda",
  "pallet-uniques",
  "parity-scale-codec",
@@ -12172,7 +12172,7 @@ dependencies = [
  "pallet-conviction-voting",
  "pallet-currencies",
  "pallet-dca",
- "pallet-democracy 4.3.3",
+ "pallet-democracy 4.3.4",
  "pallet-dispatcher",
  "pallet-dynamic-evm-fee",
  "pallet-dynamic-fees",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "15.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "hash-db",
  "log",
@@ -979,7 +979,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.14.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1802,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1819,7 +1819,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1842,7 +1842,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -1887,7 +1887,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -1917,7 +1917,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1932,7 +1932,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -1958,7 +1958,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.12.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1980,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2006,7 +2006,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -2043,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -2060,7 +2060,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.17.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -2096,7 +2096,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -2107,7 +2107,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -2147,7 +2147,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.15.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -2156,7 +2156,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2172,7 +2172,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2186,7 +2186,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.10.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2196,7 +2196,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "8.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -2212,7 +2212,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -2222,7 +2222,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2239,7 +2239,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2263,7 +2263,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2282,7 +2282,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -2317,7 +2317,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2356,7 +2356,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -3449,7 +3449,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3577,7 +3577,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3601,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "43.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "14.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -3662,7 +3662,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3678,7 +3678,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -3708,7 +3708,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "array-bytes",
  "docify",
@@ -3723,7 +3723,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.46.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "futures",
  "indicatif",
@@ -3745,7 +3745,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "38.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -3786,7 +3786,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "30.0.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3806,7 +3806,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.1.0",
@@ -3818,7 +3818,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3828,7 +3828,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "cfg-if",
  "docify",
@@ -3848,7 +3848,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3862,7 +3862,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -3872,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6495,7 +6495,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "futures",
  "log",
@@ -6514,7 +6514,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -7387,7 +7387,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-asset-conversion"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7405,7 +7405,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7447,7 +7447,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7464,7 +7464,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7480,7 +7480,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7496,7 +7496,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7511,7 +7511,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7524,7 +7524,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7547,7 +7547,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "aquamarine",
  "docify",
@@ -7568,7 +7568,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7583,7 +7583,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7602,7 +7602,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -7651,7 +7651,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7688,7 +7688,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.17.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -7706,7 +7706,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7796,7 +7796,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7815,7 +7815,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7831,7 +7831,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -7918,7 +7918,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "5.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7953,7 +7953,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8060,7 +8060,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8082,7 +8082,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8095,7 +8095,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8302,7 +8302,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8338,7 +8338,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8360,7 +8360,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -8376,7 +8376,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8395,7 +8395,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8501,7 +8501,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8517,7 +8517,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "41.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -8536,7 +8536,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8553,7 +8553,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8588,7 +8588,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8603,7 +8603,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "35.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8621,7 +8621,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "36.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8641,7 +8641,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "33.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -8651,7 +8651,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8667,7 +8667,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8806,7 +8806,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.9.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8823,7 +8823,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8839,7 +8839,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8853,7 +8853,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "38.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8871,7 +8871,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8885,7 +8885,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8939,7 +8939,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8980,7 +8980,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8997,7 +8997,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9018,7 +9018,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9034,7 +9034,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9105,7 +9105,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9127,7 +9127,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "22.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -9136,7 +9136,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9146,7 +9146,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9162,7 +9162,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9177,7 +9177,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9196,7 +9196,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9263,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "38.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9278,7 +9278,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -9294,7 +9294,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -9306,7 +9306,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9324,7 +9324,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9338,7 +9338,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9354,7 +9354,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9368,7 +9368,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9382,7 +9382,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -9406,7 +9406,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9476,7 +9476,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -9829,7 +9829,7 @@ dependencies = [
 [[package]]
 name = "polkadot-approval-distribution"
 version = "18.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "bitvec",
  "futures",
@@ -9849,7 +9849,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "always-assert",
  "futures",
@@ -9865,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "derive_more",
  "fatality",
@@ -9889,7 +9889,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "fatality",
@@ -9922,7 +9922,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "cfg-if",
  "clap",
@@ -9950,7 +9950,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "bitvec",
  "fatality",
@@ -9973,7 +9973,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "15.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9984,7 +9984,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "derive_more",
  "fatality",
@@ -10009,7 +10009,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -10023,7 +10023,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10045,7 +10045,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -10068,7 +10068,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -10086,7 +10086,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "18.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -10119,7 +10119,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "bitvec",
  "futures",
@@ -10141,7 +10141,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10161,7 +10161,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -10176,7 +10176,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "futures",
@@ -10198,7 +10198,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -10212,7 +10212,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10229,7 +10229,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "fatality",
  "futures",
@@ -10248,7 +10248,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "futures",
@@ -10265,7 +10265,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "fatality",
  "futures",
@@ -10279,7 +10279,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10297,7 +10297,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "always-assert",
  "array-bytes",
@@ -10326,7 +10326,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -10342,7 +10342,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "cpu-time",
  "futures",
@@ -10368,7 +10368,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -10383,7 +10383,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "lazy_static",
  "log",
@@ -10402,7 +10402,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "bs58 0.5.1",
  "futures",
@@ -10421,7 +10421,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "18.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -10447,7 +10447,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -10473,7 +10473,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -10483,7 +10483,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -10513,7 +10513,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -10549,7 +10549,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "futures",
@@ -10571,7 +10571,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "bounded-collections",
  "derive_more",
@@ -10587,7 +10587,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -10613,7 +10613,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -10648,7 +10648,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -10698,7 +10698,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "bs58 0.5.1",
  "frame-benchmarking",
@@ -10710,7 +10710,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -10759,7 +10759,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -10866,7 +10866,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
@@ -10889,7 +10889,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -11957,7 +11957,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -12057,7 +12057,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -12556,7 +12556,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "29.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "log",
  "sp-core",
@@ -12567,7 +12567,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "futures",
@@ -12597,7 +12597,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12619,7 +12619,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.42.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -12634,7 +12634,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "array-bytes",
  "docify",
@@ -12661,7 +12661,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -12672,7 +12672,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.47.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -12713,7 +12713,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "fnv",
  "futures",
@@ -12740,7 +12740,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -12766,7 +12766,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "futures",
@@ -12790,7 +12790,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "futures",
@@ -12819,7 +12819,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -12855,7 +12855,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -12877,7 +12877,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -12913,7 +12913,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -12933,7 +12933,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -12946,7 +12946,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.30.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -12990,7 +12990,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.30.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -13010,7 +13010,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "futures",
@@ -13033,7 +13033,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.40.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -13056,7 +13056,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.35.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -13069,7 +13069,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.32.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "log",
  "polkavm",
@@ -13080,7 +13080,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.35.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -13098,7 +13098,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "console",
  "futures",
@@ -13115,7 +13115,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "33.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -13129,7 +13129,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.15.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.4",
@@ -13158,7 +13158,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.45.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13209,7 +13209,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -13227,7 +13227,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "ahash",
  "futures",
@@ -13246,7 +13246,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13267,7 +13267,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13304,7 +13304,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "array-bytes",
  "futures",
@@ -13323,7 +13323,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.12.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "bs58 0.5.1",
  "ed25519-dalek",
@@ -13340,7 +13340,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -13374,7 +13374,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -13383,7 +13383,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -13415,7 +13415,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13435,7 +13435,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "17.1.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -13459,7 +13459,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "array-bytes",
  "futures",
@@ -13491,7 +13491,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.46.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "directories",
@@ -13555,7 +13555,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.36.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -13566,7 +13566,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.22.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "clap",
  "fs4",
@@ -13579,7 +13579,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13598,7 +13598,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "derive_more",
  "futures",
@@ -13619,7 +13619,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "25.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "chrono",
  "futures",
@@ -13639,7 +13639,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "37.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "chrono",
  "console",
@@ -13668,7 +13668,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -13679,7 +13679,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "futures",
@@ -13706,7 +13706,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "futures",
@@ -13722,7 +13722,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -14263,7 +14263,7 @@ dependencies = [
 [[package]]
 name = "slot-range-helper"
 version = "15.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -14470,7 +14470,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "docify",
  "hash-db",
@@ -14492,7 +14492,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -14506,7 +14506,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14518,7 +14518,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -14532,7 +14532,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14544,7 +14544,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -14554,7 +14554,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "37.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -14573,7 +14573,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "futures",
@@ -14588,7 +14588,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14604,7 +14604,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14622,7 +14622,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "22.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -14643,7 +14643,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "21.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -14660,7 +14660,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.40.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14671,7 +14671,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "array-bytes",
  "bitflags 1.3.2",
@@ -14717,7 +14717,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -14730,7 +14730,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
@@ -14740,7 +14740,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -14749,7 +14749,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14759,7 +14759,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.29.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -14769,7 +14769,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.15.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14781,7 +14781,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -14794,7 +14794,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "bytes",
  "docify",
@@ -14820,7 +14820,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -14830,7 +14830,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -14841,7 +14841,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -14850,7 +14850,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.7.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -14860,7 +14860,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.12.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14871,7 +14871,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "34.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -14888,7 +14888,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14901,7 +14901,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -14911,7 +14911,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -14921,7 +14921,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "32.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -14931,7 +14931,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "39.0.5"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "docify",
  "either",
@@ -14957,7 +14957,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "28.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -14976,7 +14976,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "Inflector",
  "expander",
@@ -14989,7 +14989,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "36.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -15003,7 +15003,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "36.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -15016,7 +15016,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.43.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "hash-db",
  "log",
@@ -15036,7 +15036,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -15060,12 +15060,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 
 [[package]]
 name = "sp-storage"
 version = "21.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -15077,7 +15077,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -15089,7 +15089,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -15100,7 +15100,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -15109,7 +15109,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -15123,7 +15123,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "ahash",
  "hash-db",
@@ -15146,7 +15146,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -15163,7 +15163,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -15174,7 +15174,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -15186,7 +15186,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -15263,7 +15263,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-parachain-info"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -15276,7 +15276,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "14.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -15295,7 +15295,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "17.0.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -15317,7 +15317,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -15460,7 +15460,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -15485,12 +15485,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -15510,7 +15510,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "http-body-util",
  "hyper 1.5.1",
@@ -15524,7 +15524,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -15537,7 +15537,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15554,7 +15554,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "24.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "array-bytes",
  "build-helper",
@@ -16163,7 +16163,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -16174,7 +16174,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "expander",
  "proc-macro-crate 3.1.0",
@@ -17003,7 +17003,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "18.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -17111,7 +17111,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -17501,7 +17501,7 @@ dependencies = [
 [[package]]
 name = "xcm-emulator"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "array-bytes",
  "cumulus-pallet-parachain-system",
@@ -17536,7 +17536,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "10.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -17547,7 +17547,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.4.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch2#102d917df1356688ad83606c269814f1eeab6c9f"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch3#1e0ec4dd5f938a53c8cb6e01941123357fd83de3"
 dependencies = [
  "frame-support",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,111 +160,111 @@ pallet-evm-precompile-call-permit = { path = "precompiles/call-permit", default-
 precompile-utils = { path = "precompiles/utils", default-features = false }
 
 # Frame
-frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-frame-benchmarking-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-frame-executive = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-frame-remote-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-frame-support = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false, features = ["tuples-96"] }
-frame-support-procedural = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false, features = ["tuples-96"] }
-frame-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-frame-system-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-frame-try-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-frame-metadata-hash-extension = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-arithmetic = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-authority-discovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-block-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-genesis-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-blockchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-consensus-babe = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-consensus-beefy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-inherents = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-io = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-npos-elections = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sc-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-runtime-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-runtime-interface-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-staking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-std = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-storage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-state-machine = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-trie = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-version = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-weights = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-crypto-hashing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-crypto-ec-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sp-wasm-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+frame-benchmarking-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+frame-executive = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+frame-remote-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+frame-support = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false, features = ["tuples-96"] }
+frame-support-procedural = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false, features = ["tuples-96"] }
+frame-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+frame-system-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+frame-try-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+frame-metadata-hash-extension = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-arithmetic = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-authority-discovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-block-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-genesis-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-blockchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-consensus-babe = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-consensus-beefy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-inherents = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-io = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-npos-elections = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sc-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-runtime-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-runtime-interface-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-staking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-std = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-storage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-state-machine = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-trie = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-version = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-weights = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-crypto-hashing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-crypto-ec-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sp-wasm-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
 
-sc-basic-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sc-chain-spec = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sc-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sc-client-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sc-client-db = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sc-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sc-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sc-consensus-grandpa = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sc-executor = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sc-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sc-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sc-network-sync = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sc-network-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sc-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sc-rpc-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sc-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sc-telemetry = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sc-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sc-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sc-transaction-pool-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-sc-sysinfo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+sc-basic-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sc-chain-spec = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sc-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sc-client-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sc-client-db = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sc-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sc-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sc-consensus-grandpa = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sc-executor = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sc-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sc-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sc-network-sync = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sc-network-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sc-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sc-rpc-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sc-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sc-telemetry = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sc-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sc-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sc-transaction-pool-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+sc-sysinfo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
 
 # Substrate Pallets
-pallet-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-balances = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-bags-list = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-collective = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-conviction-voting = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-elections-phragmen = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-identity = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-multisig = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-preimage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-proxy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-referenda = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-scheduler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-sudo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-tips = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-transaction-payment-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-treasury = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-uniques = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-im-online = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-message-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-state-trie-migration = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-whitelist = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+pallet-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-balances = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-bags-list = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-collective = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-conviction-voting = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-elections-phragmen = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-identity = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-multisig = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-preimage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-proxy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-referenda = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-scheduler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-sudo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-tips = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-transaction-payment-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-treasury = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-uniques = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-im-online = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-message-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-state-trie-migration = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-whitelist = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
 
-substrate-build-script-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-substrate-frame-rpc-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-substrate-prometheus-endpoint = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-substrate-rpc-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-substrate-wasm-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-substrate-state-trie-migration-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+substrate-build-script-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+substrate-frame-rpc-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+substrate-prometheus-endpoint = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+substrate-rpc-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+substrate-wasm-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+substrate-state-trie-migration-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
 
 #TODO: We use our custom ORML as it contains the fix of bug for reducible_balance check, for Preserve mode. Once the official ORML pushes a new version with the fix, we can use that again
 # ORML dependencies
@@ -282,30 +282,30 @@ orml-xcm-support = { git = "https://github.com/galacticcouncil/open-runtime-modu
 orml-xtokens = { git = "https://github.com/galacticcouncil/open-runtime-module-library", branch = "polkadot-stable2409", default-features = false }
 
 # Cumulus dependencies
-cumulus-client-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-cumulus-client-collator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-cumulus-client-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-cumulus-client-consensus-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-cumulus-client-consensus-proposer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-cumulus-client-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-cumulus-client-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-cumulus-pallet-aura-ext = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-cumulus-pallet-parachain-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-cumulus-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-cumulus-pallet-xcmp-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-cumulus-primitives-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-cumulus-primitives-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-cumulus-primitives-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-cumulus-relay-chain-inprocess-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-cumulus-relay-chain-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-cumulus-relay-chain-minimal-node = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-collator-selection = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-staging-parachain-info = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-xcm-emulator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-xcm-runtime-apis = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-parachains-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+cumulus-client-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+cumulus-client-collator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+cumulus-client-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+cumulus-client-consensus-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+cumulus-client-consensus-proposer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+cumulus-client-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+cumulus-client-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+cumulus-pallet-aura-ext = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+cumulus-pallet-parachain-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+cumulus-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+cumulus-primitives-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+cumulus-primitives-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+cumulus-relay-chain-inprocess-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+cumulus-relay-chain-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+cumulus-relay-chain-minimal-node = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-collator-selection = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+staging-parachain-info = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+xcm-emulator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+xcm-runtime-apis = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+parachains-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
 
 # Frontier
 fc-consensus = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-stable2409", default-features = false }
@@ -338,36 +338,36 @@ module-evm-utility-macro = { path = "runtime/hydradx/src/evm/evm-utility/macro",
 ethereum = { version = "0.15.0", default-features = false, features = ["with-codec"] }
 
 # Polkadot dependencies
-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-pallet-xcm-benchmarks = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-polkadot-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-core-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-polkadot-parachain = { package = "polkadot-parachain-primitives", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false, features = [
+pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+pallet-xcm-benchmarks = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+polkadot-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-core-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+polkadot-parachain = { package = "polkadot-parachain-primitives", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false, features = [
     "wasm-api",
 ] }
-polkadot-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-polkadot-runtime-parachains = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-polkadot-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-polkadot-xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
+polkadot-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+polkadot-runtime-parachains = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+polkadot-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+polkadot-xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
 
-polkadot-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-node-core-pvf = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-node-network-protocol = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-node-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-node-subsystem = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-node-subsystem-util = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-overseer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-runtime-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-polkadot-statement-table = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-rococo-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-node-core-pvf = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-node-network-protocol = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-node-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-node-subsystem = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-node-subsystem-util = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-overseer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-runtime-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+polkadot-statement-table = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+rococo-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
 
-cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
 
 [patch."https://github.com/moonbeam-foundation/open-runtime-module-library"]
 # ORML dependencies
@@ -382,316 +382,316 @@ orml-xcm-support = { git = "https://github.com/galacticcouncil/open-runtime-modu
 orml-xtokens = { git = "https://github.com/galacticcouncil/open-runtime-module-library", branch = "polkadot-stable2409" }
 
 [patch."https://github.com/moonbeam-foundation/polkadot-sdk"]
-cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2", default-features = false }
-frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-frame-benchmarking-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-frame-executive = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-frame-remote-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-frame-support = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-frame-support-procedural = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-frame-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-frame-system-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-frame-system-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-frame-try-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-frame-metadata-hash-extension = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-arithmetic = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-authority-discovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-block-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-genesis-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-blockchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-consensus-babe = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-inherents = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-io = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-npos-elections = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-runtime-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-runtime-interface-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-wasm-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-panic-handler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-database = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-staking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-std = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-storage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-trie = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-version = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-basic-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-chain-spec = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-client-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-client-db = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-consensus-grandpa = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-executor = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-network-sync = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-network-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-rpc-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-telemetry = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-transaction-pool-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-sysinfo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-state-machine = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-weights = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-crypto-hashing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3", default-features = false }
+frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+frame-benchmarking-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+frame-executive = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+frame-remote-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+frame-support = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+frame-support-procedural = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+frame-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+frame-system-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+frame-system-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+frame-try-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+frame-metadata-hash-extension = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-arithmetic = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-authority-discovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-block-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-genesis-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-blockchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-consensus-babe = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-inherents = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-io = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-npos-elections = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-runtime-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-runtime-interface-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-wasm-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-panic-handler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-database = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-staking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-std = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-storage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-trie = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-version = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-basic-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-chain-spec = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-client-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-client-db = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-consensus-grandpa = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-executor = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-network-sync = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-network-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-rpc-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-telemetry = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-transaction-pool-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-sysinfo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-state-machine = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-weights = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-crypto-hashing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
 
 # Substrate Pallets
-pallet-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-balances = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-collective = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-elections-phragmen = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-identity = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-multisig = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-preimage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-proxy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-scheduler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-sudo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-tips = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-transaction-payment = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-transaction-payment-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-treasury = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-uniques = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-im-online = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-message-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-state-trie-migration = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-balances = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-collective = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-elections-phragmen = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-identity = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-multisig = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-preimage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-proxy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-scheduler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-sudo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-tips = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-transaction-payment = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-transaction-payment-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-treasury = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-uniques = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-im-online = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-message-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-state-trie-migration = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
 
-substrate-build-script-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-substrate-frame-rpc-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-substrate-prometheus-endpoint = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-substrate-rpc-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-substrate-wasm-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-substrate-state-trie-migration-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+substrate-build-script-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+substrate-frame-rpc-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+substrate-prometheus-endpoint = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+substrate-rpc-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+substrate-wasm-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+substrate-state-trie-migration-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
 
 # Cumulus dependencies
-cumulus-client-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-client-collator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-client-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-client-consensus-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-client-consensus-proposer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-client-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-client-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-pallet-aura-ext = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-pallet-parachain-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-pallet-xcmp-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-primitives-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-primitives-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-primitives-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-relay-chain-inprocess-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-relay-chain-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-relay-chain-minimal-node = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-collator-selection = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-staging-parachain-info = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-xcm-emulator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-parachains-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-xcm-runtime-apis = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-client-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-client-collator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-client-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-client-consensus-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-client-consensus-proposer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-client-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-client-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-pallet-aura-ext = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-pallet-parachain-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-primitives-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-primitives-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-primitives-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-relay-chain-inprocess-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-relay-chain-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-relay-chain-minimal-node = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-collator-selection = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+staging-parachain-info = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+xcm-emulator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+parachains-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+xcm-runtime-apis = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
 
 # Polkadot dependencies
-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-xcm-benchmarks = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-core-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-parachain = { package = "polkadot-parachain-primitives", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-runtime-parachains = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-xcm-benchmarks = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-core-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-parachain = { package = "polkadot-parachain-primitives", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-runtime-parachains = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
 
-polkadot-node-core-pvf = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-node-network-protocol = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-node-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-node-subsystem = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-node-subsystem-util = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-overseer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-runtime-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-statement-table = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-rococo-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-node-core-pvf = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-node-network-protocol = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-node-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-node-subsystem = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-node-subsystem-util = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-overseer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-runtime-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-statement-table = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+rococo-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
 
-cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
 
 [patch."https://github.com/paritytech/polkadot-sdk"]
-frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-frame-benchmarking-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-frame-executive = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-frame-remote-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-frame-support = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-frame-support-procedural = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-frame-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-frame-system-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-frame-system-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-frame-try-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-frame-metadata-hash-extension = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-arithmetic = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-authority-discovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-block-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-genesis-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-blockchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-consensus-babe = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-inherents = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-io = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-npos-elections = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-runtime-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-runtime-interface-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-wasm-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-panic-handler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-database = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-staking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-std = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-storage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-trie = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-version = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-basic-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-chain-spec = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-client-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-client-db = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-consensus-grandpa = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-executor = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-network-sync = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-network-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-rpc-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-telemetry = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-transaction-pool-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-sysinfo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sc-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-state-machine = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-weights = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-sp-crypto-hashing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+frame-benchmarking-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+frame-executive = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+frame-remote-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+frame-support = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+frame-support-procedural = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+frame-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+frame-system-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+frame-system-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+frame-try-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+frame-metadata-hash-extension = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-arithmetic = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-authority-discovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-block-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-genesis-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-blockchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-consensus-babe = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-inherents = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-io = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-npos-elections = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-runtime-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-runtime-interface-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-wasm-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-panic-handler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-database = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-staking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-std = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-storage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-trie = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-version = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-basic-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-chain-spec = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-client-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-client-db = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-consensus-grandpa = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-executor = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-network-sync = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-network-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-rpc-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-telemetry = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-transaction-pool-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-sysinfo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sc-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-state-machine = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-weights = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+sp-crypto-hashing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
 
 # Substrate Pallets
-pallet-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-balances = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-collective = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-elections-phragmen = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-identity = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-multisig = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-preimage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-proxy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-scheduler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-sudo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-tips = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-transaction-payment = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-transaction-payment-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-treasury = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-uniques = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-im-online = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-message-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-state-trie-migration = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-balances = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-collective = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-elections-phragmen = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-identity = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-multisig = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-preimage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-proxy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-scheduler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-sudo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-tips = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-transaction-payment = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-transaction-payment-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-treasury = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-uniques = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-im-online = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-message-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-state-trie-migration = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
 
-substrate-build-script-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-substrate-frame-rpc-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-substrate-prometheus-endpoint = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-substrate-rpc-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-substrate-wasm-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-substrate-state-trie-migration-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+substrate-build-script-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+substrate-frame-rpc-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+substrate-prometheus-endpoint = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+substrate-rpc-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+substrate-wasm-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+substrate-state-trie-migration-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
 
 # Cumulus dependencies
-cumulus-client-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-client-collator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-client-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-client-consensus-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-client-consensus-proposer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-client-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-client-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-pallet-aura-ext = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-pallet-parachain-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-pallet-xcmp-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-primitives-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-primitives-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-primitives-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-relay-chain-inprocess-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-relay-chain-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-relay-chain-minimal-node = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-collator-selection = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-staging-parachain-info = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-xcm-emulator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-parachains-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-xcm-runtime-apis = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-client-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-client-collator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-client-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-client-consensus-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-client-consensus-proposer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-client-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-client-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-pallet-aura-ext = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-pallet-parachain-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-primitives-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-primitives-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-primitives-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-relay-chain-inprocess-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-relay-chain-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-relay-chain-minimal-node = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-collator-selection = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+staging-parachain-info = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+xcm-emulator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+parachains-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+xcm-runtime-apis = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
 
 # Polkadot dependencies
-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-pallet-xcm-benchmarks = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-core-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-parachain = { package = "polkadot-parachain-primitives", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-runtime-parachains = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+pallet-xcm-benchmarks = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-core-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-parachain = { package = "polkadot-parachain-primitives", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-runtime-parachains = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
 
-polkadot-node-core-pvf = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-node-network-protocol = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-node-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-node-subsystem = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-node-subsystem-util = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-overseer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-runtime-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-polkadot-statement-table = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-rococo-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+polkadot-node-core-pvf = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-node-network-protocol = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-node-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-node-subsystem = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-node-subsystem-util = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-overseer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-runtime-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+polkadot-statement-table = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+rococo-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
 
-cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
-cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch2" }
+cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }
+cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch3" }

--- a/pallets/democracy/Cargo.toml
+++ b/pallets/democracy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-democracy"
-version = "4.3.3"
+version = "4.3.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/pallets/democracy/src/lib.rs
+++ b/pallets/democracy/src/lib.rs
@@ -1195,11 +1195,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			let who = T::VoteRemovalOrigin::ensure_origin(origin)?;
 			let target = T::Lookup::lookup(target)?;
-			let scope = if target == who {
-				crate::types::UnvoteScope::Any
-			} else {
-				crate::types::UnvoteScope::OnlyExpired
-			};
+			let scope = crate::types::UnvoteScope::Any;
 			Self::try_remove_vote(&target, index, scope, true)?;
 			Ok(())
 		}

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "304.0.0"
+version = "305.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -128,7 +128,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 304,
+	spec_version: 305,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
This PR adds support for the migrations needed for async_backing

Changes to polkadot-sdk: https://github.com/galacticcouncil/polkadot-sdk/compare/stable2409-patch2...galacticcouncil:polkadot-sdk:stable2409-patch3