### PR TITLE
fix: remove check if updated_at is zero from stableswap's peg oracle adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4610,7 +4610,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-adapters"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -4666,7 +4666,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "319.0.0"
+version = "320.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/runtime/adapters/Cargo.toml
+++ b/runtime/adapters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-adapters"
-version = "1.6.1"
+version = "1.6.2"
 description = "Structs and other generic types for building runtimes."
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/runtime/adapters/src/stableswap_peg_oracle.rs
+++ b/runtime/adapters/src/stableswap_peg_oracle.rs
@@ -124,13 +124,6 @@ where
 				let current_block = frame_system::Pallet::<Runtime>::current_block_number();
 				let updated_at = current_block.saturating_sub(diff_blocks.into());
 
-				if updated_at.is_zero() {
-					log::error!(target: "stableswap-peg-oracle",
-						"Calculated updated at is 0th block. CurrentBlock: {:?}, DiffBlocks: {:?}", current_block, diff_blocks);
-
-					return Err(DispatchError::Other("PegOracle not available"));
-				}
-
 				Ok(RawEntry {
 					price: (price_num, MM_ORACLE_DENOM),
 					volume: Default::default(),

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "319.0.0"
+version = "320.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -120,7 +120,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 319,
+	spec_version: 320,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
This PR removes check if `updated_at` of `MMOracle` is zero