### PR TITLE
fix: prevent nft burning outside of pallet that created it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4660,7 +4660,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "308.0.0"
+version = "309.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -12127,7 +12127,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-integration-tests"
-version = "1.38.4"
+version = "1.38.5"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "1.38.4"
+version = "1.38.5"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/src/call_filter.rs
+++ b/integration-tests/src/call_filter.rs
@@ -322,3 +322,19 @@ fn referenda_can_not_be_filtered() {
 		assert!(hydradx_runtime::CallFilter::contains(&successful_call));
 	});
 }
+
+#[test]
+fn burn_nft_should_be_filtered_out() {
+	TestNet::reset();
+
+	Hydra::execute_with(|| {
+		// the values here don't need to make sense, all we need is a valid Call
+		let call = hydradx_runtime::RuntimeCall::Uniques(pallet_uniques::Call::burn {
+			collection: 2222,
+			item: 1,
+			check_owner: None,
+		});
+
+		assert!(!hydradx_runtime::CallFilter::contains(&call));
+	});
+}

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "308.0.0"
+version = "309.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -118,7 +118,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 308,
+	spec_version: 309,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/hydradx/src/system.rs
+++ b/runtime/hydradx/src/system.rs
@@ -117,6 +117,9 @@ impl Contains<RuntimeCall> for CallFilter {
 			RuntimeCall::EVM(pallet_evm::Call::create { .. }) => false,
 			RuntimeCall::EVM(pallet_evm::Call::create2 { .. }) => false,
 			RuntimeCall::OrmlXcm(_) => false,
+			//NOTE: this prevents creation of thombstone positions if nft was burned outside
+			//of pallet that created it.
+			RuntimeCall::Uniques(pallet_uniques::Call::burn { .. }) => false,
 			_ => true,
 		}
 	}


### PR DESCRIPTION
This PR call filters out `nft::burn()` call. This stops burning of nfts outside of pallets that created it and stops creation of dead positions