### PR TITLE
chore: Bump polkadot-sdk to stable2409-patch5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "15.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "hash-db",
  "log",
@@ -979,7 +979,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.14.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1802,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1819,7 +1819,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1842,7 +1842,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -1887,7 +1887,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -1917,7 +1917,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1932,7 +1932,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -1958,7 +1958,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.12.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1980,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2006,7 +2006,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -2043,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -2060,7 +2060,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.17.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -2096,7 +2096,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -2107,7 +2107,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -2147,7 +2147,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.15.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -2156,7 +2156,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2172,7 +2172,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2186,7 +2186,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.10.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2196,7 +2196,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "8.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -2212,7 +2212,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -2222,7 +2222,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2239,7 +2239,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2263,7 +2263,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2282,7 +2282,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -2317,7 +2317,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2356,7 +2356,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -3449,7 +3449,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3577,7 +3577,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3601,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "43.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "14.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -3662,7 +3662,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3678,7 +3678,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "38.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -3708,7 +3708,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "array-bytes",
  "docify",
@@ -3723,7 +3723,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.46.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "futures",
  "indicatif",
@@ -3745,7 +3745,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "38.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -3786,7 +3786,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "30.0.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3806,7 +3806,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.1.0",
@@ -3818,7 +3818,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3828,7 +3828,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "cfg-if",
  "docify",
@@ -3848,7 +3848,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3862,7 +3862,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -3872,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4666,7 +4666,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "323.0.0"
+version = "324.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -6506,7 +6506,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "futures",
  "log",
@@ -6525,7 +6525,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -7398,7 +7398,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-asset-conversion"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7416,7 +7416,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7458,7 +7458,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7475,7 +7475,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7491,7 +7491,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7507,7 +7507,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7522,7 +7522,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7535,7 +7535,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7558,7 +7558,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "aquamarine",
  "docify",
