### PR TITLE
fix: change asset fee to 25 bips

### DIFF
--- a/integration-tests/src/dca.rs
+++ b/integration-tests/src/dca.rs
@@ -232,11 +232,11 @@ mod omnipool {
 						filler: Omnipool::protocol_account(),
 						filler_type: pallet_broadcast::types::Filler::Omnipool,
 						operation: pallet_broadcast::types::TradeOperation::ExactOut,
-						inputs: vec![Asset::new(HDX, 140280462317696)],
-						outputs: vec![Asset::new(LRNA, 70140229415762)],
+						inputs: vec![Asset::new(HDX, 140421094366889)],
+						outputs: vec![Asset::new(LRNA, 70210545436637)],
 						fees: vec![
-							Fee::new(LRNA, 17535057353, Destination::Burned),
-							Fee::new(LRNA, 17535057354, Destination::Account(Treasury::account_id()))
+							Fee::new(LRNA, 17552636359, Destination::Burned),
+							Fee::new(LRNA, 17552636359, Destination::Account(Treasury::account_id()))
 						],
 						operation_stack: vec![
 							ExecutionType::DCA(schedule_id, 0),
@@ -249,11 +249,11 @@ mod omnipool {
 						filler: Omnipool::protocol_account(),
 						filler_type: pallet_broadcast::types::Filler::Omnipool,
 						operation: pallet_broadcast::types::TradeOperation::ExactOut,
-						inputs: vec![Asset::new(LRNA, 70105159301055)],
+						inputs: vec![Asset::new(LRNA, 70175440163919)],
 						outputs: vec![Asset::new(DAI, amount_out)],
 						fees: vec![Fee::new(
 							DAI,
-							150225338008,
+							250626566417,
 							Destination::Account(Omnipool::protocol_account())
 						)],
 						operation_stack: vec![
@@ -277,11 +277,11 @@ mod omnipool {
 						filler: Omnipool::protocol_account(),
 						filler_type: pallet_broadcast::types::Filler::Omnipool,
 						operation: pallet_broadcast::types::TradeOperation::ExactOut,
-						inputs: vec![Asset::new(HDX, 140280475647099)],
-						outputs: vec![Asset::new(LRNA, 70140232425987)],
+						inputs: vec![Asset::new(HDX, 140421107723192)],
+						outputs: vec![Asset::new(LRNA, 70210548452699)],
 						fees: vec![
-							Fee::new(LRNA, 17535058106, Destination::Burned),
-							Fee::new(LRNA, 17535058106, Destination::Account(Treasury::account_id()))
+							Fee::new(LRNA, 17552637113, Destination::Burned),
+							Fee::new(LRNA, 17552637113, Destination::Account(Treasury::account_id()))
 						],
 						operation_stack: vec![
 							ExecutionType::DCA(schedule_id, 3),
@@ -294,11 +294,11 @@ mod omnipool {
 						filler: Omnipool::protocol_account(),
 						filler_type: pallet_broadcast::types::Filler::Omnipool,
 						operation: pallet_broadcast::types::TradeOperation::ExactOut,
-						inputs: vec![Asset::new(LRNA, 70105162309775)],
+						inputs: vec![Asset::new(LRNA, 70175443178473)],
 						outputs: vec![Asset::new(DAI, amount_out)],
 						fees: vec![Fee::new(
 							DAI,
-							150225338008,
+							250626566417,
 							Destination::Account(Omnipool::protocol_account())
 						)],
 						operation_stack: vec![
@@ -499,7 +499,7 @@ mod omnipool {
 			));
 
 			//Assert
-			assert_balance!(ALICE.into(), HDX, 859719537618218);
+			assert_balance!(ALICE.into(), HDX, 859578905568959);
 			assert_balance!(ALICE.into(), DAI, ALICE_INITIAL_DAI_BALANCE + amount_out);
 		});
 
@@ -528,7 +528,7 @@ mod omnipool {
 			));
 
 			//Assert
-			assert_balance!(ALICE.into(), HDX, 859719537618218);
+			assert_balance!(ALICE.into(), HDX, 859578905568959);
 			assert_balance!(ALICE.into(), DAI, ALICE_INITIAL_DAI_BALANCE + amount_out);
 		});
 	}
@@ -586,7 +586,7 @@ mod omnipool {
 			));
 
 			//Assert
-			assert_balance!(ALICE.into(), LRNA, 4929894840779065);
+			assert_balance!(ALICE.into(), LRNA, 4929824559916281);
 			assert_balance!(ALICE.into(), DAI, ALICE_INITIAL_DAI_BALANCE + amount_out);
 		});
 
@@ -618,7 +618,7 @@ mod omnipool {
 			));
 
 			//Assert
-			assert_balance!(ALICE.into(), LRNA, 4929894840779065);
+			assert_balance!(ALICE.into(), LRNA, 4929824559916281);
 			assert_balance!(ALICE.into(), DAI, ALICE_INITIAL_DAI_BALANCE + amount_out);
 		});
 	}
@@ -718,7 +718,7 @@ mod omnipool {
 			let fee = Currencies::free_balance(HDX, &Treasury::account_id()) - TREASURY_ACCOUNT_INIT_BALANCE;
 			assert!(fee > 0, "Treasury got rugged");
 
-			assert_balance!(ALICE.into(), DAI, 2071285765446401);
+			assert_balance!(ALICE.into(), DAI, 2071214372591672);
 			assert_balance!(ALICE.into(), HDX, alice_init_hdx_balance - dca_budget);
 			assert_reserved_balance!(&ALICE.into(), HDX, dca_budget - amount_to_sell - fee);
 		});
