### PR TITLE
fix: remove redundant min. deposit check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4666,7 +4666,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "320.0.0"
+version = "321.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -4818,7 +4818,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-traits"
-version = "3.15.4"
+version = "3.15.5"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -8545,7 +8545,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-liquidity-mining"
-version = "4.4.6"
+version = "4.4.7"
 dependencies = [
  "fixed",
  "frame-support",

--- a/pallets/liquidity-mining/Cargo.toml
+++ b/pallets/liquidity-mining/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-liquidity-mining"
-version = "4.4.6"
+version = "4.4.7"
 description = "Liquidity mining"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/pallets/liquidity-mining/src/lib.rs
+++ b/pallets/liquidity-mining/src/lib.rs
@@ -249,9 +249,6 @@ pub mod pallet {
 		/// Liquidity mining is in `active` or `terminated` state and action cannot be completed.
 		LiquidityMiningIsNotStopped,
 
-		/// LP shares amount is not valid.
-		InvalidDepositAmount,
-
 		/// Account is not allowed to perform action.
 		Forbidden,
 
@@ -470,7 +467,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// - `reward_currency`: payoff currency of rewards.
 	/// - `owner`: liq. mining farm owner.
 	/// - `yield_per_period`: percentage return on `reward_currency` of all pools.
-	/// - `min_deposit`: minimum amount of LP shares to be deposited into liquidity mining by each user.
+	/// - `min_deposit`: minimum value of LP shares to be deposited into liquidity mining by each user.
 	/// - `price_adjustment`: price adjustment between `incentivized_asset` and `reward_currency`.
 	/// This value should be `1` if `incentivized_asset` and `reward_currency` are the same.
 	#[allow(clippy::too_many_arguments)]
@@ -577,7 +574,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// - `global_farm_id`: global farm id.
 	/// - `planned_yielding_periods`: planned number of periods to distribute `total_rewards`.
 	/// - `yield_per_period`: percentage return on `reward_currency` of all pools.
-	/// - `min_deposit`: minimum amount of LP shares to be deposited into liquidity mining by each user.
+	/// - `min_deposit`: minimum value of LP shares to be deposited into liquidity mining by each user.
 	fn update_global_farm(
 		global_farm_id: GlobalFarmId,
 		planned_yielding_periods: PeriodOf<T>,
@@ -1441,11 +1438,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					let global_farm = maybe_global_farm
 						.as_mut()
 						.defensive_ok_or::<Error<T, I>>(InconsistentStateError::GlobalFarmNotFound.into())?;
-
-					ensure!(
-						deposit.shares.ge(&global_farm.min_deposit),
-						Error::<T, I>::InvalidDepositAmount,
-					);
 
 					//NOTE: If yield-farm is active also global-farm MUST be active.
 					ensure!(

--- a/pallets/liquidity-mining/src/tests/deposit_lp_shares.rs
+++ b/pallets/liquidity-mining/src/tests/deposit_lp_shares.rs
@@ -557,42 +557,6 @@ fn deposit_lp_shares_should_work() {
 }
 
 #[test]
-fn deposit_lp_shares_bellow_min_deposit_should_not_work() {
-	let _ = predefined_test_ext_with_deposits().execute_with(|| {
-		with_transaction(|| {
-			//NOTE: min. deposit is 10
-			let yield_farm_id = GC_BSX_TKN1_YIELD_FARM_ID;
-
-			assert_noop!(
-				LiquidityMining::deposit_lp_shares(GC_FARM, yield_farm_id, BSX_TKN1_AMM, 0, |_, _, _| { Ok(10_u128) }),
-				Error::<Test, Instance1>::InvalidDepositAmount
-			);
-
-			assert_noop!(
-				LiquidityMining::deposit_lp_shares(GC_FARM, yield_farm_id, BSX_TKN1_AMM, 1, |_, _, _| { Ok(10_u128) }),
-				Error::<Test, Instance1>::InvalidDepositAmount
-			);
-
-			assert_noop!(
-				LiquidityMining::deposit_lp_shares(GC_FARM, yield_farm_id, BSX_TKN1_AMM, 8, |_, _, _| { Ok(10_u128) }),
-				Error::<Test, Instance1>::InvalidDepositAmount
-			);
-
-			//margin value should works
-			assert_ok!(LiquidityMining::deposit_lp_shares(
-				GC_FARM,
-				yield_farm_id,
-				BSX_TKN1_AMM,
-				crate::MIN_DEPOSIT,
-				|_, _, _| { Ok(crate::MIN_DEPOSIT) }
-			));
-
-			TransactionOutcome::Commit(DispatchResult::Ok(()))
-		})
-	});
-}
-
-#[test]
 fn deposit_lp_shares_non_existing_yield_farm_should_not_work() {
 	predefined_test_ext_with_deposits().execute_with(|| {
 		let _ = with_transaction(|| {
@@ -644,6 +608,23 @@ fn deposit_lp_shares_should_not_work_when_valued_shares_are_bellow_min_deposit()
 				),
 				Error::<Test, Instance1>::IncorrectValuedShares
 			);
+
+			TransactionOutcome::Commit(DispatchResult::Ok(()))
+		})
+	});
+}
+
+#[test]
+fn deposit_lp_shares_should_work_when_valued_shares_are_euqal_to_min_deposit() {
+	let _ = predefined_test_ext_with_deposits().execute_with(|| {
+		with_transaction(|| {
+			assert_ok!(LiquidityMining::deposit_lp_shares(
+				GC_FARM,
+				GC_BSX_TKN1_YIELD_FARM_ID,
+				BSX_TKN1_AMM,
+				crate::MIN_DEPOSIT,
+				|_, _, _| { Ok(crate::MIN_DEPOSIT) }
+			));
 
 			TransactionOutcome::Commit(DispatchResult::Ok(()))
 		})

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "320.0.0"
+version = "321.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -120,7 +120,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 320,
+	spec_version: 321,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-traits"
-version = "3.15.4"
+version = "3.15.5"
 description = "Shared traits"
 authors = ["GalacticCouncil"]
 edition = "2021"
@@ -28,4 +28,5 @@ std = [
     "codec/std",
     "frame-support/std",
     "sp-std/std",
+    "primitives/std",
 ]


### PR DESCRIPTION
This PR remove `deposit.shares >= min_deposits` and leave only `valued_shares >= min_deposit` check