### PR TITLE
fix: missing EVM logs

### DIFF
--- a/integration-tests/src/erc20.rs
+++ b/integration-tests/src/erc20.rs
@@ -334,13 +334,9 @@ fn erc20_transfer_returning_false_should_be_handled_as_error() {
 	Hydra::execute_with(|| {
 		let token = deploy_contract("WeirdToken", deployer());
 
+		let asset = bind_erc20(token);
 		assert_noop!(
-			<Erc20Currency<Runtime> as MultiCurrency<AccountId>>::transfer(
-				token,
-				&AccountId::from(ALICE),
-				&AccountId::from(BOB),
-				100
-			),
+			Currencies::transfer(RuntimeOrigin::signed(ALICE.into()), BOB.into(), asset, 100),
 			Other("evm: erc20 transfer returned false")
 		);
 	});

--- a/runtime/hydradx/src/evm/aave_trade_executor.rs
+++ b/runtime/hydradx/src/evm/aave_trade_executor.rs
@@ -1,7 +1,8 @@
 use crate::evm::executor::{BalanceOf, CallResult, NonceIdOf};
 use crate::evm::precompiles::erc20_mapping::HydraErc20Mapping;
 use crate::evm::precompiles::handle::EvmDataWriter;
-use crate::evm::{Erc20Currency, EvmAccounts, Executor};
+use crate::evm::Executor;
+use crate::evm::{Erc20Currency, EvmAccounts};
 use crate::Vec;
 use crate::{Currencies, Runtime};
 use codec::{Decode, Encode, MaxEncodedLen};

--- a/runtime/hydradx/src/evm/erc20_currency.rs
+++ b/runtime/hydradx/src/evm/erc20_currency.rs
@@ -1,6 +1,5 @@
 use crate::evm::aave_trade_executor::AaveTradeExecutor;
-use crate::evm::executor::{BalanceOf, NonceIdOf};
-use crate::evm::executor::{CallResult, Executor};
+use crate::evm::executor::{BalanceOf, CallResult, Executor, NonceIdOf};
 use crate::evm::{EvmAccounts, EvmAddress};
 use ethabi::ethereum_types::BigEndianHash;
 use evm::ExitReason;
@@ -43,10 +42,11 @@ pub struct Erc20Currency<T>(PhantomData<T>);
 
 impl<T> ERC20 for Erc20Currency<T>
 where
-	T: pallet_evm::Config + pallet_dispatcher::Config,
-	BalanceOf<T>: TryFrom<U256> + Into<U256>,
+	T: pallet_evm::Config + pallet_dispatcher::Config + frame_system::Config,
 	T::AddressMapping: pallet_evm::AddressMapping<T::AccountId>,
 	pallet_evm::AccountIdOf<T>: From<T::AccountId>,
+	<T as frame_system::Config>::AccountId: AsRef<[u8]>,
+	BalanceOf<T>: TryFrom<U256> + Into<U256>,
 	NonceIdOf<T>: Into<T::Nonce>,
 {
 	type Balance = Balance;

--- a/runtime/hydradx/src/evm/executor.rs
+++ b/runtime/hydradx/src/evm/executor.rs
@@ -107,7 +107,7 @@ where
 			None,               // max_priority_fee_per_gas
 			None,               // nonce
 			vec![],
-			false, // is_transactional - we dont need to check for  EIP-3607, and it also makes the total_fee_per_gas to default (0)
+			false, // is_transactional - we dont need to check for  EIP-3607, and it also makes the payed fee zeo
 			false, // validate
 			None,  // weight_limit
 			None,  // proof_size_base_cost

--- a/runtime/hydradx/src/evm/executor.rs
+++ b/runtime/hydradx/src/evm/executor.rs
@@ -103,18 +103,17 @@ where
 			data,
 			value,
 			gas_limit,
-			Some(U256::zero()), // max_fee_per_gas effectively zero
+			Some(U256::zero()), // max_fee_per_gas
 			None,               // max_priority_fee_per_gas
-			None,               // nonce (Runner will use current, but we reset later)
+			None,               // nonce
 			vec![],
 			false, // is_transactional
-			false, // validate (skip pre-validation for system calls)
+			false, // validate
 			None,  // weight_limit
 			None,  // proof_size_base_cost
 			evm_config,
 		);
 
-		// Reset nonce to its original value
 		frame_system::Account::<T>::mutate(source_account_id.clone(), |a| a.nonce = original_nonce.into());
 
 		match call_info_result {
@@ -129,11 +128,9 @@ where
 				(info.exit_reason, info.value)
 			}
 			Err(runner_error) => {
-				log::error!(target: "evm_executor", "SystemEvmRunner: EVM call failed: {:?}", runner_error.error);
+				log::error!(target: "evm_executor", "EVM call failed: {:?}", runner_error.error);
 				// Map RunnerError to a generic EVM execution failure
-				let exit_reason = ExitReason::Error(ExitError::Other(sp_std::borrow::Cow::Borrowed(
-					"SystemEvmRunner: Call failed",
-				)));
+				let exit_reason = ExitReason::Error(ExitError::Other(sp_std::borrow::Cow::Borrowed("EVM Call failed")));
 				(exit_reason, Vec::new())
 			}
 		}