@@ -776,10 +776,10 @@ mod omnipool {
 						filler_type: pallet_broadcast::types::Filler::Omnipool,
 						operation: pallet_broadcast::types::TradeOperation::ExactIn,
 						inputs: vec![Asset::new(LRNA, 49974999160577)],
-						outputs: vec![Asset::new(DAI, 71285765478967)],
+						outputs: vec![Asset::new(DAI, 71214372624206)],
 						fees: vec![Fee::new(
 							DAI,
-							107089282142,
+							178482136903,
 							Destination::Account(Omnipool::protocol_account())
 						)],
 						operation_stack: vec![
@@ -821,10 +821,10 @@ mod omnipool {
 						filler_type: pallet_broadcast::types::Filler::Omnipool,
 						operation: pallet_broadcast::types::TradeOperation::ExactIn,
 						inputs: vec![Asset::new(LRNA, 49974997361814)],
-						outputs: vec![Asset::new(DAI, 71285760673769)],
+						outputs: vec![Asset::new(DAI, 71214367823821)],
 						fees: vec![Fee::new(
 							DAI,
-							107089274924,
+							178482124872,
 							Destination::Account(Omnipool::protocol_account())
 						)],
 						operation_stack: vec![
@@ -1491,7 +1491,7 @@ mod omnipool {
 			assert!(fee > 0, "Treasury got rugged");
 
 			assert_balance!(ALICE.into(), HDX, alice_init_hdx_balance - dca_budget);
-			assert_balance!(ALICE.into(), DAI, 2071285765446401);
+			assert_balance!(ALICE.into(), DAI, 2071214372591672);
 			assert_reserved_balance!(&ALICE.into(), HDX, dca_budget - amount_in - fee);
 		});
 	}
@@ -1599,7 +1599,7 @@ mod omnipool {
 			let treasury_balance = Currencies::free_balance(LRNA, &Treasury::account_id());
 			assert!(treasury_balance > 0);
 
-			assert_balance!(ALICE.into(), DAI, 2142642852904326);
+			assert_balance!(ALICE.into(), DAI, 2142499995765714);
 			assert_balance!(ALICE.into(), LRNA, alice_init_hub_balance - dca_budget);
 			let reserved_budget = Currencies::reserved_balance(LRNA, &ALICE.into());
 			assert!(reserved_budget < dca_budget);
@@ -1638,7 +1638,7 @@ mod omnipool {
 			let fee = Currencies::free_balance(HDX, &Treasury::account_id()) - TREASURY_ACCOUNT_INIT_BALANCE;
 			assert_reserved_balance!(&ALICE.into(), HDX, dca_budget - amount_to_sell - fee);
 
-			assert_balance!(ALICE.into(), DAI, 2071285765446401);
+			assert_balance!(ALICE.into(), DAI, 2071214372591672);
 		});
 
 		//Direct Omnipool
@@ -1664,7 +1664,7 @@ mod omnipool {
 
 			//Assert
 			assert_balance!(ALICE.into(), HDX, alice_init_hdx_balance - amount_to_sell);
-			assert_balance!(ALICE.into(), DAI, 2071285765446401);
+			assert_balance!(ALICE.into(), DAI, 2071214372591672);
 		});
 
 		//Router
@@ -1696,7 +1696,7 @@ mod omnipool {
 
 			//Assert
 			assert_balance!(ALICE.into(), HDX, alice_init_hdx_balance - amount_to_sell);
-			assert_balance!(ALICE.into(), DAI, 2071285765446401);
+			assert_balance!(ALICE.into(), DAI, 2071214372591672);
 		});
 	}
 
@@ -1728,7 +1728,7 @@ mod omnipool {
 			let fee = Currencies::free_balance(LRNA, &Treasury::account_id());
 			assert_reserved_balance!(&ALICE.into(), LRNA, dca_budget - amount_to_sell - fee);
 
-			assert_balance!(ALICE.into(), DAI, 2142642852904326);
+			assert_balance!(ALICE.into(), DAI, 2142499995765714);
 		});
 
 		//Direct omnipool
@@ -1754,7 +1754,7 @@ mod omnipool {
 
 			//Assert
 			assert_balance!(ALICE.into(), LRNA, alice_init_lrna_balance - amount_to_sell);
-			assert_balance!(ALICE.into(), DAI, 2142642852904326);
+			assert_balance!(ALICE.into(), DAI, 2142499995765714);
 		});
 
 		//Router
@@ -1782,7 +1782,7 @@ mod omnipool {
 
 			//Assert
 			assert_balance!(ALICE.into(), LRNA, alice_init_lrna_balance - amount_to_sell);
-			assert_balance!(ALICE.into(), DAI, 2142642852904326);
+			assert_balance!(ALICE.into(), DAI, 2142499995765714);
 		});
 	}
 
@@ -2361,7 +2361,7 @@ mod stableswap {
 	#[test]
 	fn sell_should_work_with_omnipool_and_stable_trades() {
 		let amount_to_sell = 200 * UNITS;
-		let amount_to_receive = 197416345953090;
+		let amount_to_receive = 197218633037918;
 		//With DCA
 		TestNet::reset();
 		Hydra::execute_with(|| {
@@ -2733,7 +2733,7 @@ mod stableswap {
 				let fee = Currencies::free_balance(stable_asset_1, &Treasury::account_id());
 				assert!(fee > 0, "The treasury did not receive the fee");
 				assert_balance!(ALICE.into(), stable_asset_1, alice_init_stable1_balance - dca_budget);
-				assert_balance!(ALICE.into(), HDX, 1070797284164893);
+				assert_balance!(ALICE.into(), HDX, 1070726380525269);
 
 				assert_reserved_balance!(&ALICE.into(), stable_asset_1, dca_budget - amount_to_sell - fee);
 				TransactionOutcome::Commit(DispatchResult::Ok(()))
@@ -2834,7 +2834,7 @@ mod stableswap {
 					stable_asset_1,
 					alice_init_stable1_balance - amount_to_sell
 				);
-				assert_balance!(ALICE.into(), HDX, 1070797284164893);
+				assert_balance!(ALICE.into(), HDX, 1070726380525269);
 
 				TransactionOutcome::Commit(DispatchResult::Ok(()))
 			});
@@ -2937,7 +2937,7 @@ mod stableswap {
 					stable_asset_1,
 					alice_init_stable1_balance - amount_to_sell
 				);
-				assert_balance!(ALICE.into(), HDX, 1070797284164893);
+				assert_balance!(ALICE.into(), HDX, 1070726380525269);
 
 				TransactionOutcome::Commit(DispatchResult::Ok(()))
 			});
@@ -3477,7 +3477,7 @@ mod all_pools {
 
 				//Assert
 				assert_balance!(ALICE.into(), HDX, alice_init_hdx_balance - dca_budget);
-				assert_balance!(ALICE.into(), DAI, 2380585424345097);
+				assert_balance!(ALICE.into(), DAI, 2380211607465609);
 
 				TransactionOutcome::Commit(DispatchResult::Ok(()))
 			});
