### PR TITLE
fix: hsm arbitrage finding - correct decimals handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4674,7 +4674,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "339.0.0"
+version = "340.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -8432,7 +8432,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-hsm"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "ethabi",
  "evm",
@@ -12267,7 +12267,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-integration-tests"
-version = "1.52.0"
+version = "1.52.1"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "1.52.0"
+version = "1.52.1"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/src/hsm.rs
+++ b/integration-tests/src/hsm.rs
@@ -145,7 +145,6 @@ fn add_hsm_facilitator_should_work() {
 		assert!(facilitators.contains(&hsm_evm_address), "Facilitator not added");
 	});
 }
-
 #[test]
 fn buying_hollar_from_hsm_should_work() {
 	TestNet::reset();
@@ -1995,6 +1994,180 @@ fn arb_should_repeg_continuously_when_less_hollar_in_pool() {
 }
 
 #[test]
+fn arb_should_repeg_continuously_when_less_hollar_in_pool_and_collateral_has_12_decimals() {
+	let collateral_asset_id = 1003;
+	TestNet::reset();
+	crate::driver::HydrationTestDriver::with_snapshot(PATH_TO_SNAPSHOT).execute(|| {
+		let flash_minter: EvmAddress = hex!["8F3aC7f6482ABc1A5c48a95D97F7A235186dBb68"].into();
+
+		let hsm_address = hydradx_runtime::HSM::account_id();
+		assert_ok!(EVMAccounts::bind_evm_address(hydradx_runtime::RuntimeOrigin::signed(
+			hsm_address.clone().into()
+		)));
+		let hsm_evm_address = EVMAccounts::evm_address(&hsm_address);
+		add_facilitator(hsm_evm_address, "hsm", 1_000_000_000_000_000_000_000_000_000);
+
+		assert!(!check_flash_borrower(hsm_evm_address));
+		add_flash_borrower(hsm_evm_address);
+		assert!(check_flash_borrower(hsm_evm_address));
+
+		assert_ok!(EVMAccounts::bind_evm_address(hydradx_runtime::RuntimeOrigin::signed(
+			ALICE.into()
+		),));
+		let alice_evm_address = EVMAccounts::evm_address(&AccountId::from(ALICE));
+		mint(minter(), alice_evm_address, 1_000_000_000_000_000_000_000_000);
+		let alice_hollar_balance = balance_of(alice_evm_address);
+		assert_eq!(alice_hollar_balance, U256::from(1_000_000_000_000_000_000_000_000u128));
+
+		let pool_id = 9876;
+		let asset_ids = vec![222, collateral_asset_id];
+
+		assert_ok!(hydradx_runtime::AssetRegistry::register(
+			RawOrigin::Root.into(),
+			Some(pool_id),
+			Some(b"pool".to_vec().try_into().unwrap()),
+			AssetType::StableSwap,
+			Some(1u128),
+			None,
+			None,
+			None,
+			None,
+			true,
+		));
+		assert_ok!(hydradx_runtime::AssetRegistry::register(
+			RawOrigin::Root.into(),
+			Some(collateral_asset_id),
+			Some(b"col".to_vec().try_into().unwrap()),
+			AssetType::Token,
+			Some(1u128),
+			None,
+			Some(12u8),
+			None,
+			None,
+			true,
+		));
+
+		let amplification = 1000u16;
+		let fee = Permill::from_float(0.002);
+
+		assert_ok!(hydradx_runtime::Stableswap::create_pool(
+			hydradx_runtime::RuntimeOrigin::root(),
+			pool_id,
+			BoundedVec::truncate_from(asset_ids),
+			amplification,
+			fee,
+		));
+
+		assert_ok!(Tokens::set_balance(
+			RawOrigin::Root.into(),
+			ALICE.into(),
+			collateral_asset_id,
+			5_000_020_000_000_000_000,
+			0,
+		));
+		let initial_liquidity = vec![
+			AssetAmount::new(collateral_asset_id, 5_000_000_000_000_000_000u128),
+			AssetAmount::new(222, 500_000_000_000_000_000_000_000u128),
+		];
+
+		assert_ok!(hydradx_runtime::Stableswap::add_assets_liquidity(
+			hydradx_runtime::RuntimeOrigin::signed(ALICE.into()),
+			pool_id,
+			BoundedVec::truncate_from(initial_liquidity),
+			0
+		));
+
+		hydradx_run_to_next_block();
+
+		assert_ok!(HSM::add_collateral_asset(
+			hydradx_runtime::RuntimeOrigin::root(),
+			collateral_asset_id,
+			pool_id,
+			Permill::zero(),
+			FixedU128::from_rational(99, 100),
+			Permill::zero(),
+			Perbill::from_float(0.0002),
+			None
+		));
+
+		assert_ok!(HSM::set_flash_minter(
+			hydradx_runtime::RuntimeOrigin::root(),
+			flash_minter,
+		));
+		let state = Stableswap::create_snapshot(pool_id).unwrap();
+		let r = state
+			.assets
+			.iter()
+			.zip(state.reserves.iter())
+			.map(|(a, b)| (a.clone(), b.clone()))
+			.collect();
+		let initial_spot_price = hydra_dx_math::stableswap::calculate_spot_price(
+			pool_id,
+			r,
+			state.amplification,
+			222,
+			collateral_asset_id,
+			state.share_issuance,
+			1_000_000_000_000_000_000,
+			Some(state.fee),
+			&state.pegs,
+		);
+
+		let mut last_spot_price = initial_spot_price;
+
+		for block_idx in 0..50 {
+			assert_ok!(HSM::execute_arbitrage(
+				hydradx_runtime::RuntimeOrigin::none(),
+				collateral_asset_id,
+				None
+			));
+			let state = Stableswap::create_snapshot(pool_id).unwrap();
+			let r = state
+				.assets
+				.iter()
+				.zip(state.reserves.iter())
+				.map(|(a, b)| (a.clone(), b.clone()))
+				.collect();
+			let spot_price = hydra_dx_math::stableswap::calculate_spot_price(
+				pool_id,
+				r,
+				state.amplification,
+				222,
+				collateral_asset_id,
+				state.share_issuance,
+				1_000_000_000_000_000_000,
+				Some(state.fee),
+				&state.pegs,
+			);
+			println!("Block: {:?}: spot: {:?}", block_idx, spot_price);
+			assert!(spot_price > last_spot_price);
+			last_spot_price = spot_price;
+			hydradx_run_to_next_block();
+		}
+
+		let state = Stableswap::create_snapshot(pool_id).unwrap();
+		let r = state
+			.assets
+			.iter()
+			.zip(state.reserves.iter())
+			.map(|(a, b)| (a.clone(), b.clone()))
+			.collect();
+		let final_spot_price = hydra_dx_math::stableswap::calculate_spot_price(
+			pool_id,
+			r,
+			state.amplification,
+			222,
+			collateral_asset_id,
+			state.share_issuance,
+			1_000_000_000_000_000_000,
+			Some(state.fee),
+			&state.pegs,
+		);
+		assert!(initial_spot_price < final_spot_price);
+	});
+}
+
+#[test]
 fn arb_should_repeg_continuously_when_more_hollar_in_pool() {
 	TestNet::reset();
 	crate::driver::HydrationTestDriver::with_snapshot(PATH_TO_SNAPSHOT).execute(|| {
@@ -2156,6 +2329,194 @@ fn arb_should_repeg_continuously_when_more_hollar_in_pool() {
 			state.amplification,
 			222,
 			2,
+			state.share_issuance,
+			1_000_000_000_000_000_000,
+			Some(state.fee),
+			&state.pegs,
+		);
+		assert!(initial_spot_price > final_spot_price);
+	});
+}
+
+#[test]
+fn arb_should_repeg_continuously_when_more_hollar_in_pool_and_collateral_has_12_decimals() {
+	let collateral_asset_id = 1003;
+	TestNet::reset();
+	crate::driver::HydrationTestDriver::with_snapshot(PATH_TO_SNAPSHOT).execute(|| {
+		let flash_minter: EvmAddress = hex!["8F3aC7f6482ABc1A5c48a95D97F7A235186dBb68"].into();
+
+		let hsm_address = hydradx_runtime::HSM::account_id();
+		assert_ok!(EVMAccounts::bind_evm_address(hydradx_runtime::RuntimeOrigin::signed(
+			hsm_address.clone().into()
+		)));
+		let hsm_evm_address = EVMAccounts::evm_address(&hsm_address);
+		add_facilitator(hsm_evm_address, "hsm", 1_000_000_000_000_000_000_000_000_000);
+
+		assert!(!check_flash_borrower(hsm_evm_address));
+		add_flash_borrower(hsm_evm_address);
+		assert!(check_flash_borrower(hsm_evm_address));
+
+		assert_ok!(EVMAccounts::bind_evm_address(hydradx_runtime::RuntimeOrigin::signed(
+			ALICE.into()
+		),));
+		let alice_evm_address = EVMAccounts::evm_address(&AccountId::from(ALICE));
+		mint(minter(), alice_evm_address, 5_000_000_000_000_000_000_000_000);
+		let alice_hollar_balance = balance_of(alice_evm_address);
+		assert_eq!(alice_hollar_balance, U256::from(5_000_000_000_000_000_000_000_000u128));
+
+		let pool_id = 9876;
+		let asset_ids = vec![222, collateral_asset_id];
+
+		assert_ok!(hydradx_runtime::AssetRegistry::register(
+			RawOrigin::Root.into(),
+			Some(pool_id),
+			Some(b"pool".to_vec().try_into().unwrap()),
+			AssetType::StableSwap,
+			Some(1u128),
+			None,
+			None,
+			None,
+			None,
+			true,
+		));
+		assert_ok!(hydradx_runtime::AssetRegistry::register(
+			RawOrigin::Root.into(),
+			Some(collateral_asset_id),
+			Some(b"col".to_vec().try_into().unwrap()),
+			AssetType::Token,
+			Some(1u128),
+			None,
+			Some(12u8),
+			None,
+			None,
+			true,
+		));
+
+		let amplification = 1000u16;
+		let fee = Permill::from_float(0.002);
+
+		assert_ok!(hydradx_runtime::Stableswap::create_pool(
+			hydradx_runtime::RuntimeOrigin::root(),
+			pool_id,
+			BoundedVec::truncate_from(asset_ids),
+			amplification,
+			fee,
+		));
+
+		assert_ok!(Tokens::set_balance(
+			RawOrigin::Root.into(),
+			ALICE.into(),
+			collateral_asset_id,
+			5_000_020_000_000_000_000,
+			0,
+		));
+
+		let initial_liquidity = vec![
+			AssetAmount::new(222, 5_000_000_000_000_000_000_000_000u128),
+			AssetAmount::new(collateral_asset_id, 500_000_000_000_000_000u128),
+		];
+
+		assert_ok!(hydradx_runtime::Stableswap::add_assets_liquidity(
+			hydradx_runtime::RuntimeOrigin::signed(ALICE.into()),
+			pool_id,
+			BoundedVec::truncate_from(initial_liquidity),
+			0
+		));
+
+		hydradx_run_to_next_block();
+
+		assert_ok!(HSM::add_collateral_asset(
+			hydradx_runtime::RuntimeOrigin::root(),
+			collateral_asset_id,
+			pool_id,
+			Permill::zero(),
+			FixedU128::from_rational(99, 100),
+			Permill::zero(),
+			Perbill::from_float(0.0002),
+			None
+		));
+
+		assert_ok!(HSM::set_flash_minter(
+			hydradx_runtime::RuntimeOrigin::root(),
+			flash_minter,
+		));
+
+		// To make sure HSM has some collateral
+		assert_ok!(HSM::buy(
+			hydradx_runtime::RuntimeOrigin::signed(ALICE.into()),
+			collateral_asset_id,
+			222,
+			500_000_000_000_000_000_000_000,
+			u128::MAX,
+		));
+
+		hydradx_run_to_next_block();
+
+		let state = Stableswap::create_snapshot(pool_id).unwrap();
+		let r = state
+			.assets
+			.iter()
+			.zip(state.reserves.iter())
+			.map(|(a, b)| (a.clone(), b.clone()))
+			.collect();
+		let initial_spot_price = hydra_dx_math::stableswap::calculate_spot_price(
+			pool_id,
+			r,
+			state.amplification,
+			222,
+			collateral_asset_id,
+			state.share_issuance,
+			1_000_000_000_000_000_000,
+			Some(state.fee),
+			&state.pegs,
+		);
+		dbg!(initial_spot_price);
+
+		let mut last_spot_price = initial_spot_price;
+
+		for block_idx in 0..50 {
+			assert_ok!(HSM::execute_arbitrage(
+				hydradx_runtime::RuntimeOrigin::none(),
+				collateral_asset_id,
+				None
+			));
+			let state = Stableswap::create_snapshot(pool_id).unwrap();
+			let r = state
+				.assets
+				.iter()
+				.zip(state.reserves.iter())
+				.map(|(a, b)| (a.clone(), b.clone()))
+				.collect();
+			let spot_price = hydra_dx_math::stableswap::calculate_spot_price(
+				pool_id,
+				r,
+				state.amplification,
+				222,
+				collateral_asset_id,
+				state.share_issuance,
+				1_000_000_000_000_000_000,
+				Some(state.fee),
+				&state.pegs,
+			);
+			println!("Block: {:?}: spot: {:?}", block_idx, spot_price);
+			assert!(spot_price < last_spot_price);
+			last_spot_price = spot_price;
+			hydradx_run_to_next_block();
+		}
+
+		let state = Stableswap::create_snapshot(pool_id).unwrap();
+		let r = state
+			.assets
+			.iter()
+			.zip(state.reserves.iter())
+			.map(|(a, b)| (a.clone(), b.clone()))
+			.collect();
+		let final_spot_price = hydra_dx_math::stableswap::calculate_spot_price(
+			pool_id,
+			r,
+			state.amplification,
+			222,
+			collateral_asset_id,
 			state.share_issuance,
 			1_000_000_000_000_000_000,
 			Some(state.fee),

--- a/pallets/hsm/Cargo.toml
+++ b/pallets/hsm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-hsm"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 description = "Hollar stability module"
 authors = ["GalacticCouncil"]

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "339.0.0"
+version = "340.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -120,7 +120,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 339,
+	spec_version: 340,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
This PR fixes only find_arbitrage_opportunity where it did not handle collateral decimals correctly. 

it does not have an impact on hsm main functionality.