### PR TITLE
fix: bug of referral fee processing within router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4609,7 +4609,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-adapters"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -4660,7 +4660,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "305.0.0"
+version = "306.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -12127,7 +12127,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-integration-tests"
-version = "1.38.1"
+version = "1.38.2"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "1.38.1"
+version = "1.38.2"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/src/referrals.rs
+++ b/integration-tests/src/referrals.rs
@@ -309,47 +309,6 @@ fn claim_should_work_when_trade_happens_via_router() {
 }
 
 #[test]
-fn claim_should_work_within_direct_omni_trade() {
-	Hydra::execute_with(|| {
-		//Arrange
-		init_omnipool_with_oracle_for_block_12();
-		let code =
-			ReferralCode::<<Runtime as pallet_referrals::Config>::CodeLength>::truncate_from(b"BALLS69".to_vec());
-		assert_ok!(Referrals::register_code(
-			RuntimeOrigin::signed(ALICE.into()),
-			code.clone()
-		));
-		assert_ok!(Referrals::link_code(RuntimeOrigin::signed(BOB.into()), code));
-
-		assert_ok!(Referrals::claim_rewards(RuntimeOrigin::signed(ALICE.into())));
-
-		let old_balance = Currencies::free_balance(HDX, &ALICE.into());
-		assert_ok!(Omnipool::sell(
-			RuntimeOrigin::signed(BOB.into()),
-			HDX,
-			DAI,
-			1_000_000_000_000,
-			0
-		));
-
-		let pot_balance = Currencies::free_balance(DAI, &Referrals::pot_account_id());
-		assert!(pot_balance > 0);
-
-		//Act
-		assert_ok!(Referrals::claim_rewards(RuntimeOrigin::signed(ALICE.into())));
-
-		let pot_balance = Currencies::free_balance(DAI, &Referrals::pot_account_id());
-		assert_eq!(pot_balance, 0);
-
-		//Assert that user receives claim amounts
-		let new_balance = Currencies::free_balance(HDX, &ALICE.into());
-		let claimed_amount = new_balance - old_balance;
-		assert!(claimed_amount > 0);
-		assert_eq!(claimed_amount, 853605689);
-	});
-}
-
-#[test]
 fn trading_hdx_in_omnipool_should_skip_referrals_program() {
 	Hydra::execute_with(|| {
 		init_omnipool_with_oracle_for_block_12();

--- a/integration-tests/src/referrals.rs
+++ b/integration-tests/src/referrals.rs
@@ -563,43 +563,6 @@ fn buying_with_hdx_in_omnipool_should_transfer_correct_fee() {
 }
 
 #[test]
-fn buying_with_hdx_in_router_should_transfer_correct_fee() {
-	Hydra::execute_with(|| {
-		init_omnipool_with_oracle_for_block_12();
-		assert_ok!(Staking::initialize_staking(RawOrigin::Root.into()));
-		let staking_acc = Staking::pot_account_id();
-		let ref_account = Referrals::pot_account_id();
-		let orig_balance = Currencies::free_balance(DAI, &ref_account);
-		let stak_orig_balance = Currencies::free_balance(HDX, &staking_acc);
-		assert_ok!(Omnipool::buy(
-			RuntimeOrigin::signed(BOB.into()),
-			DAI,
-			HDX,
-			1_000_000_000_000_000_000,
-			u128::MAX,
-		));
-
-		/*assert_ok!(hydradx_runtime::Router::buy(
-			RuntimeOrigin::signed(BOB.into()),
-			HDX,
-			DAI,
-			1_000_000_000_000_000_000,
-			u128::MAX,
-			vec![].try_into().unwrap(),
-		));*/
-
-		let expected_taken_fee = 2225865033829934;
-
-		let ref_dai_balance = Currencies::free_balance(DAI, &ref_account);
-		let staking_balance = Currencies::free_balance(HDX, &staking_acc);
-		assert_eq!(ref_dai_balance.abs_diff(orig_balance), expected_taken_fee);
-		assert_eq!(staking_balance.abs_diff(stak_orig_balance), 0);
-
-		assert_ok!(Referrals::claim_rewards(RuntimeOrigin::signed(BOB.into())));
-	});
-}
-
-#[test]
 fn trading_in_omnipool_should_increase_staking_shares_when_no_code_linked() {
 	Hydra::execute_with(|| {
 		init_omnipool_with_oracle_for_block_12();

--- a/runtime/adapters/Cargo.toml
+++ b/runtime/adapters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-adapters"
-version = "1.5.2"
+version = "1.5.3"
 description = "Structs and other generic types for building runtimes."
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/runtime/adapters/src/lib.rs
+++ b/runtime/adapters/src/lib.rs
@@ -340,7 +340,8 @@ where
 		+ pallet_circuit_breaker::Config
 		+ frame_system::Config<RuntimeOrigin = Origin, AccountId = sp_runtime::AccountId32>
 		+ pallet_staking::Config
-		+ pallet_referrals::Config,
+		+ pallet_referrals::Config
+		+ pallet_broadcast::Config,
 	<Runtime as frame_system::Config>::AccountId: From<AccountId>,
 	<Runtime as pallet_staking::Config>::AssetId: From<AssetId>,
 	<Runtime as pallet_referrals::Config>::AssetId: From<AssetId>,
@@ -477,6 +478,9 @@ where
 		asset: AssetId,
 		amount: Balance,
 	) -> Result<Vec<Option<(Balance, AccountId)>>, Self::Error> {
+		//Within router, we use router as trader account, so we should get the actual user account to correctly process trade fee and accrue rewards
+		let trader = pallet_broadcast::Pallet::<Runtime>::get_swapper().unwrap_or(trader);
+
 		if asset == Lrna::get() {
 			return Ok(vec![]);
 		}

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "305.0.0"
+version = "306.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -128,7 +128,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 305,
+	spec_version: 306,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
TODO:
- [x] check with chopsticks if it is resolved with a test referral flow

Within a router trade, we have the router account that executes the trade

It leads to incorrectly processed fee and reward accrue in [on_trade](https://github.com/galacticcouncil/hydration-node/blob/174ac5d13f0eca23b120b61ed57b854079d2f939/runtime/adapters/src/lib.rs#L486) event handler.

https://github.com/galacticcouncil/hydration-node/blob/174ac5d13f0eca23b120b61ed57b854079d2f939/runtime/adapters/src/lib.rs#L486

The fix is to use the actual user (instead of the router account) which we track in the broadcast pallet.
