### PR TITLE
feat: declare precompiles using builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4666,7 +4666,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "317.0.0"
+version = "318.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -12200,7 +12200,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-integration-tests"
-version = "1.41.0"
+version = "1.42.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "1.41.0"
+version = "1.42.0"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/src/evm_permit.rs
+++ b/integration-tests/src/evm_permit.rs
@@ -11,7 +11,7 @@ use frame_support::{assert_noop, assert_ok, sp_runtime::codec::Encode};
 use frame_system::RawOrigin;
 use hydra_dx_math::types::Ratio;
 use hydradx_adapters::price::ConvertBalance;
-use hydradx_runtime::evm::precompiles::{CALLPERMIT, DISPATCH_ADDR};
+use hydradx_runtime::evm::precompiles::{CallPermitAddress, DispatchAddress};
 use hydradx_runtime::types::ShortOraclePrice;
 use hydradx_runtime::AssetRegistry;
 use hydradx_runtime::DOT_ASSET_LOCATION;
@@ -30,6 +30,7 @@ use pallet_transaction_multi_payment::EVMPermit;
 use pretty_assertions::assert_eq;
 use primitives::constants::currency::UNITS;
 use primitives::{AssetId, Balance};
+use sp_core::Get;
 use sp_core::{H256, U256};
 use sp_runtime::traits::Convert;
 use sp_runtime::traits::SignedExtension;
