### PR TITLE
feat: ERC20_mapping runtime API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4666,7 +4666,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "326.0.0"
+version = "327.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "326.0.0"
+version = "327.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/evm/precompiles/erc20_mapping.rs
+++ b/runtime/hydradx/src/evm/precompiles/erc20_mapping.rs
@@ -51,6 +51,18 @@ impl Erc20Mapping<AssetId> for HydraErc20Mapping {
 	}
 }
 
+sp_api::decl_runtime_apis! {
+	/// The API to query AssetId <-> EVM address conversions.
+	pub trait Erc20MappingApi where
+	{
+		/// Get the EVM address of the asset.
+		fn asset_address(asset_id: AssetId) -> EvmAddress;
+
+		/// Get the asset id corresponding to EVM address. If not found, returns `None`.
+		fn address_to_asset(address: hydradx_traits::evm::EvmAddress) -> Option<AssetId>;
+	}
+}
+
 /// The asset id (with type u32) is encoded in the last 4 bytes of EVM address
 impl Erc20Encoding<AssetId> for HydraErc20Mapping {
 	fn encode_evm_address(asset_id: AssetId) -> EvmAddress {

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -120,7 +120,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 326,
+	spec_version: 327,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -978,6 +978,15 @@ impl_runtime_apis! {
 		}
 		fn account_id(evm_address: H160) -> AccountId {
 			EVMAccounts::account_id(evm_address)
+		}
+	}
+
+	impl evm::precompiles::erc20_mapping::Erc20MappingApi<Block> for Runtime {
+		fn asset_address(asset_id: AssetId) -> evm::EvmAddress {
+			HydraErc20Mapping::asset_address(asset_id)
+		}
+		fn address_to_asset(address: evm::EvmAddress) -> Option<AssetId> {
+			HydraErc20Mapping::address_to_asset(address)
 		}
 	}
 


### PR DESCRIPTION
This PR implements new runtime API, required by the liquidation worker.
Does not contain any new logic, just exposes existing 2 methods as a runtime API.