@@ -3632,7 +3632,7 @@ mod with_onchain_route {
 	#[test]
 	fn sell_should_work_with_omnipool_and_stable_trades_with_onchain_routes() {
 		let amount_to_sell = 200 * UNITS;
-		let amount_to_receive = 187360410419945u128;
+		let amount_to_receive = 187172768546856u128;
 
 		TestNet::reset();
 		Hydra::execute_with(|| {
@@ -3841,7 +3841,7 @@ mod with_onchain_route {
 			assert!(fee > 0, "The treasury did not receive the fee");
 
 			assert_balance!(ALICE.into(), DOT, alice_init_dot_balance - dca_budget);
-			assert_balance!(ALICE.into(), HDX, 1398403530658226);
+			assert_balance!(ALICE.into(), HDX, 1398004528624518);
 
 			assert_reserved_balance!(&ALICE.into(), DOT, dca_budget - amount_to_sell - fee);
 		});
@@ -4101,7 +4101,7 @@ mod with_onchain_route {
 			let fee = Currencies::free_balance(DOT, &Treasury::account_id());
 			assert!(fee > 0, "The treasury did not receive the fee");
 
-			assert_balance!(ALICE.into(), HDX, 5268495216206711);
+			assert_balance!(ALICE.into(), HDX, 5268226594908739);
 			assert_reserved_balance!(&ALICE.into(), DOT, dca_budget - amount_to_sell - fee);
 		});
 	}

--- a/integration-tests/src/dynamic_fees.rs
+++ b/integration-tests/src/dynamic_fees.rs
@@ -7,6 +7,7 @@ use pallet_dynamic_fees::types::FeeEntry;
 use pallet_dynamic_fees::UpdateAndRetrieveFees;
 use primitives::AssetId;
 use sp_runtime::{FixedU128, Permill};
+use test_utils::assert_eq_approx;
 use xcm_emulator::TestExt;
 
 const DOT_UNITS: u128 = 10_000_000_000;
@@ -403,11 +404,11 @@ fn test_fees_update_in_multi_blocks() {
 		let eth_fee = hydradx_runtime::DynamicFees::current_fees(ETH).unwrap();
 		let btc_fee = hydradx_runtime::DynamicFees::current_fees(BTC).unwrap();
 
-		assert_eq!(hdx_fee.asset_fee, Permill::from_float(0.04364));
-		assert_eq!(dai_fee.asset_fee, Permill::from_float(0.0015));
-		assert_eq!(dot_fee.asset_fee, Permill::from_float(0.0015));
-		assert_eq!(eth_fee.asset_fee, Permill::from_float(0.0015));
-		assert_eq!(btc_fee.asset_fee, Permill::from_float(0.0015));
+		assert_eq!(hdx_fee.asset_fee, Permill::from_float(0.044552));
+		assert_eq!(dai_fee.asset_fee, Permill::from_float(0.0025));
+		assert_eq!(dot_fee.asset_fee, Permill::from_float(0.0025));
+		assert_eq!(eth_fee.asset_fee, Permill::from_float(0.0025));
+		assert_eq!(btc_fee.asset_fee, Permill::from_float(0.0025));
 
 		assert_eq!(hdx_fee.protocol_fee, Permill::from_float(0.0005));
 		assert_eq!(dai_fee.protocol_fee, Permill::from_float(0.0005));
@@ -426,17 +427,17 @@ fn test_fees_update_in_multi_blocks() {
 		assert_eq!(hdx_final_fees, (Permill::from_float(0.05), Permill::from_float(0.0005)));
 		assert_eq!(
 			dai_final_fees,
-			(Permill::from_float(0.002888), Permill::from_float(0.0005))
+			(Permill::from_float(0.003886), Permill::from_float(0.0005))
 		);
 		assert_eq!(
 			dot_final_fees,
-			(Permill::from_float(0.0015), Permill::from_float(0.001524))
+			(Permill::from_float(0.0025), Permill::from_float(0.001524))
 		);
 		assert_eq!(
 			eth_final_fees,
-			(Permill::from_float(0.0015), Permill::from_float(0.0025))
+			(Permill::from_float(0.0025), Permill::from_float(0.0025))
 		);
-		assert_eq!(btc_final_fees, (Permill::from_float(0.0015), Permill::from_parts(778)));
+		assert_eq!(btc_final_fees, (Permill::from_float(0.0025), Permill::from_parts(778)));
 
 		let dai_state = hydradx_runtime::Omnipool::load_asset_state(DAI).unwrap();
 
@@ -445,22 +446,26 @@ fn test_fees_update_in_multi_blocks() {
 		let dai_final_fees = UpdateAndRetrieveFees::<hydradx_runtime::Runtime>::get((DAI, dai_state.reserve));
 		assert_eq!(
 			dai_final_fees,
-			(Permill::from_float(0.00291), Permill::from_float(0.0005))
+			(Permill::from_float(0.003908), Permill::from_float(0.0005))
 		);
 
 		hydradx_run_to_next_block();
 		let dai_final_fees = UpdateAndRetrieveFees::<hydradx_runtime::Runtime>::get((DAI, dai_state.reserve));
 		assert_eq!(
 			dai_final_fees,
-			(Permill::from_float(0.002918), Permill::from_float(0.0005))
+			(Permill::from_float(0.003916), Permill::from_float(0.0005))
 		);
 
 		hydradx_run_to_next_block();
 		let dai_final_fees = UpdateAndRetrieveFees::<hydradx_runtime::Runtime>::get((DAI, dai_state.reserve));
-		assert_eq!(
-			dai_final_fees,
-			(Permill::from_float(0.002914), Permill::from_float(0.0005))
+
+		assert_eq_approx!(
+			dai_final_fees.0,
+			Permill::from_float(0.003912),
+			Permill::from_float(0.000001),
+			"Final fee is not correct"
 		);
+		assert_eq!(dai_final_fees.1, Permill::from_float(0.0005));
 
 		hydradx_run_to_next_block();
 		hydradx_run_to_next_block();
@@ -468,7 +473,7 @@ fn test_fees_update_in_multi_blocks() {
 		let dai_final_fees = UpdateAndRetrieveFees::<hydradx_runtime::Runtime>::get((DAI, dai_state.reserve));
 		assert_eq!(
 			dai_final_fees,
-			(Permill::from_float(0.002854), Permill::from_float(0.0005))
+			(Permill::from_float(0.003852), Permill::from_float(0.0005))
 		);
 	});
 }
@@ -490,11 +495,11 @@ fn test_fees_update_after_selling_lrna_in_multi_blocks() {
 		let eth_fee = hydradx_runtime::DynamicFees::current_fees(ETH).unwrap();
 		let btc_fee = hydradx_runtime::DynamicFees::current_fees(BTC).unwrap();
 
-		assert_eq!(hdx_fee.asset_fee, Permill::from_float(0.04364));
-		assert_eq!(dai_fee.asset_fee, Permill::from_float(0.0015));
-		assert_eq!(dot_fee.asset_fee, Permill::from_float(0.0015));
-		assert_eq!(eth_fee.asset_fee, Permill::from_float(0.0015));
-		assert_eq!(btc_fee.asset_fee, Permill::from_float(0.0015));
+		assert_eq!(hdx_fee.asset_fee, Permill::from_float(0.044552));
+		assert_eq!(dai_fee.asset_fee, Permill::from_float(0.0025));
+		assert_eq!(dot_fee.asset_fee, Permill::from_float(0.0025));
+		assert_eq!(eth_fee.asset_fee, Permill::from_float(0.0025));
+		assert_eq!(btc_fee.asset_fee, Permill::from_float(0.0025));
 
 		assert_eq!(hdx_fee.protocol_fee, Permill::from_float(0.0005));
 		assert_eq!(dai_fee.protocol_fee, Permill::from_float(0.0005));
@@ -517,7 +522,7 @@ fn test_fees_update_after_selling_lrna_in_multi_blocks() {
 		//ASSERT
 		assert_eq!(
 			(dai_fee.0, dai_fee.1),
-			(Permill::from_float(0.003199), Permill::from_float(0.0005))
+			(Permill::from_float(0.004196), Permill::from_float(0.0005))
 		);
 	});
 }
@@ -539,11 +544,11 @@ fn test_fees_update_after_buying_with_lrna_in_multi_blocks() {
 		let eth_fee = hydradx_runtime::DynamicFees::current_fees(ETH).unwrap();
 		let btc_fee = hydradx_runtime::DynamicFees::current_fees(BTC).unwrap();
 
-		assert_eq!(hdx_fee.asset_fee, Permill::from_float(0.04364));
-		assert_eq!(dai_fee.asset_fee, Permill::from_float(0.0015));
-		assert_eq!(dot_fee.asset_fee, Permill::from_float(0.0015));
-		assert_eq!(eth_fee.asset_fee, Permill::from_float(0.0015));
-		assert_eq!(btc_fee.asset_fee, Permill::from_float(0.0015));
+		assert_eq!(hdx_fee.asset_fee, Permill::from_float(0.044552));
+		assert_eq!(dai_fee.asset_fee, Permill::from_float(0.0025));
+		assert_eq!(dot_fee.asset_fee, Permill::from_float(0.0025));
+		assert_eq!(eth_fee.asset_fee, Permill::from_float(0.0025));
+		assert_eq!(btc_fee.asset_fee, Permill::from_float(0.0025));
 
 		assert_eq!(hdx_fee.protocol_fee, Permill::from_float(0.0005));
 		assert_eq!(dai_fee.protocol_fee, Permill::from_float(0.0005));
@@ -566,7 +571,7 @@ fn test_fees_update_after_buying_with_lrna_in_multi_blocks() {
 		//ASSERT
 		assert_eq!(
 			(dai_fee.0, dai_fee.1),
-			(Permill::from_float(0.003031), Permill::from_float(0.0005))
+			(Permill::from_float(0.004028), Permill::from_float(0.0005))
 		);
 	});
 }

--- a/integration-tests/src/evm_permit.rs
+++ b/integration-tests/src/evm_permit.rs
@@ -344,7 +344,7 @@ fn fee_should_be_paid_in_hdx_when_permit_is_dispatched_and_address_is_not_bounde
 
 		// Verify omnipool sell
 		let user_weth_balance = user_acc.balance(WETH);
-		assert_eq!(user_weth_balance, 3570615837132);
+		assert_eq!(user_weth_balance, 3567039857685);
 
 		let user_dot_balance = user_acc.balance(DOT);
 		assert!(user_dot_balance < initial_user_dot_balance);
@@ -926,7 +926,7 @@ fn convert_amount_should_work_when_converting_insufficient_to_sufficient_asset()
 			let insufficient_amount = 10 * UNITS;
 			let amount_in_weth = Convert::convert((insufficient_asset, WETH, insufficient_amount)).unwrap();
 			assert_eq!(
-				(4292926597696669208, Ratio::new(4292926597696669208, 10000000000000)),
+				(4292926607826008319, Ratio::new(4292926607826008319, 10000000000000)),
 				amount_in_weth
 			);
 
@@ -1298,7 +1298,7 @@ fn evm_permit_dispatch_flow_should_work() {
 
 		// Verify omnipool sell
 		let user_weth_balance = user_acc.balance(WETH);
-		assert_eq!(user_weth_balance, 3570615837132);
+		assert_eq!(user_weth_balance, 3567039857685);
 
 		let user_dot_balance = user_acc.balance(DOT);
 		assert!(user_dot_balance < initial_user_dot_balance);
@@ -1435,7 +1435,7 @@ fn evm_permit_should_fail_when_replayed() {
 
 		// Verify omnipool sell
 		let user_weth_balance = user_acc.balance(WETH);
-		assert_eq!(user_weth_balance, 3570615837132);
+		assert_eq!(user_weth_balance, 3567039857685);
 
 		let user_dot_balance = user_acc.balance(DOT);
 		assert!(user_dot_balance < initial_user_dot_balance);
@@ -1755,7 +1755,7 @@ fn dispatch_permit_should_charge_tx_fee_when_call_fails() {
 		let hdx_balance = user_acc.balance(HDX);
 		let tx_fee = initial_user_hdx_balance - hdx_balance;
 
-		assert_eq!(tx_fee, 4491170299119);
+		assert_eq!(tx_fee, 4491170276643);
 	})
 }
 
@@ -1962,7 +1962,7 @@ fn dispatch_permit_should_not_pause_tx_when_call_execution_fails() {
 		let hdx_balance = user_acc.balance(HDX);
 		let tx_fee = initial_user_hdx_balance - hdx_balance;
 
-		assert_eq!(tx_fee, 4491170299119);
+		assert_eq!(tx_fee, 4491170276643);
 
 		let call = RuntimeCall::MultiTransactionPayment(pallet_transaction_multi_payment::Call::dispatch_permit {
 			from: user_evm_address,

--- a/integration-tests/src/exchange_asset.rs
+++ b/integration-tests/src/exchange_asset.rs
@@ -122,8 +122,11 @@ fn hydra_should_swap_assets_when_receiving_from_acala_with_sell() {
 			50 * UNITS - fee
 		);
 		// We receive about 39_101 HDX (HDX is super cheap in our test)
-		let received = 39_101 * UNITS + BOB_INITIAL_NATIVE_BALANCE + 207_131_554_396 + 39_199_205_144_415;
-		assert_eq!(hydradx_runtime::Balances::free_balance(AccountId::from(BOB)), received);
+		let received = 39_101 * UNITS;
+		assert_eq!(
+			hydradx_runtime::Balances::free_balance(AccountId::from(BOB)),
+			40101207131554396
+		);
 
 		let last_swapped_events: Vec<pallet_broadcast::Event<hydradx_runtime::Runtime>> = get_last_swapped_events();
 		let last_two_swapped_events = &last_swapped_events[last_swapped_events.len() - 2..];

--- a/integration-tests/src/hsm.rs
+++ b/integration-tests/src/hsm.rs
@@ -1063,11 +1063,11 @@ fn sell_collateral_to_get_hollar_via_router_should_work_when_collateral_is_acqui
 			let alice_hollar_balance = balance_of(alice_evm_address);
 			assert_eq!(
 				alice_hollar_balance - initial_alice_hollar_balance,
-				U256::from(88623906325736u128)
+				U256::from(88535149283848u128)
 			);
 
 			let hsm_collateral_balance = Tokens::free_balance(COLLATERAL, &hsm_address);
-			assert_eq!(hsm_collateral_balance, 44311953162868);
+			assert_eq!(hsm_collateral_balance, 44267574641924);
 
 			let alice_collateral_balance = Tokens::free_balance(COLLATERAL, &AccountId::from(ALICE));
 			assert_eq!(alice_collateral_balance, 0u128);

--- a/integration-tests/src/omnipool_init.rs
+++ b/integration-tests/src/omnipool_init.rs
@@ -86,7 +86,7 @@ fn omnipool_launch_init_params_should_be_correct() {
 			u128::MAX,
 		));
 
-		let expected = 1662982831332175506391u128;
+		let expected = 1664733011875663575256u128;
 
 		let charlie_dai = hydradx_runtime::Tokens::free_balance(DAI, &AccountId::from(CHARLIE));
 
@@ -117,7 +117,7 @@ fn omnipool_launch_init_params_should_be_correct() {
 			u128::MAX,
 		));
 
-		let expected = 2425314174355896988615u128;
+		let expected = 2428053975026574531220;
 
 		let charlie_dai = hydradx_runtime::Tokens::free_balance(DAI, &AccountId::from(CHARLIE));
 

--- a/integration-tests/src/omnipool_liquidity_mining.rs
+++ b/integration-tests/src/omnipool_liquidity_mining.rs
@@ -1846,7 +1846,7 @@ fn price_adjustment_from_oracle_should_be_saved_in_global_farm_when_oracle_is_av
 		//Assert
 		let global_farm = hydradx_runtime::OmnipoolWarehouseLM::global_farm(global_farm_1_id).unwrap();
 		let price_adjustment = DefaultPriceAdjustment::get(&global_farm).unwrap();
-		assert_eq!(price_adjustment, FixedU128::from_inner(830_815305689850039738u128));
+		assert_eq!(price_adjustment, FixedU128::from_inner(830_815305689849957936u128));
 	});
 }
 
