### PR TITLE
fix: allow MM oracle used by stableswap to be updated in current block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4610,7 +4610,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-adapters"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -4666,7 +4666,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "318.0.0"
+version = "319.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -12200,7 +12200,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-integration-tests"
-version = "1.42.0"
+version = "1.42.1"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "1.42.0"
+version = "1.42.1"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/src/stableswap.rs
+++ b/integration-tests/src/stableswap.rs
@@ -161,14 +161,20 @@ fn peg_oracle_adapter_should_not_work_when_mm_oracle_price_was_updated_in_curren
 		hydradx_runtime::Timestamp::set_timestamp(now);
 		hydradx_run_to_block(current_block);
 
-		assert_noop!(
-			PegOracle::<Runtime, evm::Executor<Runtime>, EmaOracle>::get_raw_entry(
-				Default::default(), //NOTE: MMOracle doesn't use this param, only contract's address
-				PegSource::MMOracle(
+		let peg = PegOracle::<Runtime, evm::Executor<Runtime>, EmaOracle>::get_raw_entry(
+			Default::default(), //NOTE: MMOracle doesn't use this param, only contract's address
+			PegSource::MMOracle(
 				hex!["17711BE5D63B2Fe8A2C379725DE720773158b954"].into(), //NOTE: dia's USDC oracle
-			)
 			),
-			DispatchError::Other("PegOracle not available")
-		);
+		)
+		.expect("failed to retrieve peg from contract");
+
+		let expected_peg = RawEntry {
+			price: (99988686_u128, 100_000_000_u128),
+			volume: Default::default(),
+			liquidity: Default::default(),
+			updated_at: current_block,
+		};
+		assert_eq!(peg, expected_peg)
 	});
 }

--- a/runtime/adapters/Cargo.toml
+++ b/runtime/adapters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-adapters"
-version = "1.6.0"
+version = "1.6.1"
 description = "Structs and other generic types for building runtimes."
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/runtime/adapters/src/stableswap_peg_oracle.rs
+++ b/runtime/adapters/src/stableswap_peg_oracle.rs
@@ -121,13 +121,6 @@ where
 					.saturating_div(SECS_PER_BLOCK.into())
 					.saturated_into::<BlockNumber>();
 
-				if diff_blocks.is_zero() {
-					log::error!(target: "stableswap-peg-oracle",
-						"Oracle can't be updated in the same block. Constract: {:?}, DiffBlocks: {:?}", addr, diff_blocks);
-
-					return Err(DispatchError::Other("PegOracle not available"));
-				}
-
 				let current_block = frame_system::Pallet::<Runtime>::current_block_number();
 				let updated_at = current_block.saturating_sub(diff_blocks.into());
 

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "318.0.0"
+version = "319.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -120,7 +120,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 318,
+	spec_version: 319,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
This PR udpates stableswap peg oracle adapter to allow `MMOracle` price to be updated in current block.