### PR TITLE
test: reduce accepted difference in stableswap integration test

### DIFF
--- a/integration-tests/src/stableswap.rs
+++ b/integration-tests/src/stableswap.rs
@@ -114,7 +114,7 @@ fn gigadot_pool_should_work() {
 			assert_eq_approx!(
 				adot_received,
 				expected_adot_received,
-				100_000_000_000_000_000,
+				100_000_000,
 				"Expected adot received is not equal to actual adot received"
 			);
 


### PR DESCRIPTION
This PR only makes the accepted difference in one integration test more reasonable. 

It was set  unnecessary large value. 