### PR TITLE
feat: make aave executor safe again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4674,7 +4674,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "347.0.0"
+version = "348.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "347.0.0"
+version = "348.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/evm/aave_trade_executor.rs
+++ b/runtime/hydradx/src/evm/aave_trade_executor.rs
@@ -7,6 +7,7 @@ use crate::{Runtime, Vec};
 use codec::{Decode, Encode, MaxEncodedLen};
 use ethabi::{decode, ParamType};
 use evm::ExitReason::Succeed;
+use evm::ExitSucceed;
 use frame_support::dispatch::DispatchResult;
 use frame_support::ensure;
 use frame_support::pallet_prelude::TypeInfo;
@@ -185,7 +186,7 @@ where
 		let (res, reserves_data) = Executor::<T>::view(context, data, VIEW_GAS_LIMIT);
 
 		ensure!(
-			matches!(res, Succeed(_)),
+			matches!(res, Succeed(ExitSucceed::Returned)),
 			ExecutorError::Error("Failed to get reserves list".into())
 		);
 
@@ -194,6 +195,9 @@ where
 
 		let decoded = decode(&param_types, reserves_data.as_ref())
 			.map_err(|_| ExecutorError::Error("Failed to decode reserves list".into()))?;
+
+		// ensure sufficient length
+		ensure!(decoded.len() >= 1, ExecutorError::Error("Empty reserve list".into()));
 
 		// Convert decoded addresses to EvmAddress format
 		let addresses = decoded[0]
@@ -217,7 +221,7 @@ where
 		let (res, reserve_data) = Executor::<T>::view(context, data, VIEW_GAS_LIMIT);
 
 		ensure!(
-			matches!(res, Succeed(_)),
+			matches!(res, Succeed(ExitSucceed::Returned)),
 			ExecutorError::Error("Failed to get reserve data".into())
 		);
 
@@ -239,6 +243,12 @@ where
 
 		let decoded = decode(&param_types, reserve_data.as_ref())
 			.map_err(|_| ExecutorError::Error("Failed to decode reserve data".into()))?;
+
+		// Ensure sufficient length
+		ensure!(
+			decoded.len() >= param_types.len(),
+			ExecutorError::Error("Invalid reserve data format".into())
+		);
 
 		Ok(ReserveData {
 			configuration: decoded[0].clone().into_uint().unwrap_or_default(),
@@ -272,7 +282,7 @@ where
 		let data = EvmDataWriter::new_with_selector(Function::ScaledTotalSupply).build();
 		let (res, value) = Executor::<T>::view(context, data, VIEW_GAS_LIMIT);
 		ensure!(
-			matches!(res, Succeed(_)),
+			matches!(res, Succeed(ExitSucceed::Returned)),
 			ExecutorError::Error("Failed to get scaled total supply".into())
 		);
 		U256::checked_from(value.as_slice()).ok_or(ExecutorError::Error("Failed to decode scaled total supply".into()))
@@ -291,7 +301,7 @@ where
 
 		let (res, value) = Executor::<T>::view(context, data, VIEW_GAS_LIMIT);
 
-		if !matches!(res, Succeed(_)) {
+		if !matches!(res, Succeed(ExitSucceed::Returned)) {
 			// not a token
 			return None;
 		}

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -120,7 +120,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 347,
+	spec_version: 348,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
This PR only makes the aave executor safer, by ensurng correct vec lengths and return values.