### PR TITLE
fix: aave swapped event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4660,7 +4660,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "307.0.0"
+version = "308.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -7667,7 +7667,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-broadcast"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -12127,7 +12127,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-integration-tests"
-version = "1.38.3"
+version = "1.38.4"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9050,7 +9050,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-stableswap"
-version = "5.1.3"
+version = "5.1.4"
 dependencies = [
  "bitflags 1.3.2",
  "frame-benchmarking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8410,7 +8410,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-lbp"
-version = "4.10.3"
+version = "4.10.4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8689,7 +8689,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-omnipool"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "bitflags 1.3.2",
  "frame-benchmarking",
@@ -8749,7 +8749,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-otc"
-version = "2.1.5"
+version = "2.1.6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8772,7 +8772,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-otc-settlements"
-version = "1.1.7"
+version = "1.1.8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9423,7 +9423,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-xyk"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "1.38.3"
+version = "1.38.4"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/src/aave_router.rs
+++ b/integration-tests/src/aave_router.rs
@@ -16,6 +16,7 @@ use hydradx_runtime::evm::precompiles::erc20_mapping::HydraErc20Mapping;
 use hydradx_runtime::{AssetId, Currencies, EVMAccounts, Liquidation, Router, Runtime, RuntimeOrigin};
 use hydradx_runtime::{AssetRegistry, Stableswap};
 use hydradx_traits::evm::Erc20Encoding;
+use hydradx_traits::evm::Erc20Mapping;
 use hydradx_traits::evm::EvmAddress;
 use hydradx_traits::router::ExecutorError;
 use hydradx_traits::router::PoolType::{Aave, XYK};
@@ -37,7 +38,6 @@ use sp_runtime::DispatchResult;
 use sp_runtime::FixedU128;
 use sp_runtime::Permill;
 use sp_runtime::TransactionOutcome;
-
 pub fn with_aave(execution: impl FnOnce()) {
 	TestNet::reset();
 	// Snapshot contains the storage of EVM, AssetRegistry, Timestamp, Omnipool and Tokens pallets
@@ -240,7 +240,7 @@ fn buy_dot() {
 		));
 		assert_eq!(Currencies::free_balance(ADOT, &ALICE.into()), BAG - ONE - 2);
 
-		let atoken = HydraErc20Mapping::encode_evm_address(ADOT);
+		let atoken = HydraErc20Mapping::asset_address(ADOT);
 		let filler = pallet_evm_accounts::Pallet::<Runtime>::truncated_account_id(atoken);
 
 		pretty_assertions::assert_eq!(
@@ -318,7 +318,7 @@ fn sell_adot_should_work_when_less_spent_due_to_aave_rounding() {
 		assert_eq!(Currencies::free_balance(ADOT, &ALICE.into()), balance - amount + 1);
 		assert_eq!(Currencies::free_balance(DOT, &ALICE.into()), dots + amount + 6);
 
-		let atoken = HydraErc20Mapping::encode_evm_address(ADOT);
+		let atoken = HydraErc20Mapping::asset_address(ADOT);
 		let filler = pallet_evm_accounts::Pallet::<Runtime>::truncated_account_id(atoken);
 
 		pretty_assertions::assert_eq!(

--- a/integration-tests/src/aave_router.rs
+++ b/integration-tests/src/aave_router.rs
@@ -245,7 +245,7 @@ fn buy_dot() {
 
 		pretty_assertions::assert_eq!(
 			*get_last_swapped_events().last().unwrap(),
-			pallet_broadcast::Event::<Runtime>::Swapped2 {
+			pallet_broadcast::Event::<Runtime>::Swapped3 {
 				swapper: ALICE.into(),
 				filler,
 				filler_type: pallet_broadcast::types::Filler::AAVE,
@@ -323,7 +323,7 @@ fn sell_adot_should_work_when_less_spent_due_to_aave_rounding() {
 
 		pretty_assertions::assert_eq!(
 			*get_last_swapped_events().last().unwrap(),
-			pallet_broadcast::Event::<Runtime>::Swapped2 {
+			pallet_broadcast::Event::<Runtime>::Swapped3 {
 				swapper: ALICE.into(),
 				filler,
 				filler_type: pallet_broadcast::types::Filler::AAVE,

--- a/integration-tests/src/dca.rs
+++ b/integration-tests/src/dca.rs
@@ -225,7 +225,7 @@ mod omnipool {
 			pretty_assertions::assert_eq!(
 				last_two_swapped_events,
 				vec![
-					pallet_broadcast::Event::Swapped2 {
+					pallet_broadcast::Event::Swapped3 {
 						swapper: ALICE.into(),
 						filler: Omnipool::protocol_account(),
 						filler_type: pallet_broadcast::types::Filler::Omnipool,
@@ -242,7 +242,7 @@ mod omnipool {
 							ExecutionType::Omnipool(2)
 						]
 					},
-					pallet_broadcast::Event::Swapped2 {
+					pallet_broadcast::Event::Swapped3 {
 						swapper: ALICE.into(),
 						filler: Omnipool::protocol_account(),
 						filler_type: pallet_broadcast::types::Filler::Omnipool,
@@ -270,7 +270,7 @@ mod omnipool {
 			pretty_assertions::assert_eq!(
 				last_two_swapped_events,
 				vec![
-					pallet_broadcast::Event::Swapped2 {
+					pallet_broadcast::Event::Swapped3 {
 						swapper: ALICE.into(),
 						filler: Omnipool::protocol_account(),
 						filler_type: pallet_broadcast::types::Filler::Omnipool,
@@ -287,7 +287,7 @@ mod omnipool {
 							ExecutionType::Omnipool(5)
 						],
 					},
-					pallet_broadcast::Event::Swapped2 {
+					pallet_broadcast::Event::Swapped3 {
 						swapper: ALICE.into(),
 						filler: Omnipool::protocol_account(),
 						filler_type: pallet_broadcast::types::Filler::Omnipool,
@@ -751,7 +751,7 @@ mod omnipool {
 			pretty_assertions::assert_eq!(
 				last_two_swapped_events,
 				vec![
-					pallet_broadcast::Event::Swapped2 {
+					pallet_broadcast::Event::Swapped3 {
 						swapper: ALICE.into(),
 						filler: Omnipool::protocol_account(),
 						filler_type: pallet_broadcast::types::Filler::Omnipool,
@@ -768,7 +768,7 @@ mod omnipool {
 							ExecutionType::Omnipool(2)
 						],
 					},
-					pallet_broadcast::Event::Swapped2 {
+					pallet_broadcast::Event::Swapped3 {
 						swapper: ALICE.into(),
 						filler: Omnipool::protocol_account(),
 						filler_type: pallet_broadcast::types::Filler::Omnipool,
@@ -796,7 +796,7 @@ mod omnipool {
 			pretty_assertions::assert_eq!(
 				last_two_swapped_events,
 				vec![
-					pallet_broadcast::Event::Swapped2 {
+					pallet_broadcast::Event::Swapped3 {
 						swapper: ALICE.into(),
 						filler: Omnipool::protocol_account(),
 						filler_type: pallet_broadcast::types::Filler::Omnipool,
@@ -813,7 +813,7 @@ mod omnipool {
 							ExecutionType::Omnipool(5)
 						],
 					},
-					pallet_broadcast::Event::Swapped2 {
+					pallet_broadcast::Event::Swapped3 {
 						swapper: ALICE.into(),
 						filler: Omnipool::protocol_account(),
 						filler_type: pallet_broadcast::types::Filler::Omnipool,

--- a/integration-tests/src/polkadot_test_net.rs
+++ b/integration-tests/src/polkadot_test_net.rs
@@ -960,7 +960,7 @@ pub fn get_last_swapped_events() -> Vec<pallet_broadcast::Event<hydradx_runtime:
 	last_events
 		.into_iter()
 		.filter_map(|event| {
-			if let RuntimeEvent::Broadcast(inner_event @ pallet_broadcast::Event::Swapped2 { .. }) = event {
+			if let RuntimeEvent::Broadcast(inner_event @ pallet_broadcast::Event::Swapped3 { .. }) = event {
 				Some(inner_event)
 			} else {
 				None
@@ -972,7 +972,7 @@ pub fn get_last_swapped_events() -> Vec<pallet_broadcast::Event<hydradx_runtime:
 #[macro_export]
 macro_rules! assert_operation_stack {
     ($event:expr, [$($pattern:pat),*]) => {
-        if let pallet_broadcast::Event::Swapped2 { operation_stack, .. } = $event {
+        if let pallet_broadcast::Event::Swapped3 { operation_stack, .. } = $event {
             assert!(matches!(&operation_stack[..],
                 [
                     $($pattern),*

--- a/integration-tests/src/referrals.rs
+++ b/integration-tests/src/referrals.rs
@@ -447,7 +447,7 @@ fn buying_hdx_in_omnipool_should_transfer_correct_fee() {
 				protocol_fee_amount: 608401,
 			}
 			.into(),
-			pallet_broadcast::Event::Swapped2 {
+			pallet_broadcast::Event::Swapped3 {
 				swapper: BOB.into(),
 				filler: Omnipool::protocol_account(),
 				filler_type: Filler::Omnipool,
@@ -461,7 +461,7 @@ fn buying_hdx_in_omnipool_should_transfer_correct_fee() {
 				operation_stack: vec![ExecutionType::Omnipool(0)],
 			}
 			.into(),
-			pallet_broadcast::Event::Swapped2 {
+			pallet_broadcast::Event::Swapped3 {
 				swapper: BOB.into(),
 				filler: Omnipool::protocol_account(),
 				filler_type: Filler::Omnipool,
@@ -516,7 +516,7 @@ fn buying_with_hdx_in_omnipool_should_transfer_correct_fee() {
 				protocol_fee_amount: 22652141,
 			}
 			.into(),
-			pallet_broadcast::Event::Swapped2 {
+			pallet_broadcast::Event::Swapped3 {
 				swapper: BOB.into(),
 				filler: Omnipool::protocol_account(),
 				filler_type: pallet_broadcast::types::Filler::Omnipool,
@@ -530,7 +530,7 @@ fn buying_with_hdx_in_omnipool_should_transfer_correct_fee() {
 				operation_stack: vec![ExecutionType::Omnipool(0)],
 			}
 			.into(),
-			pallet_broadcast::Event::Swapped2 {
+			pallet_broadcast::Event::Swapped3 {
 				swapper: BOB.into(),
 				filler: Omnipool::protocol_account(),
 				filler_type: pallet_broadcast::types::Filler::Omnipool,

--- a/integration-tests/src/router.rs
+++ b/integration-tests/src/router.rs
@@ -458,7 +458,7 @@ mod router_different_pools_tests {
 			pretty_assertions::assert_eq!(
 				swapped_events,
 				vec![
-					pallet_broadcast::Event::Swapped2 {
+					pallet_broadcast::Event::Swapped3 {
 						swapper: BOB.into(),
 						filler: XYK::get_pair_id(pallet_xyk::types::AssetPair {
 							asset_in: HDX,
@@ -483,7 +483,7 @@ mod router_different_pools_tests {
 						)],
 						operation_stack: vec![ExecutionType::Router(0)],
 					},
-					pallet_broadcast::Event::Swapped2 {
+					pallet_broadcast::Event::Swapped3 {
 						swapper: BOB.into(),
 						filler: XYK::get_pair_id(pallet_xyk::types::AssetPair {
 							asset_in: HDX,
@@ -508,7 +508,7 @@ mod router_different_pools_tests {
 						)],
 						operation_stack: vec![ExecutionType::Router(1)],
 					},
-					pallet_broadcast::Event::Swapped2 {
+					pallet_broadcast::Event::Swapped3 {
 						swapper: BOB.into(),
 						filler: XYK::get_pair_id(pallet_xyk::types::AssetPair {
 							asset_in: HDX,
@@ -2229,7 +2229,7 @@ mod omnipool_router_tests {
 			pretty_assertions::assert_eq!(
 				swapped_events,
 				vec![
-					pallet_broadcast::Event::Swapped2 {
+					pallet_broadcast::Event::Swapped3 {
 						swapper: BOB.into(),
 						filler: Omnipool::protocol_account(),
 						filler_type: pallet_broadcast::types::Filler::Omnipool,
@@ -2242,7 +2242,7 @@ mod omnipool_router_tests {
 						],
 						operation_stack: vec![ExecutionType::Router(0), ExecutionType::Omnipool(1)],
 					},
-					pallet_broadcast::Event::Swapped2 {
+					pallet_broadcast::Event::Swapped3 {
 						swapper: BOB.into(),
 						filler: Omnipool::protocol_account(),
 						filler_type: pallet_broadcast::types::Filler::Omnipool,
@@ -2289,7 +2289,7 @@ mod omnipool_router_tests {
 					protocol_fee_amount: 6_007_435,
 				}
 				.into(),
-				pallet_broadcast::Event::Swapped2 {
+				pallet_broadcast::Event::Swapped3 {
 					swapper: BOB.into(),
 					filler: Omnipool::protocol_account(),
 					filler_type: pallet_broadcast::types::Filler::Omnipool,
@@ -2304,7 +2304,7 @@ mod omnipool_router_tests {
 					operation_stack: vec![ExecutionType::Omnipool(0)],
 				}
 				.into(),
-				pallet_broadcast::Event::Swapped2 {
+				pallet_broadcast::Event::Swapped3 {
 					swapper: BOB.into(),
 					filler: Omnipool::protocol_account(),
 					filler_type: pallet_broadcast::types::Filler::Omnipool,
@@ -2468,7 +2468,7 @@ mod omnipool_router_tests {
 			pretty_assertions::assert_eq!(
 				last_swapped_events,
 				vec![
-					pallet_broadcast::Event::Swapped2 {
+					pallet_broadcast::Event::Swapped3 {
 						swapper: BOB.into(),
 						filler: Omnipool::protocol_account(),
 						filler_type: pallet_broadcast::types::Filler::Omnipool,
@@ -2481,7 +2481,7 @@ mod omnipool_router_tests {
 						],
 						operation_stack: vec![ExecutionType::Router(0), ExecutionType::Omnipool(1)],
 					},
-					pallet_broadcast::Event::Swapped2 {
+					pallet_broadcast::Event::Swapped3 {
 						swapper: BOB.into(),
 						filler: Omnipool::protocol_account(),
 						filler_type: pallet_broadcast::types::Filler::Omnipool,
@@ -2528,7 +2528,7 @@ mod omnipool_router_tests {
 					protocol_fee_amount: 2254511,
 				}
 				.into(),
-				pallet_broadcast::Event::Swapped2 {
+				pallet_broadcast::Event::Swapped3 {
 					swapper: BOB.into(),
 					filler: Omnipool::protocol_account(),
 					filler_type: pallet_broadcast::types::Filler::Omnipool,
@@ -2542,7 +2542,7 @@ mod omnipool_router_tests {
 					operation_stack: vec![ExecutionType::Omnipool(0)],
 				}
 				.into(),
-				pallet_broadcast::Event::Swapped2 {
+				pallet_broadcast::Event::Swapped3 {
 					swapper: BOB.into(),
 					filler: Omnipool::protocol_account(),
 					filler_type: pallet_broadcast::types::Filler::Omnipool,
@@ -2838,7 +2838,7 @@ mod lbp_router_tests {
 
 			pretty_assertions::assert_eq!(
 				*get_last_swapped_events().last().unwrap(),
-				pallet_broadcast::Event::<Runtime>::Swapped2 {
+				pallet_broadcast::Event::<Runtime>::Swapped3 {
 					swapper: BOB.into(),
 					filler: LBP::get_pair_id(pallet_lbp::types::AssetPair::new(DAI, HDX)),
 					filler_type: pallet_broadcast::types::Filler::LBP,
@@ -2887,7 +2887,7 @@ mod lbp_router_tests {
 					fee_amount: 20_000_000_000,
 				}
 				.into(),
-				pallet_broadcast::Event::Swapped2 {
+				pallet_broadcast::Event::Swapped3 {
 					swapper: BOB.into(),
 					filler: LBP::get_pair_id(pallet_lbp::types::AssetPair::new(DAI, HDX)),
 					filler_type: pallet_broadcast::types::Filler::LBP,

--- a/integration-tests/src/utility.rs
+++ b/integration-tests/src/utility.rs
@@ -72,7 +72,7 @@ fn batch_execution_type_should_be_included_in_batch() {
 		pretty_assertions::assert_eq!(
 			swapped_events,
 			vec![
-				pallet_broadcast::Event::<Runtime>::Swapped2 {
+				pallet_broadcast::Event::<Runtime>::Swapped3 {
 					swapper: BOB.into(),
 					filler: LBP::get_pair_id(pallet_lbp::types::AssetPair::new(DAI, LRNA)),
 					filler_type: pallet_broadcast::types::Filler::LBP,
@@ -90,7 +90,7 @@ fn batch_execution_type_should_be_included_in_batch() {
 					)],
 					operation_stack: vec![ExecutionType::Batch(0), ExecutionType::Router(1)],
 				},
-				pallet_broadcast::Event::<Runtime>::Swapped2 {
+				pallet_broadcast::Event::<Runtime>::Swapped3 {
 					swapper: BOB.into(),
 					filler: Omnipool::protocol_account(),
 					filler_type: pallet_broadcast::types::Filler::Omnipool,
@@ -104,7 +104,7 @@ fn batch_execution_type_should_be_included_in_batch() {
 					)],
 					operation_stack: vec![ExecutionType::Batch(0), ExecutionType::Router(1)],
 				},
-				pallet_broadcast::Event::<Runtime>::Swapped2 {
+				pallet_broadcast::Event::<Runtime>::Swapped3 {
 					swapper: BOB.into(),
 					filler: XYK::get_pair_id(pallet_xyk::types::AssetPair {
 						asset_in: HDX,
@@ -171,7 +171,7 @@ fn batch_execution_type_should_be_popped_when_multiple_batch_calls_happen() {
 		//Assert
 		pretty_assertions::assert_eq!(
 			*get_last_swapped_events().last().unwrap(),
-			pallet_broadcast::Event::<Runtime>::Swapped2 {
+			pallet_broadcast::Event::<Runtime>::Swapped3 {
 				swapper: BOB.into(),
 				filler: XYK::get_pair_id(pallet_xyk::types::AssetPair {
 					asset_in: HDX,
@@ -257,7 +257,7 @@ fn nested_batch_should_represent_embeddedness() {
 		pretty_assertions::assert_eq!(
 			swapped_events,
 			vec![
-				pallet_broadcast::Event::<Runtime>::Swapped2 {
+				pallet_broadcast::Event::<Runtime>::Swapped3 {
 					swapper: BOB.into(),
 					filler: LBP::get_pair_id(pallet_lbp::types::AssetPair::new(DAI, LRNA)),
 					filler_type: pallet_broadcast::types::Filler::LBP,
@@ -279,7 +279,7 @@ fn nested_batch_should_represent_embeddedness() {
 						ExecutionType::Router(2)
 					],
 				},
-				pallet_broadcast::Event::<Runtime>::Swapped2 {
+				pallet_broadcast::Event::<Runtime>::Swapped3 {
 					swapper: BOB.into(),
 					filler: Omnipool::protocol_account(),
 					filler_type: pallet_broadcast::types::Filler::Omnipool,
@@ -297,7 +297,7 @@ fn nested_batch_should_represent_embeddedness() {
 						ExecutionType::Router(2)
 					],
 				},
-				pallet_broadcast::Event::<Runtime>::Swapped2 {
+				pallet_broadcast::Event::<Runtime>::Swapped3 {
 					swapper: BOB.into(),
 					filler: XYK::get_pair_id(pallet_xyk::types::AssetPair {
 						asset_in: HDX,

--- a/pallets/broadcast/Cargo.toml
+++ b/pallets/broadcast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-broadcast"
-version = "1.2.1"
+version = "1.3.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/pallets/broadcast/src/lib.rs
+++ b/pallets/broadcast/src/lib.rs
@@ -86,9 +86,12 @@ pub mod pallet {
 	pub enum Event<T: Config> {
 		/// Trade executed.
 		///
-		/// Swapped2 is a fixed and renamed version of original Swapped,
+		/// Swapped3 is a fixed and renamed version of original Swapped,
 		/// as Swapped contained wrong input/output amounts for XYK buy trade
-		Swapped2 {
+		///
+		/// Swapped3 is a fixed and renamed version of original Swapped3,
+		/// as Swapped contained wrong filler account on AAVE trades
+		Swapped3 {
 			swapper: T::AccountId,
 			filler: T::AccountId,
 			filler_type: Filler,
@@ -124,7 +127,7 @@ impl<T: Config> Pallet<T> {
 	) {
 		let trade_swapper = Swapper::<T>::get().unwrap_or(swapper);
 		let operation_stack = Self::get_context();
-		Self::deposit_event(Event::<T>::Swapped2 {
+		Self::deposit_event(Event::<T>::Swapped3 {
 			swapper: trade_swapper,
 			filler,
 			filler_type,

--- a/pallets/broadcast/src/lib.rs
+++ b/pallets/broadcast/src/lib.rs
@@ -91,6 +91,7 @@ pub mod pallet {
 		///
 		/// Swapped3 is a fixed and renamed version of original Swapped3,
 		/// as Swapped contained wrong filler account on AAVE trades
+		///
 		Swapped3 {
 			swapper: T::AccountId,
 			filler: T::AccountId,

--- a/pallets/broadcast/src/tests/lib.rs
+++ b/pallets/broadcast/src/tests/lib.rs
@@ -112,7 +112,7 @@ fn event_should_be_deposited() {
 			],
 		);
 
-		expect_events(vec![Event::Swapped2 {
+		expect_events(vec![Event::Swapped3 {
 			swapper: ALICE,
 			filler: BOB,
 			filler_type: Filler::Omnipool,

--- a/pallets/lbp/Cargo.toml
+++ b/pallets/lbp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-lbp"
-version = "4.10.3"
+version = "4.10.4"
 description = "HydraDX Liquidity Bootstrapping Pool Pallet"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/pallets/lbp/src/tests.rs
+++ b/pallets/lbp/src/tests.rs
@@ -1844,7 +1844,7 @@ fn execute_sell_should_work() {
 				fee_amount: 1_000,
 			}
 			.into(),
-			pallet_broadcast::Event::Swapped2 {
+			pallet_broadcast::Event::Swapped3 {
 				swapper: ALICE,
 				filler: pool_id,
 				filler_type: pallet_broadcast::types::Filler::LBP,
@@ -1987,7 +1987,7 @@ fn execute_buy_should_work() {
 				fee_amount: 1_000,
 			}
 			.into(),
-			pallet_broadcast::Event::Swapped2 {
+			pallet_broadcast::Event::Swapped3 {
 				swapper: ALICE,
 				filler: pool_id,
 				filler_type: pallet_broadcast::types::Filler::LBP,
@@ -2316,7 +2316,7 @@ fn buy_should_work() {
 				fee_amount: 35860,
 			}
 			.into(),
-			pallet_broadcast::Event::Swapped2 {
+			pallet_broadcast::Event::Swapped3 {
 				swapper: buyer,
 				filler: pool_id,
 				filler_type: pallet_broadcast::types::Filler::LBP,
@@ -2461,7 +2461,7 @@ fn buy_should_work_when_limit_is_set_above_account_balance() {
 				fee_amount: 35860,
 			}
 			.into(),
-			pallet_broadcast::Event::Swapped2 {
+			pallet_broadcast::Event::Swapped3 {
 				swapper: buyer,
 				filler: pool_id,
 				filler_type: pallet_broadcast::types::Filler::LBP,
@@ -2495,7 +2495,7 @@ fn buy_should_work_when_limit_is_set_above_account_balance() {
 				fee_amount: 20_000,
 			}
 			.into(),
-			pallet_broadcast::Event::Swapped2 {
+			pallet_broadcast::Event::Swapped3 {
 				swapper: buyer,
 				filler: pool_id,
 				filler_type: pallet_broadcast::types::Filler::LBP,
@@ -2586,7 +2586,7 @@ fn sell_should_work() {
 				fee_amount: 20_000,
 			}
 			.into(),
-			pallet_broadcast::Event::Swapped2 {
+			pallet_broadcast::Event::Swapped3 {
 				swapper: buyer,
 				filler: pool_id,
 				filler_type: pallet_broadcast::types::Filler::LBP,

--- a/pallets/omnipool/Cargo.toml
+++ b/pallets/omnipool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-omnipool"
-version = "5.0.7"
+version = "5.0.8"
 authors = ['GalacticCouncil']
 edition = "2021"
 license = "Apache-2.0"
@@ -59,26 +59,26 @@ test-utils = { workspace = true }
 [features]
 default = ["std"]
 std = [
-	"codec/std",
-	"sp-runtime/std",
-	"sp-std/std",
-	"frame-support/std",
-	"frame-system/std",
-	"scale-info/std",
-	"sp-core/std",
-	"sp-io/std",
-	"pallet-balances/std",
-	"orml-tokens/std",
-	"frame-benchmarking/std",
-	"pallet-broadcast/std",
-	'hydradx-traits/std',
-	'hydra-dx-math/std',
-	'orml-traits/std',
+    "codec/std",
+    "sp-runtime/std",
+    "sp-std/std",
+    "frame-support/std",
+    "frame-system/std",
+    "scale-info/std",
+    "sp-core/std",
+    "sp-io/std",
+    "pallet-balances/std",
+    "orml-tokens/std",
+    "frame-benchmarking/std",
+    "pallet-broadcast/std",
+    'hydradx-traits/std',
+    'hydra-dx-math/std',
+    'orml-traits/std',
 ]
 runtime-benchmarks = [
-	"frame-benchmarking/runtime-benchmarks",
-	"sp-core",
-	"sp-io",
-	"pallet-balances",
+    "frame-benchmarking/runtime-benchmarks",
+    "sp-core",
+    "sp-io",
+    "pallet-balances",
 ]
-try-runtime = [ "frame-support/try-runtime" ]
+try-runtime = ["frame-support/try-runtime"]

--- a/pallets/omnipool/src/tests/buy.rs
+++ b/pallets/omnipool/src/tests/buy.rs
@@ -430,7 +430,7 @@ fn buy_should_emit_event_with_correct_asset_fee_amount() {
 					protocol_fee_amount: 0,
 				}
 				.into(),
-				pallet_broadcast::Event::Swapped2 {
+				pallet_broadcast::Event::Swapped3 {
 					swapper: LP1,
 					filler: Omnipool::protocol_account(),
 					filler_type: pallet_broadcast::types::Filler::Omnipool,
@@ -441,7 +441,7 @@ fn buy_should_emit_event_with_correct_asset_fee_amount() {
 					operation_stack: vec![ExecutionType::Omnipool(0)],
 				}
 				.into(),
-				pallet_broadcast::Event::Swapped2 {
+				pallet_broadcast::Event::Swapped3 {
 					swapper: LP1,
 					filler: Omnipool::protocol_account(),
 					filler_type: pallet_broadcast::types::Filler::Omnipool,
@@ -481,7 +481,7 @@ fn buy_should_emit_event_with_correct_asset_fee_amount() {
 					protocol_fee_amount: 0,
 				}
 				.into(),
-				pallet_broadcast::Event::Swapped2 {
+				pallet_broadcast::Event::Swapped3 {
 					swapper: LP1,
 					filler: Omnipool::protocol_account(),
 					filler_type: pallet_broadcast::types::Filler::Omnipool,
@@ -492,7 +492,7 @@ fn buy_should_emit_event_with_correct_asset_fee_amount() {
 					operation_stack: vec![ExecutionType::Omnipool(1)],
 				}
 				.into(),
-				pallet_broadcast::Event::Swapped2 {
+				pallet_broadcast::Event::Swapped3 {
 					swapper: LP1,
 					filler: Omnipool::protocol_account(),
 					filler_type: pallet_broadcast::types::Filler::Omnipool,
@@ -554,7 +554,7 @@ fn buy_should_emit_event_with_correct_protocol_fee_amount() {
 					protocol_fee_amount: 5698005698005,
 				}
 				.into(),
-				pallet_broadcast::Event::Swapped2 {
+				pallet_broadcast::Event::Swapped3 {
 					swapper: LP1,
 					filler: Omnipool::protocol_account(),
 					filler_type: pallet_broadcast::types::Filler::Omnipool,
@@ -569,7 +569,7 @@ fn buy_should_emit_event_with_correct_protocol_fee_amount() {
 					operation_stack: vec![ExecutionType::Omnipool(0)],
 				}
 				.into(),
-				pallet_broadcast::Event::Swapped2 {
+				pallet_broadcast::Event::Swapped3 {
 					swapper: LP1,
 					filler: Omnipool::protocol_account(),
 					filler_type: pallet_broadcast::types::Filler::Omnipool,
@@ -628,7 +628,7 @@ fn buy_should_emit_event_with_correct_protocol_fee_amount_and_burn_fee() {
 					protocol_fee_amount: 5698005698005,
 				}
 				.into(),
-				pallet_broadcast::Event::Swapped2 {
+				pallet_broadcast::Event::Swapped3 {
 					swapper: LP1,
 					filler: Omnipool::protocol_account(),
 					filler_type: pallet_broadcast::types::Filler::Omnipool,
@@ -642,7 +642,7 @@ fn buy_should_emit_event_with_correct_protocol_fee_amount_and_burn_fee() {
 					operation_stack: vec![ExecutionType::Omnipool(0)],
 				}
 				.into(),
-				pallet_broadcast::Event::Swapped2 {
+				pallet_broadcast::Event::Swapped3 {
 					swapper: LP1,
 					filler: Omnipool::protocol_account(),
 					filler_type: pallet_broadcast::types::Filler::Omnipool,

--- a/pallets/omnipool/src/tests/invariants.rs
+++ b/pallets/omnipool/src/tests/invariants.rs
@@ -155,7 +155,7 @@ fn get_fee_amount_from_swapped_event_for_asset(asset_id: AssetId) -> Balance {
 		.collect::<Vec<_>>();
 
 	for event in events.into_iter() {
-		if let RuntimeEvent::Broadcast(pallet_broadcast::Event::Swapped2 { fees, .. }) = event {
+		if let RuntimeEvent::Broadcast(pallet_broadcast::Event::Swapped3 { fees, .. }) = event {
 			if !fees.is_empty() {
 				let fee = fees.iter().find(|f| f.asset == asset_id);
 				if let Some(fee) = fee {

--- a/pallets/otc-settlements/Cargo.toml
+++ b/pallets/otc-settlements/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'pallet-otc-settlements'
-version = '1.1.7'
+version = '1.1.8'
 description = 'A pallet with offchain worker closing OTC arbs'
 authors = ['GalacticCouncil']
 edition = '2021'

--- a/pallets/otc-settlements/src/tests.rs
+++ b/pallets/otc-settlements/src/tests.rs
@@ -300,7 +300,7 @@ fn existing_arb_opportunity_should_trigger_trade_when_correct_amount_can_be_foun
 				profit: 17_736_110_470_326,
 			}
 			.into(),
-			pallet_broadcast::Event::Swapped2 {
+			pallet_broadcast::Event::Swapped3 {
 				swapper: otc.owner,
 				filler: OtcSettlements::account_id(),
 				filler_type: pallet_broadcast::types::Filler::OTC(otc_id),

--- a/pallets/otc/Cargo.toml
+++ b/pallets/otc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'pallet-otc'
-version = '2.1.5'
+version = '2.1.6'
 description = 'A pallet for trustless over-the-counter trading'
 authors = ['GalacticCouncil']
 edition = '2021'
@@ -42,19 +42,19 @@ test-utils = { workspace = true }
 [features]
 default = ["std"]
 std = [
-  "codec/std",
-  "frame-support/std",
-  "frame-system/std",
-  "sp-runtime/std",
-  "sp-core/std",
-  "sp-io/std",
-  "sp-std/std",
-  "scale-info/std",
-  "orml-tokens/std",
-  "orml-traits/std",
-  "hydradx-traits/std",
-  "frame-benchmarking/std",
-  "pallet-broadcast/std"
+    "codec/std",
+    "frame-support/std",
+    "frame-system/std",
+    "sp-runtime/std",
+    "sp-core/std",
+    "sp-io/std",
+    "sp-std/std",
+    "scale-info/std",
+    "orml-tokens/std",
+    "orml-traits/std",
+    "hydradx-traits/std",
+    "frame-benchmarking/std",
+    "pallet-broadcast/std"
 ]
 
 runtime-benchmarks = [

--- a/pallets/otc/src/tests/fill_order.rs
+++ b/pallets/otc/src/tests/fill_order.rs
@@ -80,7 +80,7 @@ fn complete_fill_order_should_work() {
 				fee: ONE,
 			}
 			.into(),
-			pallet_broadcast::Event::Swapped2 {
+			pallet_broadcast::Event::Swapped3 {
 				swapper: BOB,
 				filler: ALICE,
 				filler_type: pallet_broadcast::types::Filler::OTC(0),
@@ -160,7 +160,7 @@ fn complete_fill_order_should_work_when_order_is_not_partially_fillable() {
 				fee: ONE,
 			}
 			.into(),
-			pallet_broadcast::Event::Swapped2 {
+			pallet_broadcast::Event::Swapped3 {
 				swapper: BOB,
 				filler: ALICE,
 				filler_type: pallet_broadcast::types::Filler::OTC(order_id),
@@ -252,7 +252,7 @@ fn complete_fill_order_should_work_when_there_are_multiple_orders() {
 				fee: ONE,
 			}
 			.into(),
-			pallet_broadcast::Event::Swapped2 {
+			pallet_broadcast::Event::Swapped3 {
 				swapper: BOB,
 				filler: ALICE,
 				filler_type: pallet_broadcast::types::Filler::OTC(order_id),

--- a/pallets/otc/src/tests/partial_fill_order.rs
+++ b/pallets/otc/src/tests/partial_fill_order.rs
@@ -94,7 +94,7 @@ fn partial_fill_order_should_work_when_order_is_partially_fillable() {
 				fee,
 			}
 			.into(),
-			pallet_broadcast::Event::Swapped2 {
+			pallet_broadcast::Event::Swapped3 {
 				swapper: order.owner,
 				filler: BOB,
 				filler_type: pallet_broadcast::types::Filler::OTC(order_id),

--- a/pallets/stableswap/Cargo.toml
+++ b/pallets/stableswap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-stableswap"
-version = "5.1.3"
+version = "5.1.4"
 description = "AMM for correlated assets"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/pallets/stableswap/src/tests/add_liquidity.rs
+++ b/pallets/stableswap/src/tests/add_liquidity.rs
@@ -109,7 +109,7 @@ fn add_liquidity_should_emit_swapped_events() {
 
 			pretty_assertions::assert_eq!(
 				*get_last_swapped_events().last().unwrap(),
-				RuntimeEvent::Broadcast(pallet_broadcast::Event::Swapped2 {
+				RuntimeEvent::Broadcast(pallet_broadcast::Event::Swapped3 {
 					swapper: BOB,
 					filler: pool_account,
 					filler_type: pallet_broadcast::types::Filler::Stableswap(pool_id),
@@ -713,7 +713,7 @@ fn add_liquidity_should_work_correctly_when_providing_exact_amount_of_shares() {
 			let pool_account = pool_account(pool_id);
 			pretty_assertions::assert_eq!(
 				*get_last_swapped_events().last().unwrap(),
-				RuntimeEvent::Broadcast(pallet_broadcast::Event::Swapped2 {
+				RuntimeEvent::Broadcast(pallet_broadcast::Event::Swapped3 {
 					swapper: BOB,
 					filler: pool_account,
 					filler_type: pallet_broadcast::types::Filler::Stableswap(pool_id),

--- a/pallets/stableswap/src/tests/mock.rs
+++ b/pallets/stableswap/src/tests/mock.rs
@@ -514,7 +514,7 @@ pub fn get_last_swapped_events() -> Vec<RuntimeEvent> {
 
 	for event in last_events {
 		let e = event.clone();
-		if let RuntimeEvent::Broadcast(pallet_broadcast::Event::Swapped2 { .. }) = e {
+		if let RuntimeEvent::Broadcast(pallet_broadcast::Event::Swapped3 { .. }) = e {
 			swapped_events.push(e);
 		}
 	}

--- a/pallets/stableswap/src/tests/peg_one.rs
+++ b/pallets/stableswap/src/tests/peg_one.rs
@@ -124,7 +124,7 @@ fn buy_should_work_as_before_when_all_pegs_are_one() {
 					fee: 0,
 				}
 				.into(),
-				pallet_broadcast::Event::Swapped2 {
+				pallet_broadcast::Event::Swapped3 {
 					swapper: BOB,
 					filler: pool_account,
 					filler_type: pallet_broadcast::types::Filler::Stableswap(pool_id),
@@ -213,7 +213,7 @@ fn remove_liquidity_with_peg_should_work_as_before_when_pegs_are_one() {
 
 			pretty_assertions::assert_eq!(
 				*get_last_swapped_events().last().unwrap(),
-				RuntimeEvent::Broadcast(pallet_broadcast::Event::Swapped2 {
+				RuntimeEvent::Broadcast(pallet_broadcast::Event::Swapped3 {
 					swapper: BOB,
 					filler: pool_account,
 					filler_type: pallet_broadcast::types::Filler::Stableswap(pool_id),

--- a/pallets/stableswap/src/tests/remove_liquidity.rs
+++ b/pallets/stableswap/src/tests/remove_liquidity.rs
@@ -77,7 +77,7 @@ fn remove_liquidity_should_work_when_withdrawing_all_shares() {
 
 			pretty_assertions::assert_eq!(
 				*get_last_swapped_events().last().unwrap(),
-				RuntimeEvent::Broadcast(pallet_broadcast::Event::Swapped2 {
+				RuntimeEvent::Broadcast(pallet_broadcast::Event::Swapped3 {
 					swapper: BOB,
 					filler: pool_account,
 					filler_type: pallet_broadcast::types::Filler::Stableswap(pool_id),
@@ -1130,7 +1130,7 @@ fn removing_liquidity_with_exact_amount_should_emit_swapped_event() {
 
 			pretty_assertions::assert_eq!(
 				*get_last_swapped_events().last().unwrap(),
-				RuntimeEvent::Broadcast(pallet_broadcast::Event::Swapped2 {
+				RuntimeEvent::Broadcast(pallet_broadcast::Event::Swapped3 {
 					swapper: BOB,
 					filler: pool_account,
 					filler_type: pallet_broadcast::types::Filler::Stableswap(4),

--- a/pallets/stableswap/src/tests/trades.rs
+++ b/pallets/stableswap/src/tests/trades.rs
@@ -67,7 +67,7 @@ fn sell_should_work_when_correct_input_provided() {
 					fee: 0,
 				}
 				.into(),
-				pallet_broadcast::Event::Swapped2 {
+				pallet_broadcast::Event::Swapped3 {
 					swapper: BOB,
 					filler: pool_account,
 					filler_type: pallet_broadcast::types::Filler::Stableswap(pool_id),
@@ -141,7 +141,7 @@ fn buy_should_work_when_correct_input_provided() {
 					fee: 0,
 				}
 				.into(),
-				pallet_broadcast::Event::Swapped2 {
+				pallet_broadcast::Event::Swapped3 {
 					swapper: BOB,
 					filler: pool_account,
 					filler_type: pallet_broadcast::types::Filler::Stableswap(pool_id),

--- a/pallets/xyk/Cargo.toml
+++ b/pallets/xyk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-xyk"
-version = "6.8.0"
+version = "6.8.1"
 description = "XYK automated market maker"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/pallets/xyk/src/tests/fees.rs
+++ b/pallets/xyk/src/tests/fees.rs
@@ -146,7 +146,7 @@ fn discount_sell_fees_should_work() {
 				pool: pair_account,
 			}
 			.into(),
-			pallet_broadcast::Event::Swapped2 {
+			pallet_broadcast::Event::Swapped3 {
 				swapper: ALICE,
 				filler: pair_account,
 				filler_type: pallet_broadcast::types::Filler::XYK(share_token),
@@ -234,7 +234,7 @@ fn discount_sell_fees_should_work() {
 				pool: pair_account,
 			}
 			.into(),
-			pallet_broadcast::Event::Swapped2 {
+			pallet_broadcast::Event::Swapped3 {
 				swapper: ALICE,
 				filler: pair_account,
 				filler_type: pallet_broadcast::types::Filler::XYK(share_token),
@@ -317,7 +317,7 @@ fn discount_sell_fees_should_work() {
 				pool: pair_account,
 			}
 			.into(),
-			pallet_broadcast::Event::Swapped2 {
+			pallet_broadcast::Event::Swapped3 {
 				swapper: ALICE,
 				filler: pair_account,
 				filler_type: pallet_broadcast::types::Filler::XYK(share_token),
@@ -417,7 +417,7 @@ fn discount_buy_fees_should_work() {
 				pool: pair_account,
 			}
 			.into(),
-			pallet_broadcast::Event::Swapped2 {
+			pallet_broadcast::Event::Swapped3 {
 				swapper: ALICE,
 				filler: pair_account,
 				filler_type: pallet_broadcast::types::Filler::XYK(share_token),
@@ -509,7 +509,7 @@ fn discount_buy_fees_should_work() {
 				pool: pair_account,
 			}
 			.into(),
-			pallet_broadcast::Event::Swapped2 {
+			pallet_broadcast::Event::Swapped3 {
 				swapper: ALICE,
 				filler: pair_account,
 				filler_type: pallet_broadcast::types::Filler::XYK(share_token),
@@ -590,7 +590,7 @@ fn discount_buy_fees_should_work() {
 				pool: pair_account,
 			}
 			.into(),
-			pallet_broadcast::Event::Swapped2 {
+			pallet_broadcast::Event::Swapped3 {
 				swapper: ALICE,
 				filler: pair_account,
 				filler_type: pallet_broadcast::types::Filler::XYK(share_token),

--- a/pallets/xyk/src/tests/trades.rs
+++ b/pallets/xyk/src/tests/trades.rs
@@ -71,7 +71,7 @@ fn sell_test() {
 				pool: pair_account,
 			}
 			.into(),
-			pallet_broadcast::Event::Swapped2 {
+			pallet_broadcast::Event::Swapped3 {
 				swapper: ALICE,
 				filler: pair_account,
 				filler_type: pallet_broadcast::types::Filler::XYK(share_token),
@@ -135,7 +135,7 @@ fn execute_sell_should_use_event_id() {
 				pool: pair_account,
 			}
 			.into(),
-			pallet_broadcast::Event::Swapped2 {
+			pallet_broadcast::Event::Swapped3 {
 				swapper: ALICE,
 				filler: pair_account,
 				filler_type: pallet_broadcast::types::Filler::XYK(share_token),
@@ -442,7 +442,7 @@ fn sell_with_correct_fees_should_work() {
 				pool: pair_account,
 			}
 			.into(),
-			pallet_broadcast::Event::Swapped2 {
+			pallet_broadcast::Event::Swapped3 {
 				swapper: user_1,
 				filler: pair_account,
 				filler_type: pallet_broadcast::types::Filler::XYK(share_token),
@@ -660,7 +660,7 @@ fn single_buy_should_work() {
 				pool: pair_account,
 			}
 			.into(),
-			pallet_broadcast::Event::Swapped2 {
+			pallet_broadcast::Event::Swapped3 {
 				swapper: user_1,
 				filler: pair_account,
 				filler_type: pallet_broadcast::types::Filler::XYK(share_token),

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "307.0.0"
+version = "308.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/evm/aave_trade_executor.rs
+++ b/runtime/hydradx/src/evm/aave_trade_executor.rs
@@ -400,7 +400,7 @@ where
 		let trade_result = Self::do_sell(who.clone(), pool_type, asset_in, asset_out, amount_in, min_limit)?;
 
 		let who = ensure_signed(who.clone()).map_err(|_| ExecutorError::Error("Invalid origin".into()))?;
-		let atoken = HydraErc20Mapping::encode_evm_address(trade_result);
+		let atoken = HydraErc20Mapping::asset_address(trade_result);
 		let filler = pallet_evm_accounts::Pallet::<T>::truncated_account_id(atoken);
 
 		pallet_broadcast::Pallet::<T>::deposit_trade_event(
@@ -430,7 +430,7 @@ where
 		let trade_result = Self::do_sell(who.clone(), pool_type, asset_in, asset_out, amount_out, max_limit)?;
 
 		let who = ensure_signed(who.clone()).map_err(|_| ExecutorError::Error("Invalid origin".into()))?;
-		let atoken = HydraErc20Mapping::encode_evm_address(trade_result);
+		let atoken = HydraErc20Mapping::asset_address(trade_result);
 		let filler = pallet_evm_accounts::Pallet::<T>::truncated_account_id(atoken);
 
 		pallet_broadcast::Pallet::<T>::deposit_trade_event(

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -118,7 +118,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 307,
+	spec_version: 308,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
The filler is wrongly filled when AAVE swapped event is created. We namley filly the precimpile address of the asset, and not the erc20. This PR fixes that.