@@ -1954,7 +1954,7 @@ fn liquidity_mining_should_work_when_farm_distribute_bonds() {
 		// NOTE: make sure oracle's price adjustment was used.
 		let global_farm = hydradx_runtime::OmnipoolWarehouseLM::global_farm(global_farm_1_id).unwrap();
 		let price_adjustment = DefaultPriceAdjustment::get(&global_farm).unwrap();
-		assert_eq!(price_adjustment, FixedU128::from_inner(830_815305689850039738u128));
+		assert_eq!(price_adjustment, FixedU128::from_inner(830_815305689849957936u128));
 	});
 }
 

--- a/integration-tests/src/oracle.rs
+++ b/integration-tests/src/oracle.rs
@@ -112,7 +112,7 @@ fn omnipool_trades_are_ingested_into_oracle() {
 
 		// assert
 		let expected_a = ((936334588000000000, 1124993992514080).into(), 0);
-		let expected_b = ((87719064509592, 2250006013583407).into(), 0);
+		let expected_b = ((87719064743683, 2250006019587887).into(), 0);
 		for supported_period in SUPPORTED_PERIODS {
 			assert_eq!(
 				EmaOracle::get_price(asset_a, LRNA, *supported_period, OMNIPOOL_SOURCE),
@@ -161,7 +161,7 @@ fn omnipool_hub_asset_trades_are_ingested_into_oracle() {
 		hydradx_run_to_next_block();
 
 		// assert
-		let expected = ((936324588000000000, 1125006025563847).into(), 0);
+		let expected = ((936324588000000000, 1125006037627185).into(), 0);
 		for supported_period in SUPPORTED_PERIODS {
 			assert_eq!(
 				EmaOracle::get_price(HDX, LRNA, *supported_period, OMNIPOOL_SOURCE),

--- a/integration-tests/src/referrals.rs
+++ b/integration-tests/src/referrals.rs
@@ -50,7 +50,7 @@ fn trading_in_omnipool_should_transfer_portion_of_fee_to_reward_pot() {
 			0
 		));
 		let pot_balance = Currencies::free_balance(DAI, &Referrals::pot_account_id());
-		assert_eq!(pot_balance, 52326586502342568);
+		assert_eq!(pot_balance, 63391826463007828);
 	});
 }
 
@@ -73,7 +73,7 @@ fn buying_in_omnipool_should_transfer_portion_of_asset_out_fee_to_reward_pot() {
 			u128::MAX,
 		));
 		let pot_balance = Currencies::free_balance(DAI, &Referrals::pot_account_id());
-		assert_eq!(pot_balance, 54629772405101271);
+		assert_eq!(pot_balance, 66184926918975710);
 	});
 }
 