--- a/runtime/hydradx/src/evm/executor.rs
+++ b/runtime/hydradx/src/evm/executor.rs
@@ -107,7 +107,7 @@ where
 			None,               // max_priority_fee_per_gas
 			None,               // nonce
 			vec![],
-			true,  // is_transactional //TODO: CHECK if we need this or not
+			false, // is_transactional - we dont need to check for  EIP-3607, and it also makes the total_fee_per_gas to default (0)
 			false, // validate
 			None,  // weight_limit
 			None,  // proof_size_base_cost

--- a/runtime/hydradx/src/evm/executor.rs
+++ b/runtime/hydradx/src/evm/executor.rs
@@ -104,8 +104,8 @@ where
 			value,
 			gas_limit,
 			Some(U256::zero()), // max_fee_per_gas
-			None,                // max_priority_fee_per_gas
-			None,                // nonce
+			None,               // max_priority_fee_per_gas
+			None,               // nonce
 			vec![],
 			true,  // is_transactional
 			false, // validate

--- a/runtime/hydradx/src/evm/executor.rs
+++ b/runtime/hydradx/src/evm/executor.rs
@@ -1,18 +1,31 @@
-use evm::executor::stack::{StackExecutor, StackSubstateMetadata};
+use crate::evm::evm_fee::FeeCurrencyOverrideOrDefault;
+use crate::evm::runner::WrapRunner;
+use crate::evm::{EvmAccounts, WethAssetId};
+use crate::types::ShortOraclePrice;
+use crate::{DotAssetId, Runtime, XykPaymentAssetSupport};
+use core::marker::PhantomData;
 use evm::ExitFatal::Other;
-use evm::ExitReason;
-use fp_evm::Vicinity;
+use evm::{
+	executor::stack::{StackExecutor, StackState as StackStateT, StackSubstateMetadata},
+	Context as EvmContext, ExitError, ExitReason,
+};
+use fp_evm::CallInfo;
 use frame_support::storage::with_transaction;
-use frame_support::traits::Get;
+use frame_system;
+use hydradx_adapters::price::ConvertBalance;
 use hydradx_traits::evm::{CallContext, EVM};
-use pallet_evm::runner::stack::SubstrateStackState;
+use pallet_currencies::fungibles::FungibleCurrencies;
+use pallet_evm::{
+	self, runner::Runner as EvmRunnerT, AccountProvider as EvmAccountProviderT, AddressMapping as EvmAddressMappingT,
+	Config as EvmConfigT, Pallet as EvmPallet,
+}; // Import the pallet_evm crate
 use pallet_evm::{AccountProvider, AddressMapping, Config};