@@ -7579,7 +7579,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7594,7 +7594,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7613,7 +7613,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -7662,7 +7662,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7699,7 +7699,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.17.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -7717,7 +7717,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7807,7 +7807,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7826,7 +7826,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7842,7 +7842,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -7929,7 +7929,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "5.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7964,7 +7964,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8072,7 +8072,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8094,7 +8094,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8107,7 +8107,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8339,7 +8339,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8375,7 +8375,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8430,7 +8430,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -8446,7 +8446,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8465,7 +8465,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8572,7 +8572,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8588,7 +8588,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "41.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -8607,7 +8607,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8659,7 +8659,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8674,7 +8674,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "35.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8692,7 +8692,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "36.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8712,7 +8712,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "33.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -8722,7 +8722,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8738,7 +8738,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8877,7 +8877,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.9.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8894,7 +8894,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8910,7 +8910,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8924,7 +8924,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "38.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8942,7 +8942,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8956,7 +8956,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -9010,7 +9010,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9051,7 +9051,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9068,7 +9068,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9089,7 +9089,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9105,7 +9105,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9176,7 +9176,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9198,7 +9198,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "22.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -9207,7 +9207,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9217,7 +9217,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9233,7 +9233,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9248,7 +9248,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9267,7 +9267,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "38.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9349,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -9365,7 +9365,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9395,7 +9395,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9409,7 +9409,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9425,7 +9425,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9439,7 +9439,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9453,7 +9453,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -9477,7 +9477,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9547,7 +9547,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -9900,7 +9900,7 @@ dependencies = [
 [[package]]
 name = "polkadot-approval-distribution"
 version = "18.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "bitvec",
  "futures",
@@ -9920,7 +9920,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "always-assert",
  "futures",
@@ -9936,7 +9936,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "derive_more",
  "fatality",
@@ -9960,7 +9960,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "fatality",
@@ -9993,7 +9993,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "cfg-if",
  "clap",
@@ -10021,7 +10021,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10044,7 +10044,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "15.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "derive_more",
  "fatality",
@@ -10080,7 +10080,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -10094,7 +10094,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10116,7 +10116,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -10139,7 +10139,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -10157,7 +10157,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "18.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -10190,7 +10190,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "bitvec",
  "futures",
@@ -10212,7 +10212,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10232,7 +10232,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -10247,7 +10247,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "futures",
@@ -10269,7 +10269,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -10283,7 +10283,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10300,7 +10300,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "fatality",
  "futures",
@@ -10319,7 +10319,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "futures",
@@ -10336,7 +10336,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "fatality",
  "futures",
@@ -10350,7 +10350,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10368,7 +10368,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "always-assert",
  "array-bytes",
@@ -10397,7 +10397,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -10413,7 +10413,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "cpu-time",
  "futures",
@@ -10439,7 +10439,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -10454,7 +10454,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "lazy_static",
  "log",
@@ -10473,7 +10473,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "bs58 0.5.1",
  "futures",
@@ -10492,7 +10492,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "18.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -10518,7 +10518,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -10544,7 +10544,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -10554,7 +10554,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -10584,7 +10584,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -10620,7 +10620,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "futures",
@@ -10642,7 +10642,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "bounded-collections",
  "derive_more",
@@ -10658,7 +10658,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -10684,7 +10684,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -10719,7 +10719,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -10769,7 +10769,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "bs58 0.5.1",
  "frame-benchmarking",
@@ -10781,7 +10781,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -10830,7 +10830,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -10937,7 +10937,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
@@ -10960,7 +10960,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -12030,7 +12030,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -12130,7 +12130,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -12629,7 +12629,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "29.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "log",
  "sp-core",
@@ -12640,7 +12640,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "futures",
@@ -12670,7 +12670,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12692,7 +12692,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.42.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -12707,7 +12707,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "array-bytes",
  "docify",
@@ -12734,7 +12734,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -12745,7 +12745,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.47.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -12786,7 +12786,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "fnv",
  "futures",
@@ -12813,7 +12813,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -12839,7 +12839,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "futures",
@@ -12863,7 +12863,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "futures",
@@ -12892,7 +12892,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -12928,7 +12928,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -12950,7 +12950,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -12986,7 +12986,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -13006,7 +13006,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -13019,7 +13019,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.30.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -13063,7 +13063,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.30.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -13083,7 +13083,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "futures",
@@ -13106,7 +13106,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.40.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -13129,7 +13129,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.35.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -13142,7 +13142,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.32.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "log",
  "polkavm",
@@ -13153,7 +13153,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.35.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -13171,7 +13171,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "console",
  "futures",
@@ -13188,7 +13188,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "33.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -13202,7 +13202,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.15.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.4",
@@ -13231,7 +13231,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.45.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13282,7 +13282,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -13300,7 +13300,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "ahash",
  "futures",
@@ -13319,7 +13319,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13340,7 +13340,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13377,7 +13377,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.44.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "array-bytes",
  "futures",
@@ -13396,7 +13396,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.12.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "bs58 0.5.1",
  "ed25519-dalek",
@@ -13413,7 +13413,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -13447,7 +13447,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -13456,7 +13456,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -13488,7 +13488,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13508,7 +13508,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "17.1.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -13532,7 +13532,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "array-bytes",
  "futures",
@@ -13564,7 +13564,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.46.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "directories",
@@ -13628,7 +13628,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.36.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -13639,7 +13639,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.22.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "clap",
  "fs4",
@@ -13652,7 +13652,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13671,7 +13671,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "derive_more",
  "futures",
@@ -13692,7 +13692,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "25.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "chrono",
  "futures",
@@ -13712,7 +13712,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "37.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "chrono",
  "console",
@@ -13741,7 +13741,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -13752,7 +13752,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "futures",
@@ -13779,7 +13779,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "futures",
@@ -13795,7 +13795,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -14346,7 +14346,7 @@ dependencies = [
 [[package]]
 name = "slot-range-helper"
 version = "15.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -14553,7 +14553,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "docify",
  "hash-db",
@@ -14575,7 +14575,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "20.0.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -14589,7 +14589,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14601,7 +14601,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -14615,7 +14615,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14627,7 +14627,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -14637,7 +14637,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "37.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -14656,7 +14656,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "futures",
@@ -14671,7 +14671,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14687,7 +14687,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14705,7 +14705,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "22.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -14726,7 +14726,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "21.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -14743,7 +14743,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.40.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14754,7 +14754,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "array-bytes",
  "bitflags 1.3.2",
@@ -14800,7 +14800,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -14813,7 +14813,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
@@ -14823,7 +14823,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -14832,7 +14832,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14842,7 +14842,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.29.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -14852,7 +14852,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.15.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14864,7 +14864,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -14877,7 +14877,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "bytes",
  "docify",
@@ -14903,7 +14903,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -14913,7 +14913,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.40.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -14924,7 +14924,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -14933,7 +14933,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.7.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -14943,7 +14943,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.12.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14954,7 +14954,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "34.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -14971,7 +14971,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14984,7 +14984,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -14994,7 +14994,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -15004,7 +15004,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "32.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -15014,7 +15014,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "39.0.5"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "docify",
  "either",
@@ -15040,7 +15040,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "28.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -15059,7 +15059,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "Inflector",
  "expander",
@@ -15072,7 +15072,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "36.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -15086,7 +15086,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "36.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -15099,7 +15099,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.43.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "hash-db",
  "log",
@@ -15119,7 +15119,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -15143,12 +15143,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 
 [[package]]
 name = "sp-storage"
 version = "21.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -15160,7 +15160,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -15172,7 +15172,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -15183,7 +15183,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -15192,7 +15192,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -15206,7 +15206,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "ahash",
  "hash-db",
@@ -15229,7 +15229,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -15246,7 +15246,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -15257,7 +15257,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -15269,7 +15269,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -15346,7 +15346,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-parachain-info"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -15359,7 +15359,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "14.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -15378,7 +15378,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "17.0.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -15400,7 +15400,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -15543,7 +15543,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -15568,12 +15568,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -15593,7 +15593,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "http-body-util",
  "hyper 1.5.1",
@@ -15607,7 +15607,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.44.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -15620,7 +15620,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15637,7 +15637,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "24.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "array-bytes",
  "build-helper",
@@ -16246,7 +16246,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -16257,7 +16257,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "expander",
  "proc-macro-crate 3.1.0",
@@ -17086,7 +17086,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "18.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -17194,7 +17194,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -17584,7 +17584,7 @@ dependencies = [
 [[package]]
 name = "xcm-emulator"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "array-bytes",
  "cumulus-pallet-parachain-system",
@@ -17619,7 +17619,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "10.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -17630,7 +17630,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.4.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch4#b254c083cd133c390edb5a22a0886f213e05c899"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=stable2409-patch5#00d2d388d20f0673e811f31191fed6dd6a52763b"
 dependencies = [
  "frame-support",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,111 +164,111 @@ pallet-evm-precompile-flash-loan = { path = "precompiles/flash-loan", default-fe
 precompile-utils = { path = "precompiles/utils", default-features = false }
 
 # Frame
-frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-frame-benchmarking-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-frame-executive = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-frame-remote-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-frame-support = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false, features = ["tuples-96"] }
-frame-support-procedural = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false, features = ["tuples-96"] }
-frame-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-frame-system-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-frame-try-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-frame-metadata-hash-extension = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-arithmetic = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-authority-discovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-block-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-genesis-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-blockchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-consensus-babe = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-consensus-beefy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-inherents = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-io = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-npos-elections = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sc-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-runtime-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-runtime-interface-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-staking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-std = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-storage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-state-machine = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-trie = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-version = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-weights = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-crypto-hashing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-crypto-ec-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sp-wasm-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
+frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+frame-benchmarking-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+frame-executive = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+frame-remote-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+frame-support = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false, features = ["tuples-96"] }
+frame-support-procedural = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false, features = ["tuples-96"] }
+frame-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+frame-system-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+frame-try-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+frame-metadata-hash-extension = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-arithmetic = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-authority-discovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-block-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-genesis-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-blockchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-consensus-babe = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-consensus-beefy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-inherents = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-io = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-npos-elections = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sc-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-runtime-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-runtime-interface-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-staking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-std = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-storage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-state-machine = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-trie = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-version = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-weights = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-crypto-hashing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-crypto-ec-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sp-wasm-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
 