@@ -119,7 +119,7 @@ fn trading_in_omnipool_should_increase_referrer_shares() {
 			0
 		));
 		let referrer_shares = Referrals::referrer_shares::<AccountId>(ALICE.into());
-		assert_eq!(referrer_shares, 141354464);
+		assert_eq!(referrer_shares, 171245982);
 	});
 }
 #[test]
@@ -141,7 +141,7 @@ fn trading_in_omnipool_should_increase_trader_shares() {
 			0
 		));
 		let trader_shares = Referrals::trader_shares::<AccountId>(BOB.into());
-		assert_eq!(trader_shares, 94236309);
+		assert_eq!(trader_shares, 114163988);
 	});
 }
 #[test]
@@ -164,7 +164,7 @@ fn trading_in_omnipool_should_increase_external_shares() {
 		));
 
 		let external_shares = Referrals::trader_shares::<AccountId>(Staking::pot_account_id());
-		assert_eq!(external_shares, 1957821548045);
+		assert_eq!(external_shares, 2371832219816);
 	});
 }
 
@@ -187,7 +187,7 @@ fn trading_in_omnipool_should_increase_total_shares_correctly() {
 			0
 		));
 		let total_shares = Referrals::total_shares();
-		assert_eq!(total_shares, 1958057138818);
+		assert_eq!(total_shares, 2372117629786);
 	});
 }
 
@@ -342,7 +342,7 @@ fn trading_in_omnipool_should_transfer_some_portion_of_fee_when_no_code_linked()
 			0
 		));
 		let pot_balance = Currencies::free_balance(DAI, &Referrals::pot_account_id());
-		assert_eq!(pot_balance, 52326586502342569);
+		assert_eq!(pot_balance, 63391826463007829);
 		let external_shares = Referrals::trader_shares::<AccountId>(Staking::pot_account_id());
 		let total_shares = Referrals::total_shares();
 		assert_eq!(total_shares, external_shares);
@@ -368,11 +368,11 @@ fn trading_in_omnipool_should_use_global_rewards_when_not_set() {
 			0
 		));
 		let referrer_shares = Referrals::referrer_shares::<AccountId>(ALICE.into());
-		assert_eq!(referrer_shares, 141354464);
+		assert_eq!(referrer_shares, 171245982);
 		let trader_shares = Referrals::trader_shares::<AccountId>(BOB.into());
-		assert_eq!(trader_shares, 94236309);
+		assert_eq!(trader_shares, 114163988);
 		let external_shares = Referrals::trader_shares::<AccountId>(Staking::pot_account_id());
-		assert_eq!(external_shares, 1957821548045);
+		assert_eq!(external_shares, 2371832219816);
 		let total_shares = Referrals::total_shares();
 		assert_eq!(total_shares, referrer_shares + trader_shares + external_shares);
 	});
@@ -407,11 +407,11 @@ fn trading_in_omnipool_should_use_asset_rewards_when_set() {
 			0
 		));
 		let referrer_shares = Referrals::referrer_shares::<AccountId>(ALICE.into());
-		assert_eq!(referrer_shares, 94236309);
+		assert_eq!(referrer_shares, 114163988);
 		let trader_shares = Referrals::trader_shares::<AccountId>(BOB.into());
-		assert_eq!(trader_shares, 47118154);
+		assert_eq!(trader_shares, 57081994);
 		let external_shares = Referrals::trader_shares::<AccountId>(Staking::pot_account_id());
-		assert_eq!(external_shares, 1956172412620);
+		assert_eq!(external_shares, 2369834350024);
 		let total_shares = Referrals::total_shares();
 		assert_eq!(total_shares, referrer_shares + trader_shares + external_shares);
 	});