-use primitive_types::{H160, U256};
+use pallet_evm::{Error, Runner, RunnerError};
+use pallet_genesis_history::migration::Weight;
+use sp_core::{H160, H256, U256};
 use sp_runtime::{DispatchError, TransactionOutcome};
 use sp_std::vec;
 use sp_std::vec::Vec;
-
-pub struct Executor<R>(sp_std::marker::PhantomData<R>);
 
 pub type CallResult = (ExitReason, Vec<u8>);
 
@@ -20,88 +33,150 @@ pub type BalanceOf<T> =
 	<<T as pallet_evm::Config>::Currency as frame_support::traits::Currency<pallet_evm::AccountIdOf<T>>>::Balance;
 pub type NonceIdOf<T> = <<T as Config>::AccountProvider as AccountProvider>::Nonce;
 
-impl<T> Executor<T>
-where
-	T: Config + frame_system::Config,
-	BalanceOf<T>: TryFrom<U256> + Into<U256>,
-	T::AddressMapping: AddressMapping<T::AccountId>,
-	pallet_evm::AccountIdOf<T>: From<T::AccountId>,
-	NonceIdOf<T>: Into<T::Nonce>,
-{
-	pub fn execute<'config, F>(origin: H160, gas: u64, f: F) -> CallResult
-	where
-		F: for<'precompiles> FnOnce(
-			&mut StackExecutor<'config, 'precompiles, SubstrateStackState<'_, 'config, T>, T::PrecompilesType>,
-		) -> (ExitReason, Vec<u8>),
-	{
-		let gas_price = U256::one();
-		let vicinity = Vicinity { gas_price, origin };
+pub struct Executor<R>(sp_std::marker::PhantomData<R>);
 
-		let config = <T as Config>::config();
-		let precompiles = T::PrecompilesValue::get();
-		let metadata = StackSubstateMetadata::new(gas, config);
-		let state = SubstrateStackState::new(&vicinity, metadata, None, None);
-		let account = T::AddressMapping::into_account_id(origin);
-		let nonce = T::AccountProvider::account_nonce(&account.clone().into());
-		let mut executor = StackExecutor::new_with_precompiles(state, config, &precompiles);
-		let result = f(&mut executor);
-		frame_system::Account::<T>::mutate(account.clone(), |a| a.nonce = nonce.into());
-		result
-	}
-}
+type EVMRunner = WrapRunner<
+	Runtime,
+	pallet_evm::runner::stack::Runner<Runtime>, // Evm runner that we wrap
+	hydradx_adapters::price::FeeAssetBalanceInCurrency<
+		Runtime,
+		ConvertBalance<ShortOraclePrice, XykPaymentAssetSupport, DotAssetId>,
+		FeeCurrencyOverrideOrDefault<WethAssetId, EvmAccounts<Runtime>>, // Get account's fee payment asset
+		FungibleCurrencies<Runtime>,                                     // Account balance inspector
+	>,
+>;
 
 impl<T> EVM<CallResult> for Executor<T>
 where
-	T: Config + frame_system::Config + pallet_dispatcher::Config,
-	BalanceOf<T>: TryFrom<U256> + Into<U256>,
+	T: frame_system::Config + pallet_evm::Config + pallet_dispatcher::Config,
+	BalanceOf<T>: TryFrom<U256> + Into<U256> + Default,
+	NonceIdOf<T>: Into<T::Nonce>,
 	T::AddressMapping: AddressMapping<T::AccountId>,
 	pallet_evm::AccountIdOf<T>: From<T::AccountId>,