-sc-basic-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sc-chain-spec = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sc-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sc-client-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sc-client-db = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sc-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sc-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sc-consensus-grandpa = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sc-executor = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sc-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sc-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sc-network-sync = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sc-network-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sc-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sc-rpc-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sc-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sc-telemetry = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sc-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sc-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sc-transaction-pool-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-sc-sysinfo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
+sc-basic-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sc-chain-spec = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sc-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sc-client-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sc-client-db = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sc-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sc-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sc-consensus-grandpa = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sc-executor = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sc-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sc-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sc-network-sync = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sc-network-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sc-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sc-rpc-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sc-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sc-telemetry = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sc-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sc-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sc-transaction-pool-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+sc-sysinfo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
 
 # Substrate Pallets
-pallet-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-balances = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-bags-list = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-collective = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-conviction-voting = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-elections-phragmen = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-identity = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-multisig = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-preimage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-proxy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-referenda = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-scheduler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-sudo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-tips = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-transaction-payment-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-treasury = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-uniques = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-im-online = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-message-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-state-trie-migration = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-whitelist = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
+pallet-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-balances = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-bags-list = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-collective = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-conviction-voting = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-elections-phragmen = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-identity = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-multisig = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-preimage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-proxy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-referenda = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-scheduler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-sudo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-tips = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-transaction-payment-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-treasury = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-uniques = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-im-online = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-message-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-state-trie-migration = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-whitelist = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
 