@@ -96,9 +97,9 @@ fn compare_fee_in_hdx_between_evm_and_native_omnipool_calls_when_permit_is_dispa
 		let deadline = U256::from(1000000000000u128);
 		let permit =
 			pallet_evm_precompile_call_permit::CallPermitPrecompile::<hydradx_runtime::Runtime>::generate_permit(
-				CALLPERMIT,
+				CallPermitAddress::get(),
 				user_evm_address,
-				DISPATCH_ADDR,
+				DispatchAddress::get(),
 				U256::from(0),
 				omni_sell.encode(),
 				gas_limit * 10,
@@ -113,7 +114,7 @@ fn compare_fee_in_hdx_between_evm_and_native_omnipool_calls_when_permit_is_dispa
 		assert_ok!(MultiTransactionPayment::dispatch_permit(
 			hydradx_runtime::RuntimeOrigin::none(),
 			user_evm_address,
-			DISPATCH_ADDR,
+			DispatchAddress::get(),
 			U256::from(0),
 			omni_sell.encode(),
 			gas_limit * 10,
@@ -213,9 +214,9 @@ fn dispatch_permit_fee_should_be_paid_in_hdx_when_no_currency_is_set() {
 		let deadline = U256::from(1000000000000u128);
 		let permit =
 			pallet_evm_precompile_call_permit::CallPermitPrecompile::<hydradx_runtime::Runtime>::generate_permit(
-				CALLPERMIT,
+				CallPermitAddress::get(),
 				user_evm_address,
-				DISPATCH_ADDR,
+				DispatchAddress::get(),
 				U256::from(0),
 				omni_sell.encode(),
 				gas_limit * 10,
@@ -230,7 +231,7 @@ fn dispatch_permit_fee_should_be_paid_in_hdx_when_no_currency_is_set() {
 		assert_ok!(MultiTransactionPayment::dispatch_permit(
 			hydradx_runtime::RuntimeOrigin::none(),
 			user_evm_address,
-			DISPATCH_ADDR,
+			DispatchAddress::get(),
 			U256::from(0),
 			omni_sell.encode(),
 			gas_limit * 10,
@@ -308,9 +309,9 @@ fn fee_should_be_paid_in_hdx_when_permit_is_dispatched_and_address_is_not_bounde
 
 		let permit =
 			pallet_evm_precompile_call_permit::CallPermitPrecompile::<hydradx_runtime::Runtime>::generate_permit(
-				CALLPERMIT,
+				CallPermitAddress::get(),
 				user_evm_address,
-				DISPATCH_ADDR,
+				DispatchAddress::get(),
 				U256::from(0),
 				omni_sell.encode(),
 				gas_limit,
@@ -325,7 +326,7 @@ fn fee_should_be_paid_in_hdx_when_permit_is_dispatched_and_address_is_not_bounde
 		assert_ok!(MultiTransactionPayment::dispatch_permit(
 			hydradx_runtime::RuntimeOrigin::none(),
 			user_evm_address,
-			DISPATCH_ADDR,
+			DispatchAddress::get(),
 			U256::from(0),
 			omni_sell.encode(),
 			gas_limit,
@@ -411,9 +412,9 @@ fn evm_permit_should_validate_unsigned_correctly() {
 
 		let permit =
 			pallet_evm_precompile_call_permit::CallPermitPrecompile::<hydradx_runtime::Runtime>::generate_permit(
-				CALLPERMIT,
+				CallPermitAddress::get(),
 				user_evm_address,
-				DISPATCH_ADDR,
+				DispatchAddress::get(),
 				U256::from(0),
 				omni_sell.encode(),
 				gas_limit,
@@ -426,7 +427,7 @@ fn evm_permit_should_validate_unsigned_correctly() {
 
 		let call = pallet_transaction_multi_payment::Call::dispatch_permit {
 			from: user_evm_address,
-			to: DISPATCH_ADDR,
+			to: DispatchAddress::get(),
 			value: U256::from(0),
 			data: omni_sell.encode(),
 			gas_limit,
@@ -510,9 +511,9 @@ fn evm_permit_should_validate_unsigned_correctly_and_return_error_if_inner_call_
 
 		let permit =
 			pallet_evm_precompile_call_permit::CallPermitPrecompile::<hydradx_runtime::Runtime>::generate_permit(
-				CALLPERMIT,
+				CallPermitAddress::get(),
 				user_evm_address,
-				DISPATCH_ADDR,
+				DispatchAddress::get(),
 				U256::from(0),
 				omni_sell.encode(),
 				gas_limit,
@@ -525,7 +526,7 @@ fn evm_permit_should_validate_unsigned_correctly_and_return_error_if_inner_call_
 
 		let call = pallet_transaction_multi_payment::Call::dispatch_permit {
 			from: user_evm_address,
-			to: DISPATCH_ADDR,
+			to: DispatchAddress::get(),
 			value: U256::from(0),
 			data: omni_sell.encode(),
 			gas_limit,
@@ -596,9 +597,9 @@ fn evm_permit_set_currency_dispatch_should_pay_evm_fee_in_chosen_currency() {
 
 		let permit =
 			pallet_evm_precompile_call_permit::CallPermitPrecompile::<hydradx_runtime::Runtime>::generate_permit(
-				CALLPERMIT,
+				CallPermitAddress::get(),
 				user_evm_address,
-				DISPATCH_ADDR,
+				DispatchAddress::get(),
 				U256::from(0),
 				set_currency_call.encode(),
 				gas_limit,
@@ -612,7 +613,7 @@ fn evm_permit_set_currency_dispatch_should_pay_evm_fee_in_chosen_currency() {
 		// Validate unsigned first
 		let call = pallet_transaction_multi_payment::Call::dispatch_permit {
 			from: user_evm_address,
-			to: DISPATCH_ADDR,
+			to: DispatchAddress::get(),
 			value: U256::from(0),
 			data: set_currency_call.encode(),
 			gas_limit,
@@ -638,7 +639,7 @@ fn evm_permit_set_currency_dispatch_should_pay_evm_fee_in_chosen_currency() {
 		assert_ok!(MultiTransactionPayment::dispatch_permit(
 			hydradx_runtime::RuntimeOrigin::none(),
 			user_evm_address,
-			DISPATCH_ADDR,
+			DispatchAddress::get(),
 			U256::from(0),
 			set_currency_call.encode(),
 			gas_limit,
@@ -759,9 +760,9 @@ fn evm_permit_set_currency_dispatch_should_pay_evm_fee_in_insufficient_asset() {
 
 			let permit =
 				pallet_evm_precompile_call_permit::CallPermitPrecompile::<hydradx_runtime::Runtime>::generate_permit(
-					CALLPERMIT,
+					CallPermitAddress::get(),
 					user_evm_address,
-					DISPATCH_ADDR,
+					DispatchAddress::get(),
 					U256::from(0),
 					set_currency_call.encode(),
 					gas_limit,
@@ -775,7 +776,7 @@ fn evm_permit_set_currency_dispatch_should_pay_evm_fee_in_insufficient_asset() {
 			// Validate unsigned first
 			let call = pallet_transaction_multi_payment::Call::dispatch_permit {
 				from: user_evm_address,
-				to: DISPATCH_ADDR,
+				to: DispatchAddress::get(),
 				value: U256::from(0),
 				data: set_currency_call.encode(),
 				gas_limit,
@@ -801,7 +802,7 @@ fn evm_permit_set_currency_dispatch_should_pay_evm_fee_in_insufficient_asset() {
 			assert_ok!(MultiTransactionPayment::dispatch_permit(
 				hydradx_runtime::RuntimeOrigin::none(),
 				user_evm_address,
-				DISPATCH_ADDR,
+				DispatchAddress::get(),
 				U256::from(0),
 				set_currency_call.encode(),
 				gas_limit,
@@ -1234,9 +1235,9 @@ fn evm_permit_dispatch_flow_should_work() {
 
 		let permit =
 			pallet_evm_precompile_call_permit::CallPermitPrecompile::<hydradx_runtime::Runtime>::generate_permit(
-				CALLPERMIT,
+				CallPermitAddress::get(),
 				user_evm_address,
-				DISPATCH_ADDR,
+				DispatchAddress::get(),
 				U256::from(0),
 				omni_sell.encode(),
 				gas_limit,
@@ -1251,7 +1252,7 @@ fn evm_permit_dispatch_flow_should_work() {
 
 		let call = pallet_transaction_multi_payment::Call::dispatch_permit {
 			from: user_evm_address,
-			to: DISPATCH_ADDR,
+			to: DispatchAddress::get(),
 			value: U256::from(0),
 			data: omni_sell.encode(),
 			gas_limit,
@@ -1277,7 +1278,7 @@ fn evm_permit_dispatch_flow_should_work() {
 		assert_ok!(MultiTransactionPayment::dispatch_permit(
 			hydradx_runtime::RuntimeOrigin::none(),
 			user_evm_address,
-			DISPATCH_ADDR,
+			DispatchAddress::get(),
 			U256::from(0),
 			omni_sell.encode(),
 			gas_limit,
@@ -1365,9 +1366,9 @@ fn evm_permit_should_fail_when_replayed() {
 
 		let permit =
 			pallet_evm_precompile_call_permit::CallPermitPrecompile::<hydradx_runtime::Runtime>::generate_permit(
-				CALLPERMIT,
+				CallPermitAddress::get(),
 				user_evm_address,
-				DISPATCH_ADDR,
+				DispatchAddress::get(),
 				U256::from(0),
 				omni_sell.encode(),
 				gas_limit,
@@ -1382,7 +1383,7 @@ fn evm_permit_should_fail_when_replayed() {
 
 		let call = pallet_transaction_multi_payment::Call::dispatch_permit {
 			from: user_evm_address,
-			to: DISPATCH_ADDR,
+			to: DispatchAddress::get(),
 			value: U256::from(0),
 			data: omni_sell.encode(),
 			gas_limit,
@@ -1408,7 +1409,7 @@ fn evm_permit_should_fail_when_replayed() {
 		assert_ok!(MultiTransactionPayment::dispatch_permit(
 			hydradx_runtime::RuntimeOrigin::none(),
 			user_evm_address,
-			DISPATCH_ADDR,
+			DispatchAddress::get(),
 			U256::from(0),
 			omni_sell.encode(),
 			gas_limit,
@@ -1502,9 +1503,9 @@ fn dispatch_permit_should_increase_account_nonce_correctly() {
 
 		let permit =
 			pallet_evm_precompile_call_permit::CallPermitPrecompile::<hydradx_runtime::Runtime>::generate_permit(
-				CALLPERMIT,
+				CallPermitAddress::get(),
 				user_evm_address,
-				DISPATCH_ADDR,
+				DispatchAddress::get(),
 				U256::from(0),
 				omni_sell.encode(),
 				gas_limit,
@@ -1519,7 +1520,7 @@ fn dispatch_permit_should_increase_account_nonce_correctly() {
 
 		let call = pallet_transaction_multi_payment::Call::dispatch_permit {
 			from: user_evm_address,
-			to: DISPATCH_ADDR,
+			to: DispatchAddress::get(),
 			value: U256::from(0),
 			data: omni_sell.encode(),
 			gas_limit,
@@ -1545,7 +1546,7 @@ fn dispatch_permit_should_increase_account_nonce_correctly() {
 		assert_ok!(MultiTransactionPayment::dispatch_permit(
 			hydradx_runtime::RuntimeOrigin::none(),
 			user_evm_address,
-			DISPATCH_ADDR,
+			DispatchAddress::get(),
 			U256::from(0),
 			omni_sell.encode(),
 			gas_limit,
@@ -1623,9 +1624,9 @@ fn dispatch_permit_should_increase_permit_nonce_when_call_fails() {
 
 		let permit =
 			pallet_evm_precompile_call_permit::CallPermitPrecompile::<hydradx_runtime::Runtime>::generate_permit(
-				CALLPERMIT,
+				CallPermitAddress::get(),
 				user_evm_address,
-				DISPATCH_ADDR,
+				DispatchAddress::get(),
 				U256::from(0),
 				omni_sell.encode(),
 				gas_limit,
@@ -1639,7 +1640,7 @@ fn dispatch_permit_should_increase_permit_nonce_when_call_fails() {
 		assert_ok!(MultiTransactionPayment::dispatch_permit(
 			hydradx_runtime::RuntimeOrigin::none(),
 			user_evm_address,
-			DISPATCH_ADDR,
+			DispatchAddress::get(),
 			U256::from(0),
 			omni_sell.encode(),
 			gas_limit,
@@ -1714,9 +1715,9 @@ fn dispatch_permit_should_charge_tx_fee_when_call_fails() {
 
 		let permit =
 			pallet_evm_precompile_call_permit::CallPermitPrecompile::<hydradx_runtime::Runtime>::generate_permit(
-				CALLPERMIT,
+				CallPermitAddress::get(),
 				user_evm_address,
-				DISPATCH_ADDR,
+				DispatchAddress::get(),
 				U256::from(0),
 				omni_sell.encode(),
 				gas_limit,
@@ -1730,7 +1731,7 @@ fn dispatch_permit_should_charge_tx_fee_when_call_fails() {
 		assert_ok!(MultiTransactionPayment::dispatch_permit(
 			hydradx_runtime::RuntimeOrigin::none(),
 			user_evm_address,
-			DISPATCH_ADDR,
+			DispatchAddress::get(),
 			U256::from(0),
 			omni_sell.encode(),
 			gas_limit,
@@ -1810,9 +1811,9 @@ fn dispatch_permit_should_pause_tx_when_permit_is_invalid() {
 
 		let permit =
 			pallet_evm_precompile_call_permit::CallPermitPrecompile::<hydradx_runtime::Runtime>::generate_permit(
-				CALLPERMIT,
+				CallPermitAddress::get(),
 				user_evm_address,
-				DISPATCH_ADDR,
+				DispatchAddress::get(),
 				U256::from(0),
 				omni_sell.encode(),
 				gas_limit,
@@ -1826,7 +1827,7 @@ fn dispatch_permit_should_pause_tx_when_permit_is_invalid() {
 		assert_ok!(MultiTransactionPayment::dispatch_permit(
 			hydradx_runtime::RuntimeOrigin::none(),
 			user_evm_address,
-			DISPATCH_ADDR,
+			DispatchAddress::get(),
 			U256::from(1),
 			omni_sell.encode(),
 			gas_limit,
@@ -1855,7 +1856,7 @@ fn dispatch_permit_should_pause_tx_when_permit_is_invalid() {
 
 		let call = RuntimeCall::MultiTransactionPayment(pallet_transaction_multi_payment::Call::dispatch_permit {
 			from: user_evm_address,
-			to: DISPATCH_ADDR,
+			to: DispatchAddress::get(),
 			value: U256::from(0),
 			data: omni_sell.encode(),
 			gas_limit,
@@ -1921,9 +1922,9 @@ fn dispatch_permit_should_not_pause_tx_when_call_execution_fails() {
 
 		let permit =
 			pallet_evm_precompile_call_permit::CallPermitPrecompile::<hydradx_runtime::Runtime>::generate_permit(
-				CALLPERMIT,
+				CallPermitAddress::get(),
 				user_evm_address,
-				DISPATCH_ADDR,
+				DispatchAddress::get(),
 				U256::from(0),
 				omni_sell.encode(),
 				gas_limit,
@@ -1937,7 +1938,7 @@ fn dispatch_permit_should_not_pause_tx_when_call_execution_fails() {
 		assert_ok!(MultiTransactionPayment::dispatch_permit(
 			hydradx_runtime::RuntimeOrigin::none(),
 			user_evm_address,
-			DISPATCH_ADDR,
+			DispatchAddress::get(),
 			U256::from(0),
 			omni_sell.encode(),
 			gas_limit,
@@ -1966,7 +1967,7 @@ fn dispatch_permit_should_not_pause_tx_when_call_execution_fails() {
 
 		let call = RuntimeCall::MultiTransactionPayment(pallet_transaction_multi_payment::Call::dispatch_permit {
 			from: user_evm_address,
-			to: DISPATCH_ADDR,
+			to: DispatchAddress::get(),
 			value: U256::from(0),
 			data: omni_sell.encode(),
 			gas_limit,
@@ -2032,9 +2033,9 @@ fn dispatch_permit_should_pause_tx_when_no_tx_fee_is_paid() {
 
 		let permit =
 			pallet_evm_precompile_call_permit::CallPermitPrecompile::<hydradx_runtime::Runtime>::generate_permit(
-				CALLPERMIT,
+				CallPermitAddress::get(),
 				user_evm_address,
-				DISPATCH_ADDR,
+				DispatchAddress::get(),
 				U256::from(0),
 				omni_sell.encode(),
 				gas_limit,
@@ -2048,7 +2049,7 @@ fn dispatch_permit_should_pause_tx_when_no_tx_fee_is_paid() {
 		assert_ok!(MultiTransactionPayment::dispatch_permit(
 			hydradx_runtime::RuntimeOrigin::none(),
 			user_evm_address,
-			DISPATCH_ADDR,
+			DispatchAddress::get(),
 			U256::from(0),
 			omni_sell.encode(),
 			gas_limit,
@@ -2077,7 +2078,7 @@ fn dispatch_permit_should_pause_tx_when_no_tx_fee_is_paid() {
 
 		let call = RuntimeCall::MultiTransactionPayment(pallet_transaction_multi_payment::Call::dispatch_permit {
 			from: user_evm_address,
-			to: DISPATCH_ADDR,
+			to: DispatchAddress::get(),
 			value: U256::from(0),
 			data: omni_sell.encode(),
 			gas_limit,

--- a/integration-tests/src/fee_calculation.rs
+++ b/integration-tests/src/fee_calculation.rs
@@ -5,7 +5,7 @@ use frame_support::assert_ok;
 use frame_support::dispatch::DispatchClass;
 use frame_support::dispatch::GetDispatchInfo;
 use frame_support::weights::WeightToFee as WeightToFeeTrait;
-use hydradx_runtime::evm::precompiles::DISPATCH_ADDR;
+use hydradx_runtime::evm::precompiles::DispatchAddress;
 use hydradx_runtime::TransactionPayment;
 use hydradx_runtime::EVM;
 use hydradx_runtime::{Runtime, Tokens};
@@ -15,6 +15,7 @@ use primitives::constants::chain::Weight;
 use primitives::constants::currency::UNITS;
 use primitives::constants::time::HOURS;
 use sp_core::Encode;
+use sp_core::Get;
 use sp_core::U256;
 use sp_runtime::{FixedU128, Permill};
 use test_utils::assert_eq_approx;
@@ -226,7 +227,7 @@ pub fn get_evm_fee_in_cent(nonce: u128) -> f64 {
 	assert_ok!(EVM::call(
 		evm_signed_origin(evm_address()),
 		evm_address(),
-		DISPATCH_ADDR,
+		DispatchAddress::get(),
 		omni_sell.encode(),
 		U256::from(0),
 		gas_limit,

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "317.0.0"
+version = "318.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"
@@ -59,7 +59,7 @@ pallet-otc-settlements = { workspace = true }
 pallet-route-executor = { workspace = true }
 pallet-staking = { workspace = true }
 pallet-liquidation = { workspace = true }
-pallet-hsm = {workspace = true}
+pallet-hsm = { workspace = true }
 
 # pallets
 pallet-bags-list = { workspace = true }

--- a/runtime/hydradx/src/evm/permit.rs
+++ b/runtime/hydradx/src/evm/permit.rs
@@ -13,6 +13,7 @@ use pallet_transaction_multi_payment::EVMPermit;
 use primitive_types::{H160, H256, U256};
 use primitives::AccountId;
 use sp_core::crypto::AccountId32;
+use sp_core::Get;
 use sp_io::hashing::keccak_256;
 use sp_runtime::traits::{One, UniqueSaturatedInto};
 use sp_runtime::DispatchResult;
@@ -47,7 +48,7 @@ where
 		let account_nonce = NoncesStorage::get(source);
 
 		let permit = pallet_evm_precompile_call_permit::CallPermitPrecompile::<R>::generate_permit(
-			precompiles::CALLPERMIT,
+			precompiles::CallPermitAddress::get(),
 			source,
 			target,
 			value,

--- a/runtime/hydradx/src/evm/precompiles/chainlink_adapter.rs
+++ b/runtime/hydradx/src/evm/precompiles/chainlink_adapter.rs
@@ -1,6 +1,8 @@
+use crate::evm::precompiles::multicurrency::MultiCurrencyPrecompile;
 use crate::{
 	assets::LRNA,
 	evm::precompiles::{
+		dynamic::DynamicPrecompile,
 		handle::{FunctionModifier, PrecompileHandleExt},
 		substrate::RuntimeHelper,
 		succeed, Output,
@@ -9,6 +11,7 @@ use crate::{
 	EmaOracle, Router,
 };
 use codec::{Decode, Encode, EncodeLike};
+use evm::executor::stack::IsPrecompileResult;
 use frame_support::traits::{IsType, OriginTrait};
 use frame_system::pallet_prelude::BlockNumberFor;
 use hex_literal::hex;
@@ -22,6 +25,7 @@ use hydradx_traits::{
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use pallet_ema_oracle::Price;
 use pallet_evm::{ExitRevert, Precompile, PrecompileFailure, PrecompileHandle, PrecompileResult};
+use precompile_utils::precompile_set::{PrecompileCheckSummary, PrecompileKind, PrecompileSetFragment};
 use primitive_types::{H160, U128, U256};
 use primitives::{constants::chain::OMNIPOOL_SOURCE, AssetId};
 use sp_runtime::{traits::Dispatchable, RuntimeDebug};
@@ -359,4 +363,20 @@ fn decode_oracle_address_should_work() {
 		decode_oracle_address(H160::from(hex!("000001026f6d6e69706f6f6c0000000400000005"))),
 		Some((4, 5, OraclePeriod::TenMinutes, OMNIPOOL_SOURCE))
 	);
+}
+
+impl<Runtime> DynamicPrecompile for ChainlinkOraclePrecompile<Runtime> {
+	fn is_precompile(address: H160, _gas: u64) -> IsPrecompileResult {
+		if is_oracle_address(address) {
+			IsPrecompileResult::Answer {
+				is_precompile: true,
+				extra_cost: 0,
+			}
+		} else {
+			IsPrecompileResult::Answer {
+				is_precompile: false,
+				extra_cost: 0,
+			}
+		}
+	}
 }

--- a/runtime/hydradx/src/evm/precompiles/dynamic.rs
+++ b/runtime/hydradx/src/evm/precompiles/dynamic.rs
@@ -1,0 +1,74 @@
+// This file is part of https://github.com/galacticcouncil/HydraDX-node
+// Copyright (C) 2021-2025  Intergalactic, Limited (GIB).
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::evm::precompiles::{is_precompile, is_standard_precompile};
+use pallet_evm::{ExitRevert, IsPrecompileResult, Precompile, PrecompileFailure, PrecompileHandle, PrecompileResult};
+use precompile_utils::precompile_set::{PrecompileCheckSummary, PrecompileChecks, PrecompileSetFragment};
+use primitive_types::H160;
+use sp_std::marker::PhantomData;
+
+/// A trait for dynamic precompiles that can be identified by an address.
+pub trait DynamicPrecompile {
+	fn is_precompile(address: H160, gas: u64) -> IsPrecompileResult;
+}
+
+/// A wrapper for dynamic precompiles that applies security checks.
+pub struct DynamicPrecompileWrapper<P> {
+	_phantom: PhantomData<P>,
+}
+
+impl<P> PrecompileSetFragment for DynamicPrecompileWrapper<P>
+where
+	P: Precompile + DynamicPrecompile,
+{
+	fn new() -> Self {
+		Self { _phantom: PhantomData }
+	}
+
+	fn is_precompile(&self, address: H160, gas: u64) -> IsPrecompileResult {
+		P::is_precompile(address, gas)
+	}
+
+	fn execute<R: pallet_evm::Config>(&self, handle: &mut impl PrecompileHandle) -> Option<PrecompileResult> {
+		let address = handle.code_address();
+
+		if let IsPrecompileResult::Answer {
+			is_precompile: false, ..
+		} = self.is_precompile(address, handle.remaining_gas())
+		{
+			return None;
+		}
+
+		// Disallow calling custom precompiles with DELEGATECALL or CALLCODE
+		if handle.context().address != address && is_precompile(address) && !is_standard_precompile(address) {
+			return Some(Err(PrecompileFailure::Revert {
+				exit_status: ExitRevert::Reverted,
+				output: "precompile cannot be called with DELEGATECALL or CALLCODE".into(),
+			}));
+		}
+
+		Some(P::execute(handle))
+	}
+
+	fn used_addresses(&self) -> sp_std::vec::Vec<H160> {
+		sp_std::vec![]
+	}
+
+	fn summarize_checks(&self) -> sp_std::vec::Vec<PrecompileCheckSummary> {
+		// TODO: consider adding checks
+		sp_std::vec![]
+	}
+}

--- a/runtime/hydradx/src/evm/precompiles/multicurrency.rs
+++ b/runtime/hydradx/src/evm/precompiles/multicurrency.rs
@@ -20,10 +20,12 @@
 //                                          http://www.apache.org/licenses/LICENSE-2.0
 
 use crate::evm::erc20_currency::Function;
+use crate::evm::precompiles::erc20_mapping::is_asset_address;
 use crate::evm::precompiles::revert;
 use crate::{
 	evm::{
 		precompiles::{
+			dynamic::DynamicPrecompile,
 			erc20_mapping::HydraErc20Mapping,
 			handle::{EvmDataWriter, FunctionModifier, PrecompileHandleExt},
 			substrate::RuntimeHelper,
@@ -34,6 +36,7 @@ use crate::{
 	Currencies,
 };
 use codec::EncodeLike;
+use evm::executor::stack::IsPrecompileResult;
 use frame_support::traits::{IsType, OriginTrait};
 use hydradx_traits::evm::{Erc20Encoding, InspectEvmAccounts};
 use hydradx_traits::registry::Inspect as InspectRegistry;
@@ -43,6 +46,7 @@ use primitive_types::H160;
 use primitives::{AssetId, Balance};
 use sp_runtime::traits::Dispatchable;
 use sp_std::marker::PhantomData;
+use sp_std::vec;
 
 pub struct MultiCurrencyPrecompile<Runtime>(PhantomData<Runtime>);
 
@@ -93,6 +97,22 @@ where
 			exit_status: ExitRevert::Reverted,
 			output: "invalid currency id".into(),
 		})
+	}
+}
+
+impl<Runtime> DynamicPrecompile for MultiCurrencyPrecompile<Runtime> {
+	fn is_precompile(address: H160, _gas: u64) -> IsPrecompileResult {
+		if is_asset_address(address) {
+			IsPrecompileResult::Answer {
+				is_precompile: true,
+				extra_cost: 0,
+			}
+		} else {
+			IsPrecompileResult::Answer {
+				is_precompile: false,
+				extra_cost: 0,
+			}
+		}
 	}
 }
 

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -120,7 +120,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 317,
+	spec_version: 318,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
- use builder to declare precompiles as it is more declarative and has better checks
- set nesting to 0 for dispatch to prevent reentrancy attack 