### PR TITLE
fix: metadata hash in srtool build

### DIFF
--- a/.github/workflows/wasm-builder.yml
+++ b/.github/workflows/wasm-builder.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Build runtime with srtool
         id: srtool_build
         run: |
-          srtool -e docker build -p "${{ env.CHAIN }}-runtime" -r "runtime/${{ env.CHAIN }}" --default-features metadata-hash --app --json \
+          srtool -e docker build -p "${{ env.CHAIN }}-runtime" -r "runtime/${{ env.CHAIN }}" --build-opts="--features=metadata-hash" --app --json \
             | tee srtool-build.log
 
           JSON=$(cat srtool-build.log | tail -n 1)

--- a/Makefile
+++ b/Makefile
@@ -85,4 +85,4 @@ chopstics: release
 	npx @acala-network/chopsticks xcm --parachain=launch-configs/chopsticks/hydradx.yml --parachain=launch-configs/chopsticks/assethub.yml
 
 srbuild:
-	srtool -e docker build -p "hydradx-runtime" --app --image docker.io/paritytech/srtool --default-features metadata-hash --root
+	srtool -e docker build -p "hydradx-runtime" --app --image docker.io/paritytech/srtool --build-opts="--features=metadata-hash" --root


### PR DESCRIPTION
The built runtime had no metadata hash enabled, so we need to enable it with `build-ops` flags


```
Passing the metadata hash feature in the --build-opts fixes it, or at least we can send that signed transaction in the test.

This is how moonbean also pass their additional feature.

srtool -e docker build -p "hydradx-runtime" --app --image docker.io/paritytech/srtool --build-opts="--features=metadata-hash" --root


But not sure why --default-features doesnt work, I also tried with env variable, but no success.
```