### PR TITLE
feat: hsm - account whitelisting, arb profit receiver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4674,7 +4674,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "345.0.0"
+version = "346.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -8433,7 +8433,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-hsm"
-version = "1.2.3"
+version = "1.3.0"
 dependencies = [
  "ethabi",
  "evm",
@@ -12268,7 +12268,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-integration-tests"
-version = "1.52.2"
+version = "1.52.3"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "1.52.2"
+version = "1.52.3"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/pallets/hsm/Cargo.toml
+++ b/pallets/hsm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-hsm"
-version = "1.2.3"
+version = "1.3.0"
 edition = "2021"
 description = "Hollar stability module"
 authors = ["GalacticCouncil"]

--- a/pallets/hsm/src/tests/arb.rs
+++ b/pallets/hsm/src/tests/arb.rs
@@ -123,8 +123,9 @@ fn arbitrage_should_work_when_less_hollar_in_the_pool_and_arb_amount_given() {
 			assert_eq!(arb_amount, 500_005_437_502_633_106_476);
 
 			let hsm_balance_dai_after = Tokens::free_balance(DAI, &HSM::account_id());
-			assert_eq!(hsm_balance_dai_after - hsm_balance_dai_before, arb_amount);
-			assert_eq!(hsm_balance_dai_after, arb_amount);
+			let profit = Tokens::free_balance(DAI, &HsmArbProfitReceiver::get());
+			assert_eq!(profit, 10_875_005_266_593_893);
+			assert_eq!(hsm_balance_dai_after - hsm_balance_dai_before + profit, arb_amount);
 		});
 }
 
@@ -181,8 +182,9 @@ fn arbitrage_should_work_when_less_hollar_in_the_pool() {
 			assert_eq!(arb_amount, 500_005_437_502_633_106_476);
 
 			let hsm_balance_dai_after = Tokens::free_balance(DAI, &HSM::account_id());
-			assert_eq!(hsm_balance_dai_after - hsm_balance_dai_before, arb_amount);
-			assert_eq!(hsm_balance_dai_after, arb_amount);
+			let profit = Tokens::free_balance(DAI, &HsmArbProfitReceiver::get());
+			assert_eq!(profit, 10_875_005_266_593_893);
+			assert_eq!(hsm_balance_dai_after - hsm_balance_dai_before + profit, arb_amount);
 		});
 }
 

--- a/pallets/hsm/src/tests/mock.rs
+++ b/pallets/hsm/src/tests/mock.rs
@@ -72,6 +72,7 @@ pub const CHARLIE: AccountId = AccountId::new([3; 32]);
 pub const PROVIDER: AccountId = AccountId::new([4; 32]);
 
 pub const ARB_ACCOUNT: AccountId = AccountId::new([22; 32]);
+pub const PROFIT_RECEIVER: AccountId = AccountId::new([23; 32]);
 
 pub const ONE: Balance = 1_000_000_000_000_000_000;
 
@@ -193,6 +194,7 @@ parameter_types! {
 	pub PalletId: frame_support::PalletId = frame_support::PalletId(*b"py/hsmdx");
 	pub const GasLimit: u64 = 1_000_000;
 	pub AmplificationRange: RangeInclusive<NonZeroU16> = RangeInclusive::new(NonZeroU16::new(2).unwrap(), NonZeroU16::new(10_000).unwrap());
+	pub HsmArbProfitReceiver: AccountId =  PROFIT_RECEIVER.into();
 }
 
 pub struct DummyRegistry;
@@ -554,6 +556,7 @@ impl Config for Test {
 	type WeightInfo = ();
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = for_benchmark_tests::MockHSMBenchmarkHelper;
+	type ArbitrageProfitReceiver = HsmArbProfitReceiver;
 }
 
 pub struct Whitelist;

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "345.0.0"
+version = "346.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/assets.rs
+++ b/runtime/hydradx/src/assets.rs
@@ -672,7 +672,9 @@ pub struct DustRemovalWhitelist;
 
 impl Contains<AccountId> for DustRemovalWhitelist {
 	fn contains(a: &AccountId) -> bool {
-		get_all_module_accounts().contains(a) || pallet_duster::DusterWhitelist::<Runtime>::contains(a)
+		get_all_module_accounts().contains(a)
+			|| HSM::is_flash_loan_account(a)
+			|| pallet_duster::DusterWhitelist::<Runtime>::contains(a)
 	}
 }
 
@@ -1797,6 +1799,7 @@ impl pallet_hsm::Config for Runtime {
 	type PalletId = HsmPalletId;
 	type AuthorityOrigin = EitherOf<EnsureRoot<Self::AccountId>, EitherOf<EconomicParameters, GeneralAdmin>>;
 	type GhoContractAddress = AssetRegistry;
+	type ArbitrageProfitReceiver = TreasuryAccount;
 	type Currency = FungibleCurrencies<Runtime>;
 	#[cfg(feature = "runtime-benchmarks")]
 	type Evm = helpers::benchmark_helpers::DummyEvmForHsm;

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -120,7 +120,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 345,
+	spec_version: 346,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -142,6 +142,7 @@ pub fn get_all_module_accounts() -> Vec<AccountId> {
 		VestingPalletId::get().into_account_truncating(),
 		ReferralsPalletId::get().into_account_truncating(),
 		BondsPalletId::get().into_account_truncating(),
+		HsmPalletId::get().into_account_truncating(),
 		pallet_route_executor::Pallet::<Runtime>::router_account(),
 	]
 }


### PR DESCRIPTION
this pr adds minor improvement to hsm:

1. Arbitrage profit now transferred to given ArbitrageProfitReceiver - set to Treasury 
2. HSm account and loan receiver account are whitelisted, so it is not dusted.
3. Added additional info to ArbitrageExecuted event. 