### PR TITLE
fix: possible overflow in price provider for given route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4618,7 +4618,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-adapters"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",

--- a/runtime/adapters/Cargo.toml
+++ b/runtime/adapters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-adapters"
-version = "1.9.0"
+version = "1.9.1"
 description = "Structs and other generic types for building runtimes."
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/runtime/adapters/src/lib.rs
+++ b/runtime/adapters/src/lib.rs
@@ -629,18 +629,12 @@ where
 		if prices.is_empty() {
 			return None;
 		}
-
-		let nominator = prices
-			.iter()
-			.try_fold(U512::from(1u128), |acc, price| acc.checked_mul(U512::from(price.n)))?;
-
-		let denominator = prices
-			.iter()
-			.try_fold(U512::from(1u128), |acc, price| acc.checked_mul(U512::from(price.d)))?;
-
-		let rat_as_u128 = round_u512_to_rational((nominator, denominator), Rounding::Nearest);
-
-		Some(EmaPrice::new(rat_as_u128.0, rat_as_u128.1))
+		let price = prices.iter().try_fold((1u128, 1u128), |acc, price| {
+			let n = U512::from(acc.0).checked_mul(U512::from(price.n))?;
+			let d = U512::from(acc.1).checked_mul(U512::from(price.d))?;
+			Some(round_u512_to_rational((n, d), Rounding::Nearest))
+		})?;
+		Some(EmaPrice::new(price.0, price.1))
 	}
 }
 

--- a/runtime/adapters/src/tests/mod.rs
+++ b/runtime/adapters/src/tests/mod.rs
@@ -1,3 +1,4 @@
 pub mod mock;
+mod prices;
 pub mod trader;
 pub mod xcm_exchange;

--- a/runtime/adapters/src/tests/prices.rs
+++ b/runtime/adapters/src/tests/prices.rs
@@ -124,4 +124,22 @@ fn price_provider_should_not_overflow_when_route_contains_more_than_4_trades() {
 			340282366920938463463374607431768211438
 		))
 	);
+	let route = generate_route(16);
+	let price = PriceProviderForRoute::price(&route, OraclePeriod::LastBlock);
+	assert_eq!(
+		price,
+		Some(EmaPrice::new(
+			340282366920938463463374607431768211424,
+			340282366920938463463374607431768211424
+		))
+	);
+	let route = generate_route(17);
+	let price = PriceProviderForRoute::price(&route, OraclePeriod::LastBlock);
+	assert_eq!(
+		price,
+		Some(EmaPrice::new(
+			340282366920938463463374607431768211422,
+			340282366920938463463374607431768211422
+		))
+	);
 }

--- a/runtime/adapters/src/tests/prices.rs
+++ b/runtime/adapters/src/tests/prices.rs
@@ -1,0 +1,127 @@
+use crate::OraclePriceProvider;
+use frame_support::parameter_types;
+use hydra_dx_math::ema::EmaPrice;
+use hydradx_traits::router::{PoolType, Trade};
+use hydradx_traits::{AggregatedPriceOracle, OraclePeriod, PriceOracle, Source};
+use pallet_ema_oracle::OracleError;
+use primitives::constants::chain::Weight;
+
+type AssetId = u32;
+
+parameter_types! {
+    pub const LRNAAssetId: AssetId = 1;
+}
+
+struct MockOracle;
+
+impl AggregatedPriceOracle<AssetId, u32, EmaPrice> for MockOracle {
+	type Error = OracleError;
+	fn get_price(
+		_asset_a: AssetId,
+		_asset_b: AssetId,
+		_period: OraclePeriod,
+		_source: Source,
+	) -> Result<(EmaPrice, u32), Self::Error> {
+		Ok((EmaPrice::new(u128::MAX, u128::MAX), 0))
+	}
+	fn get_price_weight() -> Weight {
+		Weight::zero()
+	}
+}
+
+type PriceProviderForRoute = OraclePriceProvider<AssetId, MockOracle, LRNAAssetId>;
+
+#[test]
+fn price_provider_should_not_overflow_when_route_contains_more_than_4_trades() {
+	let generate_route = |c| -> Vec<Trade<AssetId>> {
+		let mut r = vec![];
+		for _ in 0..c {
+			r.push(Trade {
+				pool: PoolType::Omnipool,
+				asset_in: 1,
+				asset_out: 0,
+			})
+		}
+		r
+	};
+
+	let route = generate_route(2);
+	let price = PriceProviderForRoute::price(&route, OraclePeriod::LastBlock);
+	assert_eq!(
+		price,
+		Some(EmaPrice::new(
+			340282366920938463463374607431768211452,
+			340282366920938463463374607431768211452
+		))
+	);
+
+	let route = generate_route(3);
+	let price = PriceProviderForRoute::price(&route, OraclePeriod::LastBlock);
+	assert_eq!(
+		price,
+		Some(EmaPrice::new(
+			340282366920938463463374607431768211450,
+			340282366920938463463374607431768211450
+		))
+	);
+
+	let route = generate_route(4);
+	let price = PriceProviderForRoute::price(&route, OraclePeriod::LastBlock);
+	assert_eq!(
+		price,
+		Some(EmaPrice::new(
+			340282366920938463463374607431768211448,
+			340282366920938463463374607431768211448
+		))
+	);
+
+	let route = generate_route(5);
+	let price = PriceProviderForRoute::price(&route, OraclePeriod::LastBlock);
+	assert_eq!(
+		price,
+		Some(EmaPrice::new(
+			340282366920938463463374607431768211446,
+			340282366920938463463374607431768211446
+		))
+	);
+
+	let route = generate_route(6);
+	let price = PriceProviderForRoute::price(&route, OraclePeriod::LastBlock);
+	assert_eq!(
+		price,
+		Some(EmaPrice::new(
+			340282366920938463463374607431768211444,
+			340282366920938463463374607431768211444
+		))
+	);
+
+	let route = generate_route(7);
+	let price = PriceProviderForRoute::price(&route, OraclePeriod::LastBlock);
+	assert_eq!(
+		price,
+		Some(EmaPrice::new(
+			340282366920938463463374607431768211442,
+			340282366920938463463374607431768211442
+		))
+	);
+
+	let route = generate_route(8);
+	let price = PriceProviderForRoute::price(&route, OraclePeriod::LastBlock);
+	assert_eq!(
+		price,
+		Some(EmaPrice::new(
+			340282366920938463463374607431768211440,
+			340282366920938463463374607431768211440
+		))
+	);
+
+	let route = generate_route(9);
+	let price = PriceProviderForRoute::price(&route, OraclePeriod::LastBlock);
+	assert_eq!(
+		price,
+		Some(EmaPrice::new(
+			340282366920938463463374607431768211438,
+			340282366920938463463374607431768211438
+		))
+	);
+}

--- a/runtime/adapters/src/tests/prices.rs
+++ b/runtime/adapters/src/tests/prices.rs
@@ -9,7 +9,7 @@ use primitives::constants::chain::Weight;
 type AssetId = u32;
 
 parameter_types! {
-    pub const LRNAAssetId: AssetId = 1;
+	pub const LRNAAssetId: AssetId = 1;
 }
 
 struct MockOracle;


### PR DESCRIPTION
The pr fixes potential overflow in the price provider implementation that calculates a price for given route.

if the route contains more than 4-5 trades - it may overflow.

- [x] Add unit tests