### PR TITLE
fix: use specific branch for regression tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -213,7 +213,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: galacticcouncil/polkadot-ecosystem-tests
-          ref: 06a82e72a688e94d778ade6502981bb6f741558f
+          ref: hydration-ci
 
       - name: Download WASM artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
we need to use a source of truth, to make the tests easily updateable