@@ -439,12 +439,12 @@ fn buying_hdx_in_omnipool_should_transfer_correct_fee() {
 				who: BOB.into(),
 				asset_in: DAI,
 				asset_out: HDX,
-				amount_in: 27007201989029080,
+				amount_in: 27034239540904000,
 				amount_out: 1_000_000_000_000,
-				hub_amount_in: 1217484967,
-				hub_amount_out: 1216876226,
-				asset_fee_amount: 9204958426,
-				protocol_fee_amount: 608742,
+				hub_amount_in: 1218703819,
+				hub_amount_out: 1218094469,
+				asset_fee_amount: 10215297085,
+				protocol_fee_amount: 609351,
 			}
 			.into(),
 			pallet_broadcast::Event::Swapped3 {
@@ -452,11 +452,11 @@ fn buying_hdx_in_omnipool_should_transfer_correct_fee() {
 				filler: Omnipool::protocol_account(),
 				filler_type: Filler::Omnipool,
 				operation: TradeOperation::ExactOut,
-				inputs: vec![Asset::new(DAI, 27007201989029080)],
-				outputs: vec![Asset::new(LRNA, 1217484967)],
+				inputs: vec![Asset::new(DAI, 27034239540904000)],
+				outputs: vec![Asset::new(LRNA, 1218703819)],
 				fees: vec![
-					Fee::new(LRNA, 304371, Destination::Burned),
-					Fee::new(LRNA, 304371, Destination::Account(Treasury::account_id())),
+					Fee::new(LRNA, 304675, Destination::Burned),
+					Fee::new(LRNA, 304676, Destination::Account(Treasury::account_id())),
 				],
 				operation_stack: vec![ExecutionType::Omnipool(0)],
 			}
@@ -466,11 +466,11 @@ fn buying_hdx_in_omnipool_should_transfer_correct_fee() {
 				filler: Omnipool::protocol_account(),
 				filler_type: Filler::Omnipool,
 				operation: TradeOperation::ExactOut,
-				inputs: vec![Asset::new(LRNA, 1216876225)],
+				inputs: vec![Asset::new(LRNA, 1218094468)],
 				outputs: vec![Asset::new(HDX, 1_000_000_000_000)],
 				fees: vec![
 					Fee::new(HDX, 1, Destination::Account(Omnipool::protocol_account())),
-					Fee::new(HDX, 9204958425, Destination::Account(Staking::pot_account_id())),
+					Fee::new(HDX, 10215297084, Destination::Account(Staking::pot_account_id())),
 				],
 				operation_stack: vec![ExecutionType::Omnipool(0)],
 			}
@@ -480,7 +480,7 @@ fn buying_hdx_in_omnipool_should_transfer_correct_fee() {
 		let ref_dai_balance = Currencies::free_balance(DAI, &ref_account);
 		let staking_balance = Currencies::free_balance(HDX, &staking_acc);
 		assert_eq!(ref_dai_balance.abs_diff(orig_balance), 0);
-		assert_eq!(staking_balance.abs_diff(stak_orig_balance), 9204958425);
+		assert_eq!(staking_balance.abs_diff(stak_orig_balance), 10215297084);
 	});
 }
 
@@ -501,19 +501,19 @@ fn buying_with_hdx_in_omnipool_should_transfer_correct_fee() {
 			u128::MAX,
 		));
 
-		let expected_taken_fee = 2366144540787107;
+		let expected_taken_fee = 2869372640285468;
 
 		expect_hydra_last_events(vec![
 			pallet_omnipool::Event::BuyExecuted {
 				who: BOB.into(),
 				asset_in: HDX,
 				asset_out: DAI,
-				amount_in: 37584731096189,
+				amount_in: 37622382629988,
 				amount_out: 1_000_000_000_000_000_000,
-				hub_amount_in: 45316936737,
-				hub_amount_out: 45400948440,
-				asset_fee_amount: 4732289081574215,
-				protocol_fee_amount: 22658468,
+				hub_amount_in: 45362332324,
+				hub_amount_out: 45469007788,
+				asset_fee_amount: 5738745280570938,
+				protocol_fee_amount: 22681166,
 			}
 			.into(),
 			pallet_broadcast::Event::Swapped3 {
@@ -521,11 +521,11 @@ fn buying_with_hdx_in_omnipool_should_transfer_correct_fee() {
 				filler: Omnipool::protocol_account(),
 				filler_type: pallet_broadcast::types::Filler::Omnipool,
 				operation: pallet_broadcast::types::TradeOperation::ExactOut,
-				inputs: vec![Asset::new(HDX, 37584731096189)],
-				outputs: vec![Asset::new(LRNA, 45316936737)],
+				inputs: vec![Asset::new(HDX, 37622382629988)],
+				outputs: vec![Asset::new(LRNA, 45362332324)],
 				fees: vec![
-					Fee::new(LRNA, 11329234, Destination::Burned),
-					Fee::new(LRNA, 11329234, Destination::Account(Treasury::account_id())),
+					Fee::new(LRNA, 11340583, Destination::Burned),
+					Fee::new(LRNA, 11340583, Destination::Account(Treasury::account_id())),
 				],
 				operation_stack: vec![ExecutionType::Omnipool(0)],
 			}
@@ -535,12 +535,12 @@ fn buying_with_hdx_in_omnipool_should_transfer_correct_fee() {
 				filler: Omnipool::protocol_account(),
 				filler_type: pallet_broadcast::types::Filler::Omnipool,
 				operation: pallet_broadcast::types::TradeOperation::ExactOut,
-				inputs: vec![Asset::new(LRNA, 45294278269)],
+				inputs: vec![Asset::new(LRNA, 45339651158)],
 				outputs: vec![Asset::new(DAI, 1_000_000_000_000_000_000)],
 				fees: vec![
 					Fee::new(
 						DAI,
-						2366144540787108,
+						2869372640285470,
 						Destination::Account(Omnipool::protocol_account()),
 					),
 					Fee::new(
@@ -575,7 +575,7 @@ fn trading_in_omnipool_should_increase_staking_shares_when_no_code_linked() {
 		let staking_acc = Staking::pot_account_id();
 
 		let staking_shares = Referrals::trader_shares::<AccountId>(staking_acc);
-		assert_eq!(staking_shares, 1958057138820);
+		assert_eq!(staking_shares, 2372117629787);
 
 		let total_shares = Referrals::total_shares();
 		assert_eq!(total_shares, staking_shares);

--- a/integration-tests/src/router.rs
+++ b/integration-tests/src/router.rs
@@ -147,7 +147,7 @@ mod router_different_pools_tests {
 			));
 
 			//Assert
-			let amount_out = 2232143907425;
+			let amount_out = 2230008413831;
 
 			assert_balance!(BOB.into(), DAI, 1_000_000_000 * UNITS - amount_to_sell);
 			assert_balance!(BOB.into(), LRNA, BOB_INITIAL_LRNA_BALANCE);
@@ -260,7 +260,7 @@ mod router_different_pools_tests {
 			));
 
 			//Assert
-			let amount_in = 4_366_521_391;
+			let amount_in = 4370898989;
 
 			assert_balance!(BOB.into(), DAI, 1_000_000_000 * UNITS - amount_in);
 			assert_balance!(BOB.into(), LRNA, 1_000 * UNITS);
@@ -706,7 +706,7 @@ mod router_different_pools_tests {
 					ALICE_INITIAL_NATIVE_BALANCE - amount_to_sell
 				);
 
-				assert_balance!(ALICE.into(), pool_id, 4643642791732);
+				assert_balance!(ALICE.into(), pool_id, 4638992258357);
 				TransactionOutcome::Commit(DispatchResult::Ok(()))
 			});
 		});
@@ -768,7 +768,7 @@ mod router_different_pools_tests {
 				//Assert
 				assert_balance!(ALICE.into(), pool_id, 0);
 				assert_balance!(ALICE.into(), HDX, ALICE_INITIAL_NATIVE_BALANCE - amount_to_sell);
-				assert_balance!(ALICE.into(), stable_asset_1, 2902296768642);
+				assert_balance!(ALICE.into(), stable_asset_1, 2899390145403);
 				TransactionOutcome::Commit(DispatchResult::Ok(()))
 			});
 		});
