### PR TITLE
fix: remove added pallet-evm features

### DIFF
--- a/precompiles/call-permit/Cargo.toml
+++ b/precompiles/call-permit/Cargo.toml
@@ -28,7 +28,7 @@ sp-std = { workspace = true }
 # Frontier
 evm = { workspace = true, features = [ "with-codec" ] }
 fp-evm = { workspace = true }
-pallet-evm = { workspace = true, features = [ "forbid-evm-reentrancy" ] }
+pallet-evm = { workspace = true }
 
 [dev-dependencies]
 derive_more = { workspace = true }

--- a/precompiles/flash-loan/Cargo.toml
+++ b/precompiles/flash-loan/Cargo.toml
@@ -27,7 +27,7 @@ sp-std = { workspace = true }
 # Frontier
 evm = { workspace = true, features = [ "with-codec" ] }
 fp-evm = { workspace = true }
-pallet-evm = { workspace = true, features = [ "forbid-evm-reentrancy" ] }
+pallet-evm = { workspace = true }
 module-evm-utility-macro = { workspace = true }
 ethabi = { workspace = true }
 

--- a/precompiles/utils/Cargo.toml
+++ b/precompiles/utils/Cargo.toml
@@ -39,7 +39,7 @@ sp-weights = { workspace = true }
 # Frontier
 evm = { workspace = true, features = [ "with-codec" ] }
 fp-evm = { workspace = true }
-pallet-evm = { workspace = true, features = [ "forbid-evm-reentrancy" ] }
+pallet-evm = { workspace = true }
 
 # Polkadot / XCM
 xcm = { workspace = true, optional = true }

--- a/precompiles/utils/tests-external/Cargo.toml
+++ b/precompiles/utils/tests-external/Cargo.toml
@@ -27,4 +27,4 @@ sp-std = { workspace = true }
 
 evm = { workspace = true, features = [ "with-codec" ] }
 fp-evm = { workspace = true }
-pallet-evm = { workspace = true, features = [ "forbid-evm-reentrancy" ] }
+pallet-evm = { workspace = true }


### PR DESCRIPTION
ThisPR reverts recent change that added forbid-evm-reentrancy features

Unfortunately, this breaks some features that requires to do calls to evm multiple times.