-	NonceIdOf<T>: Into<T::Nonce>,
 {
 	fn call(context: CallContext, data: Vec<u8>, value: U256, gas: u64) -> CallResult {
 		let extra_gas = pallet_dispatcher::Pallet::<T>::extra_gas();
 		let gas_limit = gas.saturating_add(extra_gas);
 		log::trace!(target: "evm::executor", "Call with extra gas {:?}", extra_gas);
 
-		Self::execute(context.origin, gas_limit, |executor| {
-			let result = executor.transact_call(context.sender, context.contract, value, data, gas_limit, vec![]);
-			log::trace!(target: "evm::executor", "Call executed - used gas {:?}", executor.used_gas());
+		let source_h160 = context.sender;
+		let source_account_id = T::AddressMapping::into_account_id(source_h160);
+		let original_nonce = frame_system::Pallet::<T>::account_nonce(source_account_id.clone());
 
-			if extra_gas > 0 {
-				let extra_gas_used = executor.used_gas().saturating_sub(gas);
-				log::trace!(target: "evm::executor", "Used extra gas -{:?}", extra_gas_used);
-				pallet_dispatcher::Pallet::<T>::decrease_extra_gas(extra_gas_used);
+		let evm_config = <T as pallet_evm::Config>::config();
+
+		let call_info_result = EVMRunner::call(
+			source_h160,
+			context.contract,
+			data,
+			value,
+			gas_limit,
+			Some(U256::zero()), // max_fee_per_gas effectively zero
+			None,               // max_priority_fee_per_gas
+			None,               // nonce (Runner will use current, but we reset later)
+			vec![],
+			false, // is_transactional
+			false, // validate (skip pre-validation for system calls)
+			None,  // weight_limit
+			None,  // proof_size_base_cost
+			evm_config,
+		);
+
+		// Reset nonce to its original value
+		frame_system::Account::<T>::mutate(source_account_id.clone(), |a| a.nonce = original_nonce.into());
+
+		match call_info_result {
+			Ok(info) => {
+				log::trace!(target: "evm::executor", "Call executed - used gas {:?}", info.used_gas);
+				if extra_gas > 0 {
+					//TODO: this can panic, double check how to  convert to u64
+					let extra_gas_used = info.used_gas.standard.as_u64().saturating_sub(gas); //TODO: maybe we need effective her
+					log::trace!(target: "evm::executor", "Used extra gas -{:?}", extra_gas_used);
+					pallet_dispatcher::Pallet::<T>::decrease_extra_gas(extra_gas_used);
+				}
+				(info.exit_reason, info.value)
 			}
-
-			result
-		})
+			Err(runner_error) => {
+				log::error!(target: "evm_executor", "SystemEvmRunner: EVM call failed: {:?}", runner_error.error);
+				// Map RunnerError to a generic EVM execution failure
+				let exit_reason = ExitReason::Error(ExitError::Other(sp_std::borrow::Cow::Borrowed(
+					"SystemEvmRunner: Call failed",
+				)));
+				(exit_reason, Vec::new())
+			}
+		}
 	}
 
 	fn view(context: CallContext, data: Vec<u8>, gas: u64) -> CallResult {
 		let extra_gas = pallet_dispatcher::Pallet::<T>::extra_gas();
 		let gas_limit = gas.saturating_add(extra_gas);
-		log::trace!(target: "evm::executor", "View call with extra gas {:?}", extra_gas);
+
+		let source_h160 = context.sender;
+		let source_account_id = T::AddressMapping::into_account_id(source_h160);
+		let original_nonce = frame_system::Pallet::<T>::account_nonce(source_account_id.clone());
+
+		let evm_config = <T as pallet_evm::Config>::config();
 
 		let mut extra_gas_used = 0u64;
 
-		let result = with_transaction(|| {
-			let result = Self::execute(context.origin, gas_limit, |executor| {
-				let result =
-					executor.transact_call(context.sender, context.contract, U256::zero(), data, gas_limit, vec![]);
-				if extra_gas > 0 {
-					extra_gas_used = executor.used_gas().saturating_sub(gas);
-					log::trace!(target: "evm::executor", "View used extra gas -{:?}", extra_gas_used);
+		let outcome_from_transaction: Result<CallResult, DispatchError> = with_transaction(|| {
+			let call_info_result = EVMRunner::call(
+				source_h160,
+				context.contract,
+				data,
+				U256::zero(), // value for a view call
+				gas_limit,
+				Some(U256::zero()), // max_fee_per_gas
+				None,               // max_priority_fee_per_gas
+				None,               // nonce (should be handled by EVM runner or transaction)
+				vec![],             // access_list
+				false,              // is_transactional (false for view, transactionality is handled by with_transaction)
+				false,              // validate
+				None,               // weight_limit
+				None,               // proof_size_base_cost
+				evm_config,
+			);
+
+			let execution_result: CallResult = match call_info_result {
+				Ok(info) => {
+					log::trace!(target: "evm::executor", "Call executed - used gas {:?}", info.used_gas);
+					if extra_gas > 0 {
+						//TODO: this can panic, double check how to  convert to u64
+						extra_gas_used = info.used_gas.standard.as_u64().saturating_sub(gas); //TODO: maybe we need effective her
+						log::trace!(target: "evm::executor", "Used extra gas -{:?}", extra_gas_used);
+					}
+					(info.exit_reason, info.value)
 				}
-				result
-			});
-			TransactionOutcome::Rollback(Ok::<CallResult, DispatchError>(result))
-		})
-		.unwrap_or((ExitReason::Fatal(Other("TransactionalError".into())), Vec::new()));
+				Err(runner_error) => {
+					log::error!(target: "evm_executor", "SystemEvmRunner: EVM view failed: {:?}", runner_error.error);
+					let exit_reason = ExitReason::Error(ExitError::Other(sp_std::borrow::Cow::Borrowed(
+						"SystemEvmRunner: View failed during EVM execution",
+					)));
+					(exit_reason, Vec::new())
+				}
+			};
+			TransactionOutcome::Rollback(Ok(execution_result))
+		});
 
 		if extra_gas_used > 0 {
 			log::trace!(target: "evm::executor", "Used extra gas -{:?}", extra_gas_used);
 			pallet_dispatcher::Pallet::<T>::decrease_extra_gas(extra_gas_used);
 		}
-		result
+
+		frame_system::Account::<T>::mutate(source_account_id.clone(), |a| a.nonce = original_nonce.into());
+
+		outcome_from_transaction.unwrap_or_else(|dispatch_error| {
+			log::error!(
+				target: "evm_executor",
+				"SystemEvmRunner: EVM view failed due to transaction error: {:?}",
+				dispatch_error
+			);
+			(
+				ExitReason::Error(ExitError::Other(sp_std::borrow::Cow::Borrowed(
+					"SystemEvmRunner: View failed due to transactional error",
+				))),
+				Vec::new(),
+			)
+		})
 	}
 }

--- a/runtime/hydradx/src/evm/executor.rs
+++ b/runtime/hydradx/src/evm/executor.rs
@@ -104,10 +104,10 @@ where
 			value,
 			gas_limit,
 			Some(U256::zero()), // max_fee_per_gas
-			None,               // max_priority_fee_per_gas
-			None,               // nonce
+			None,                // max_priority_fee_per_gas
+			None,                // nonce
 			vec![],
-			false, // is_transactional
+			true,  // is_transactional
 			false, // validate
 			None,  // weight_limit
 			None,  // proof_size_base_cost

--- a/runtime/hydradx/src/evm/runner.rs
+++ b/runtime/hydradx/src/evm/runner.rs
@@ -29,7 +29,7 @@ use frame_support::traits::Get;
 use hydradx_traits::AccountFeeCurrencyBalanceInCurrency;
 use pallet_evm::runner::Runner;
 use pallet_evm::{AccountProvider, AddressMapping, CallInfo, Config, CreateInfo, FeeCalculator, RunnerError};
-use pallet_genesis_history::migration::Weight;
+use frame_support::weights::Weight;
 use primitive_types::{H160, H256, U256};
 use primitives::{AssetId, Balance};
 use sp_runtime::traits::UniqueSaturatedInto;


### PR DESCRIPTION
EVM logs were missing since we just constructed the EVM executor ourselves, which doesn't include emitting the EVM events.

By using the EvmRunner, to be exact, our WrappedRunner, we can trigger the EVM event logs.

Only EVM::call has been changed, EVM::view remains intact as there we don't care much about the events.