@@ -2175,7 +2175,7 @@ mod omnipool_router_tests {
 			));
 
 			//Assert
-			let amount_out = 220907079646017699114;
+			let amount_out = 220685840707964601769;
 
 			assert_balance!(BOB.into(), LRNA, 1_000 * UNITS - amount_to_sell);
 			assert_balance!(BOB.into(), DAI, BOB_INITIAL_DAI_BALANCE + amount_out);
@@ -2197,7 +2197,7 @@ mod omnipool_router_tests {
 
 		let amount_to_sell = 10 * UNITS;
 		let limit = 0;
-		let amount_out = 266461932256168358;
+		let amount_out = 266195070030573798;
 
 		Hydra::execute_with(|| {
 			//Arrange
@@ -2251,7 +2251,7 @@ mod omnipool_router_tests {
 						outputs: vec![Asset::new(DAI, amount_out)],
 						fees: vec![Fee::new(
 							DAI,
-							400293338391841,
+							667155563986401,
 							Destination::Account(Omnipool::protocol_account()),
 						)],
 						operation_stack: vec![ExecutionType::Router(0), ExecutionType::Omnipool(1)],
@@ -2284,8 +2284,8 @@ mod omnipool_router_tests {
 					amount_in: amount_to_sell,
 					amount_out,
 					hub_amount_in: 12014871681,
-					hub_amount_out: 12026877638,
-					asset_fee_amount: 400293338391841,
+					hub_amount_out: 12038886566,
+					asset_fee_amount: 667155563986401,
 					protocol_fee_amount: 6_007_435,
 				}
 				.into(),
@@ -2313,7 +2313,7 @@ mod omnipool_router_tests {
 					outputs: vec![Asset::new(DAI, amount_out)],
 					fees: vec![Fee::new(
 						DAI,
-						400293338391841,
+						667155563986401,
 						Destination::Account(Omnipool::protocol_account()),
 					)],
 					operation_stack: vec![ExecutionType::Omnipool(0)],
@@ -2353,7 +2353,7 @@ mod omnipool_router_tests {
 			));
 
 			//Assert
-			let amount_in = 3752843738106;
+			let amount_in = 3756606010477;
 
 			assert_balance!(BOB.into(), HDX, BOB_INITIAL_NATIVE_BALANCE - amount_in);
 			assert_balance!(BOB.into(), DAI, BOB_INITIAL_DAI_BALANCE + amount_to_buy);
@@ -2438,7 +2438,7 @@ mod omnipool_router_tests {
 
 		let amount_to_buy = UNITS * 100000;
 		let limit = 100 * UNITS;
-		let amount_in = 3752843738106;
+		let amount_in = 3756606010477;
 
 		Hydra::execute_with(|| {
 			//Arrange
@@ -2474,10 +2474,10 @@ mod omnipool_router_tests {
 						filler_type: pallet_broadcast::types::Filler::Omnipool,
 						operation: pallet_broadcast::types::TradeOperation::ExactOut,
 						inputs: vec![Asset::new(HDX, amount_in)],
-						outputs: vec![Asset::new(LRNA, 4509023679)],
+						outputs: vec![Asset::new(LRNA, 4513544013)],
 						fees: vec![
-							Fee::new(LRNA, 1127255, Destination::Burned),
-							Fee::new(LRNA, 1127256, Destination::Account(Treasury::account_id())),
+							Fee::new(LRNA, 1128386, Destination::Burned),
+							Fee::new(LRNA, 1128386, Destination::Account(Treasury::account_id())),
 						],
 						operation_stack: vec![ExecutionType::Router(0), ExecutionType::Omnipool(1)],
 					},
@@ -2486,11 +2486,11 @@ mod omnipool_router_tests {
 						filler: Omnipool::protocol_account(),
 						filler_type: pallet_broadcast::types::Filler::Omnipool,
 						operation: pallet_broadcast::types::TradeOperation::ExactOut,
-						inputs: vec![Asset::new(LRNA, 4506769168)],
+						inputs: vec![Asset::new(LRNA, 4511287241)],
 						outputs: vec![Asset::new(DAI, amount_to_buy)],
 						fees: vec![Fee::new(
 							DAI,
-							150225338007011,
+							250626566416041,
 							Destination::Account(Omnipool::protocol_account()),
 						)],
 						operation_stack: vec![ExecutionType::Router(0), ExecutionType::Omnipool(1)],
@@ -2522,10 +2522,10 @@ mod omnipool_router_tests {
 					asset_out: DAI,
 					amount_in,
 					amount_out: amount_to_buy,
-					hub_amount_in: 4509023679,
-					hub_amount_out: 4513529335,
-					asset_fee_amount: 150225338007011,
-					protocol_fee_amount: 2254511,
+					hub_amount_in: 4513544013,
+					hub_amount_out: 4522565481,
+					asset_fee_amount: 250626566416041,
+					protocol_fee_amount: 2256772,
 				}
 				.into(),
 				pallet_broadcast::Event::Swapped3 {
@@ -2534,10 +2534,10 @@ mod omnipool_router_tests {
 					filler_type: pallet_broadcast::types::Filler::Omnipool,
 					operation: pallet_broadcast::types::TradeOperation::ExactOut,
 					inputs: vec![Asset::new(HDX, amount_in)],
-					outputs: vec![Asset::new(LRNA, 4509023679)],
+					outputs: vec![Asset::new(LRNA, 4513544013)],
 					fees: vec![
-						Fee::new(LRNA, 1127255, Destination::Burned),
-						Fee::new(LRNA, 1127256, Destination::Account(Treasury::account_id())),
+						Fee::new(LRNA, 1128386, Destination::Burned),
+						Fee::new(LRNA, 1128386, Destination::Account(Treasury::account_id())),
 					],
 					operation_stack: vec![ExecutionType::Omnipool(0)],
 				}
@@ -2547,11 +2547,11 @@ mod omnipool_router_tests {
 					filler: Omnipool::protocol_account(),
 					filler_type: pallet_broadcast::types::Filler::Omnipool,
 					operation: pallet_broadcast::types::TradeOperation::ExactOut,
-					inputs: vec![Asset::new(LRNA, 4506769168)],
+					inputs: vec![Asset::new(LRNA, 4511287241)],
 					outputs: vec![Asset::new(DAI, amount_to_buy)],
 					fees: vec![Fee::new(
 						DAI,
-						150225338007011,
+						250626566416041,
 						Destination::Account(Omnipool::protocol_account()),
 					)],
 					operation_stack: vec![ExecutionType::Omnipool(0)],
@@ -4917,7 +4917,7 @@ mod with_on_chain_and_default_route {
 			));
 
 			//Assert
-			let amount_out = 266461932256168358;
+			let amount_out = 266195070030573798;
 
 			assert_balance!(BOB.into(), HDX, BOB_INITIAL_NATIVE_BALANCE - amount_to_sell);
 			assert_balance!(BOB.into(), DAI, BOB_INITIAL_DAI_BALANCE + amount_out);
@@ -4955,7 +4955,7 @@ mod with_on_chain_and_default_route {
 			));
 
 			//Assert
-			let amount_in = 3752843738106;
+			let amount_in = 3756606010477;
 
 			assert_balance!(BOB.into(), HDX, BOB_INITIAL_NATIVE_BALANCE - amount_in);
 			assert_balance!(BOB.into(), DAI, BOB_INITIAL_DAI_BALANCE + amount_to_buy);
@@ -5080,7 +5080,7 @@ mod route_spot_price {
 				));
 
 				//Assert
-				let expected_amount_out = 46513;
+				let expected_amount_out = 46467;
 
 				assert_eq!(
 					hydradx_runtime::Balances::free_balance(AccountId::from(ALICE)),
@@ -5196,7 +5196,7 @@ mod sell_all {
 		TestNet::reset();
 
 		let limit = 0;
-		let amount_out = 26604007508238527742;
+		let amount_out = 26577363534770086553;
 
 		Hydra::execute_with(|| {
 			let bob_hdx_balance = Currencies::free_balance(HDX, &BOB.into());
@@ -5238,7 +5238,7 @@ mod sell_all {
 		TestNet::reset();
 
 		let limit = 0;
-		let amount_out = 35263217460162492;
+		let amount_out = 35227901268414708;
 
 		Hydra::execute_with(|| {
 			let bob_nonnative_balance = Currencies::free_balance(DAI, &BOB.into());

--- a/integration-tests/src/staking.rs
+++ b/integration-tests/src/staking.rs
@@ -138,7 +138,7 @@ fn staking_should_transfer_hdx_fees_to_pot_account_when_omnipool_trade_is_execut
 		));
 
 		let staking_account = pallet_staking::Pallet::<hydradx_runtime::Runtime>::pot_account_id();
-		assert_eq!(Currencies::free_balance(HDX, &staking_account), 1056148317615);
+		assert_eq!(Currencies::free_balance(HDX, &staking_account), 1093580529359);
 	});
 }
 

--- a/integration-tests/src/utility.rs
+++ b/integration-tests/src/utility.rs
@@ -96,10 +96,10 @@ fn batch_execution_type_should_be_included_in_batch() {
 					filler_type: pallet_broadcast::types::Filler::Omnipool,
 					operation: pallet_broadcast::types::TradeOperation::ExactIn,
 					inputs: vec![Asset::new(LRNA, 5640664064)],
-					outputs: vec![Asset::new(HDX, 4687619499466)],
+					outputs: vec![Asset::new(HDX, 4682924837974)],
 					fees: vec![Fee::new(
 						HDX,
-						7041992238,
+						11736653730,
 						Destination::Account(Omnipool::protocol_account())
 					)],
 					operation_stack: vec![ExecutionType::Batch(0), ExecutionType::Router(1)],
@@ -117,11 +117,11 @@ fn batch_execution_type_should_be_included_in_batch() {
 						},
 					))),
 					operation: pallet_broadcast::types::TradeOperation::ExactIn,
-					inputs: vec![Asset::new(HDX, 4687619499466)],
-					outputs: vec![Asset::new(DOT, 2232143907425)],
+					inputs: vec![Asset::new(HDX, 4682924837974)],
+					outputs: vec![Asset::new(DOT, 2230008413831)],
 					fees: vec![Fee::new(
 						DOT,
-						6716581464,
+						6710155707,
 						Destination::Account(XYK::get_pair_id(pallet_xyk::types::AssetPair {
 							asset_in: HDX,
 							asset_out: DOT,
@@ -285,10 +285,10 @@ fn nested_batch_should_represent_embeddedness() {
 					filler_type: pallet_broadcast::types::Filler::Omnipool,
 					operation: pallet_broadcast::types::TradeOperation::ExactIn,
 					inputs: vec![Asset::new(LRNA, 5640664064)],
-					outputs: vec![Asset::new(HDX, 4687619499466)],
+					outputs: vec![Asset::new(HDX, 4682924837974)],
 					fees: vec![Fee::new(
 						HDX,
-						7041992238,
+						11736653730,
 						Destination::Account(Omnipool::protocol_account())
 					)],
 					operation_stack: vec![
@@ -310,11 +310,11 @@ fn nested_batch_should_represent_embeddedness() {
 						},
 					))),
 					operation: pallet_broadcast::types::TradeOperation::ExactIn,
-					inputs: vec![Asset::new(HDX, 4687619499466)],
-					outputs: vec![Asset::new(DOT, 2232143907425)],
+					inputs: vec![Asset::new(HDX, 4682924837974)],
+					outputs: vec![Asset::new(DOT, 2230008413831)],
 					fees: vec![Fee::new(
 						DOT,
-						6716581464,
+						6710155707,
 						Destination::Account(XYK::get_pair_id(pallet_xyk::types::AssetPair {
 							asset_in: HDX,
 							asset_out: DOT,

--- a/runtime/hydradx/src/assets.rs
+++ b/runtime/hydradx/src/assets.rs
@@ -1283,7 +1283,7 @@ impl pallet_otc_settlements::Config for Runtime {
 // Dynamic fees
 parameter_types! {
 	pub AssetFeeParams: FeeParams<Permill> = FeeParams{
-		min_fee: Permill::from_rational(15u32,10000u32), // 0.15%
+		min_fee: Permill::from_rational(25u32,10000u32), // 0.125%
 		max_fee: Permill::from_rational(5u32,100u32),    // 5%
 		decay: FixedU128::from_rational(1,20000),        // 0.005%
 		amplification: FixedU128::from(2),               // 2


### PR DESCRIPTION
from kubo:

```
nyone free or not even free who could help us revert  asset trade fee back to 25 bips as our previous decrease didnt have desired effect on volumes (which would offset smaller fee) , but rather decrease buybacks of
hdx unfortunately
```