-substrate-build-script-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-substrate-frame-rpc-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-substrate-prometheus-endpoint = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-substrate-rpc-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-substrate-wasm-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-substrate-state-trie-migration-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
+substrate-build-script-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+substrate-frame-rpc-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+substrate-prometheus-endpoint = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+substrate-rpc-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+substrate-wasm-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+substrate-state-trie-migration-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
 
 #TODO: We use our custom ORML as it contains the fix of bug for reducible_balance check, for Preserve mode. Once the official ORML pushes a new version with the fix, we can use that again
 # ORML dependencies
@@ -286,32 +286,32 @@ orml-xcm-support = { git = "https://github.com/galacticcouncil/open-runtime-modu
 orml-xtokens = { git = "https://github.com/galacticcouncil/open-runtime-module-library", branch = "polkadot-stable2409", default-features = false }
 
 # Cumulus dependencies
-cumulus-client-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-cumulus-client-collator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-cumulus-client-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-cumulus-client-consensus-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-cumulus-client-consensus-proposer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-cumulus-client-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-cumulus-client-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-cumulus-pallet-aura-ext = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-cumulus-pallet-parachain-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-cumulus-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-cumulus-pallet-xcmp-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-cumulus-primitives-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-cumulus-primitives-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-cumulus-primitives-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-cumulus-primitives-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-cumulus-relay-chain-inprocess-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-cumulus-relay-chain-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-cumulus-relay-chain-minimal-node = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-collator-selection = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-staging-parachain-info = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-xcm-emulator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-xcm-runtime-apis = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-parachains-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
+cumulus-client-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+cumulus-client-collator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+cumulus-client-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+cumulus-client-consensus-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+cumulus-client-consensus-proposer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+cumulus-client-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+cumulus-client-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+cumulus-pallet-aura-ext = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+cumulus-pallet-parachain-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+cumulus-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+cumulus-primitives-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+cumulus-primitives-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+cumulus-primitives-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+cumulus-relay-chain-inprocess-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+cumulus-relay-chain-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+cumulus-relay-chain-minimal-node = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-collator-selection = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+staging-parachain-info = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+xcm-emulator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+xcm-runtime-apis = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+parachains-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
 
 # Frontier
 fc-consensus = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-stable2409", default-features = false }
@@ -344,36 +344,36 @@ module-evm-utility-macro = { path = "runtime/hydradx/src/evm/evm-utility/macro",
 ethereum = { version = "0.15.0", default-features = false, features = ["with-codec"] }
 
 # Polkadot dependencies
-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-pallet-xcm-benchmarks = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-polkadot-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-core-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-polkadot-parachain = { package = "polkadot-parachain-primitives", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false, features = [
+pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+pallet-xcm-benchmarks = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+polkadot-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-core-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+polkadot-parachain = { package = "polkadot-parachain-primitives", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false, features = [
     "wasm-api",
 ] }
-polkadot-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-polkadot-runtime-parachains = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-polkadot-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-polkadot-xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
+polkadot-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+polkadot-runtime-parachains = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+polkadot-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+polkadot-xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
 
-polkadot-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-node-core-pvf = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-node-network-protocol = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-node-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-node-subsystem = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-node-subsystem-util = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-overseer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-runtime-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4", default-features = false }
-polkadot-statement-table = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-rococo-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
+polkadot-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-node-core-pvf = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-node-network-protocol = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-node-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-node-subsystem = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-node-subsystem-util = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-overseer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-runtime-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5", default-features = false }
+polkadot-statement-table = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+rococo-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
 
-cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
+cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
 
 [patch."https://github.com/moonbeam-foundation/open-runtime-module-library"]
 # ORML dependencies
@@ -388,317 +388,317 @@ orml-xcm-support = { git = "https://github.com/galacticcouncil/open-runtime-modu
 orml-xtokens = { git = "https://github.com/galacticcouncil/open-runtime-module-library", branch = "polkadot-stable2409" }
 
 [patch."https://github.com/moonbeam-foundation/polkadot-sdk"]
-frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-frame-benchmarking-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-frame-executive = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-frame-remote-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-frame-support = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-frame-support-procedural = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-frame-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-frame-system-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-frame-system-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-frame-try-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-frame-metadata-hash-extension = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-arithmetic = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-authority-discovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-block-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-genesis-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-blockchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-consensus-babe = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-inherents = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-io = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-npos-elections = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-runtime-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-runtime-interface-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-wasm-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-panic-handler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-database = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-staking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-std = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-storage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-trie = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-version = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-basic-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-chain-spec = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-client-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-client-db = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-consensus-grandpa = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-executor = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-network-sync = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-network-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-rpc-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-telemetry = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-transaction-pool-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-sysinfo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-state-machine = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-weights = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-crypto-hashing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
+frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+frame-benchmarking-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+frame-executive = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+frame-remote-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+frame-support = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+frame-support-procedural = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+frame-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+frame-system-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+frame-system-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+frame-try-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+frame-metadata-hash-extension = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-arithmetic = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-authority-discovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-block-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-genesis-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-blockchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-consensus-babe = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-inherents = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-io = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-npos-elections = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-runtime-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-runtime-interface-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-wasm-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-panic-handler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-database = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-staking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-std = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-storage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-trie = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-version = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-basic-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-chain-spec = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-client-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-client-db = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-consensus-grandpa = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-executor = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-network-sync = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-network-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-rpc-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-telemetry = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-transaction-pool-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-sysinfo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-state-machine = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-weights = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-crypto-hashing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
 
 # Substrate Pallets
-pallet-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-balances = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-collective = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-elections-phragmen = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-identity = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-multisig = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-preimage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-proxy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-scheduler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-sudo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-tips = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-transaction-payment = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-transaction-payment-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-treasury = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-uniques = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-im-online = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-message-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-state-trie-migration = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
+pallet-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-balances = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-collective = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-elections-phragmen = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-identity = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-multisig = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-preimage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-proxy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-scheduler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-sudo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-tips = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-transaction-payment = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-transaction-payment-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-treasury = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-uniques = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-im-online = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-message-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-state-trie-migration = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
 
-substrate-build-script-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-substrate-frame-rpc-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-substrate-prometheus-endpoint = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-substrate-rpc-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-substrate-wasm-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-substrate-state-trie-migration-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
+substrate-build-script-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+substrate-frame-rpc-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+substrate-prometheus-endpoint = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+substrate-rpc-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+substrate-wasm-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+substrate-state-trie-migration-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
 
 # Cumulus dependencies
-cumulus-client-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-client-collator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-client-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-client-consensus-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-client-consensus-proposer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-client-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-client-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-pallet-aura-ext = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-pallet-parachain-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-pallet-xcmp-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-primitives-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-primitives-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-primitives-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-relay-chain-inprocess-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-relay-chain-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-relay-chain-minimal-node = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-collator-selection = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-staging-parachain-info = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-xcm-emulator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-parachains-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-xcm-runtime-apis = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
+cumulus-client-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-client-collator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-client-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-client-consensus-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-client-consensus-proposer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-client-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-client-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-pallet-aura-ext = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-pallet-parachain-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-primitives-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-primitives-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-primitives-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-relay-chain-inprocess-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-relay-chain-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-relay-chain-minimal-node = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-collator-selection = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+staging-parachain-info = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+xcm-emulator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+parachains-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+xcm-runtime-apis = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
 
 # Polkadot dependencies
-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-xcm-benchmarks = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-core-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-parachain = { package = "polkadot-parachain-primitives", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-runtime-parachains = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
+pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-xcm-benchmarks = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-core-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-parachain = { package = "polkadot-parachain-primitives", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-runtime-parachains = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
 
-polkadot-node-core-pvf = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-node-network-protocol = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-node-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-node-subsystem = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-node-subsystem-util = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-overseer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-runtime-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-statement-table = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-rococo-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
+polkadot-node-core-pvf = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-node-network-protocol = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-node-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-node-subsystem = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-node-subsystem-util = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-overseer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-runtime-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-statement-table = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+rococo-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
 
-cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
+cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
 
 [patch."https://github.com/paritytech/polkadot-sdk"]
-frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-frame-benchmarking-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-frame-executive = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-frame-remote-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-frame-support = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-frame-support-procedural = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-frame-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-frame-system-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-frame-system-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-frame-try-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-frame-metadata-hash-extension = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-arithmetic = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-authority-discovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-block-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-genesis-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-blockchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-consensus-babe = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-inherents = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-io = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-npos-elections = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-runtime-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-runtime-interface-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-wasm-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-panic-handler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-database = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-staking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-std = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-storage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-trie = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-version = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-basic-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-chain-spec = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-client-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-client-db = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-consensus-grandpa = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-executor = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-network-sync = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-network-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-rpc-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-telemetry = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-transaction-pool-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-sysinfo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sc-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-state-machine = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-weights = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-sp-crypto-hashing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
+frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+frame-benchmarking-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+frame-executive = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+frame-remote-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+frame-support = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+frame-support-procedural = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+frame-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+frame-system-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+frame-system-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+frame-try-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+frame-metadata-hash-extension = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-arithmetic = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-authority-discovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-block-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-genesis-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-blockchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-consensus-babe = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-inherents = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-io = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-npos-elections = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-runtime-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-runtime-interface-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-wasm-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-panic-handler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-database = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-staking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-std = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-storage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-trie = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-version = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-basic-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-chain-spec = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-client-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-client-db = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-consensus-grandpa = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-executor = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-network-sync = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-network-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-rpc-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-telemetry = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-transaction-pool-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-sysinfo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sc-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-state-machine = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-weights = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+sp-crypto-hashing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
 
 # Substrate Pallets
-pallet-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-balances = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-collective = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-elections-phragmen = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-identity = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-multisig = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-preimage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-proxy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-scheduler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-sudo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-tips = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-transaction-payment = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-transaction-payment-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-treasury = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-uniques = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-im-online = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-message-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-state-trie-migration = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
+pallet-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-balances = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-collective = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-elections-phragmen = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-identity = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-multisig = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-preimage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-proxy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-scheduler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-sudo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-tips = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-transaction-payment = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-transaction-payment-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-treasury = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-uniques = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-im-online = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-message-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-state-trie-migration = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
 
-substrate-build-script-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-substrate-frame-rpc-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-substrate-prometheus-endpoint = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-substrate-rpc-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-substrate-wasm-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-substrate-state-trie-migration-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
+substrate-build-script-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+substrate-frame-rpc-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+substrate-prometheus-endpoint = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+substrate-rpc-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+substrate-wasm-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+substrate-state-trie-migration-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
 
 # Cumulus dependencies
-cumulus-client-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-client-collator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-client-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-client-consensus-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-client-consensus-proposer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-client-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-client-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-pallet-aura-ext = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-pallet-parachain-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-pallet-xcmp-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-primitives-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-primitives-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-primitives-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-relay-chain-inprocess-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-relay-chain-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-relay-chain-minimal-node = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-collator-selection = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-staging-parachain-info = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-xcm-emulator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-parachains-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-xcm-runtime-apis = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
+cumulus-client-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-client-collator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-client-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-client-consensus-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-client-consensus-proposer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-client-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-client-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-pallet-aura-ext = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-pallet-parachain-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-primitives-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-primitives-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-primitives-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-relay-chain-inprocess-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-relay-chain-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-relay-chain-minimal-node = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-collator-selection = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+staging-parachain-info = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+xcm-emulator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+parachains-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+xcm-runtime-apis = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
 
 # Polkadot dependencies
-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-pallet-xcm-benchmarks = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-core-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-parachain = { package = "polkadot-parachain-primitives", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-runtime-parachains = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
+pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+pallet-xcm-benchmarks = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-core-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-parachain = { package = "polkadot-parachain-primitives", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-runtime-parachains = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
 
-polkadot-node-core-pvf = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-node-network-protocol = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-node-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-node-subsystem = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-node-subsystem-util = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-overseer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-runtime-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-polkadot-statement-table = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-rococo-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
+polkadot-node-core-pvf = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-node-network-protocol = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-node-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-node-subsystem = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-node-subsystem-util = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-overseer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-runtime-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+polkadot-statement-table = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+rococo-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
 
-cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
-cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch4" }
+cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }
+cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "stable2409-patch5" }

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "323.0.0"
+version = "324.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -120,7 +120,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 323,
+	spec_version: 324,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
This PR bumps polkadot-sdk with patch5 which backports a fix for duplicate message codec indices which breaks the fuzzer.

Original issue: stable2409-patch4
Changelog: https://github.com/galacticcouncil/polkadot-sdk/compare/stable2409-patch4...galacticcouncil:polkadot-sdk:stable2409-patch5