### PR TITLE
feat: Add XCM aliasers to the runtime

### DIFF
--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -42,6 +42,7 @@ mod utility;
 pub mod utils;
 mod vesting;
 mod xcm;
+mod xcm_aliasers;
 mod xyk;
 mod xyk_liquidity_mining;
 

--- a/integration-tests/src/xcm_aliasers.rs
+++ b/integration-tests/src/xcm_aliasers.rs
@@ -1,0 +1,95 @@
+#![cfg(test)]
+use crate::polkadot_test_net::*;
+use polkadot_xcm::v4::prelude::*;
+
+#[test]
+fn aliasing_child_locations() {
+	Hydra::execute_with(|| {
+		// Allows aliasing descendant of origin.
+		let origin = Location::new(1, X1([PalletInstance(8)].into()));
+		let target = Location::new(1, X2([PalletInstance(8), GeneralIndex(9)].into()));
+		assert!(<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let origin = Location::new(1, X1([Parachain(8)].into()));
+		let target = Location::new(
+			1,
+			X2([Parachain(8), AccountId32 { network: None, id: [1u8; 32] }].into()),
+		);
+		assert!(<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let origin = Location::new(1, X1([Parachain(8)].into()));
+		let target =
+			Location::new(1, X3([Parachain(8), PalletInstance(8), GeneralIndex(9)].into()));
+		assert!(<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+
+		// Does not allow if not descendant.
+		let origin = Location::new(1, X1([PalletInstance(8)].into()));
+		let target = Location::new(0, X2([PalletInstance(8), GeneralIndex(9)].into()));
+		assert!(!<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let origin = Location::new(1, X1([Parachain(8)].into()));
+		let target = Location::new(
+			0,
+			X2([Parachain(8), AccountId32 { network: None, id: [1u8; 32] }].into()),
+		);
+		assert!(!<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let origin = Location::new(1, X1([Parachain(8)].into()));
+		let target = Location::new(0, X1([AccountId32 { network: None, id: [1u8; 32] }].into()));
+		assert!(!<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let origin = Location::new(1, X1([AccountId32 { network: None, id: [1u8; 32] }].into()));
+		let target = Location::new(0, X1([AccountId32 { network: None, id: [1u8; 32] }].into()));
+		assert!(!<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+	});
+}
+
+#[test]
+fn asset_hub_root_aliases_anything() {
+	Hydra::execute_with(|| {
+		// Allows AH root to alias anything.
+		let origin = Location::new(1, X1([Parachain(1000)].into()));
+
+		let target = Location::new(1, X1([Parachain(2000)].into()));
+		assert!(<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let target = Location::new(1, X1([AccountId32 { network: None, id: [1u8; 32] }].into()));
+		assert!(<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let target = Location::new(
+			1,
+			X2([Parachain(8), AccountId32 { network: None, id: [1u8; 32] }].into()),
+		);
+		assert!(<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let target =
+			Location::new(1, X3([Parachain(42), PalletInstance(8), GeneralIndex(9)].into()));
+		assert!(<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let target = Location::new(2, X1([GlobalConsensus(Ethereum { chain_id: 1 })].into()));
+		assert!(<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let target = Location::new(2, X2([GlobalConsensus(Kusama), Parachain(1000)].into()));
+		assert!(<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let target = Location::new(0, X2([PalletInstance(8), GeneralIndex(9)].into()));
+		assert!(<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+
+		// Other AH locations cannot alias anything.
+		let origin = Location::new(1, X2([Parachain(1000), GeneralIndex(9)].into()));
+		assert!(!<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let origin = Location::new(1, X2([Parachain(1000), PalletInstance(9)].into()));
+		assert!(!<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let origin = Location::new(
+			1,
+			X2([Parachain(1000), AccountId32 { network: None, id: [1u8; 32] }].into()),
+		);
+		assert!(!<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+
+		// Other root locations cannot alias anything.
+		let origin = Location::new(1, Here);
+		let target = Location::new(2, X1([GlobalConsensus(Ethereum { chain_id: 1 })].into()));
+		assert!(!<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let target = Location::new(2, X2([GlobalConsensus(Kusama), Parachain(1000)].into()));
+		assert!(!<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let target = Location::new(0, X2([PalletInstance(8), GeneralIndex(9)].into()));
+		assert!(!<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+
+		let origin = Location::new(0, Here);
+		let target = Location::new(1, X1([Parachain(2000)].into()));
+		assert!(!<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let origin = Location::new(1, X1([Parachain(1001)].into()));
+		assert!(!<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let origin = Location::new(1, X1([Parachain(1002)].into()));
+		assert!(!<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+	});
+}


### PR DESCRIPTION
## Description

Right now, the relay can basically act as any other parachain via XCM using `DescendOrigin`, since it's the parent location of all parachains. This is useful when we want an OpenGov proposal to perform actions on multiple chains' sovereign accounts.
With the upcoming Asset Hub Migration, OpenGov changes location and this no longer works. A way to make an OpenGov proposal on Asset Hub act on multiple chains' sovereign accounts, we can introduce the suggested aliasers from [RFC#122](https://github.com/polkadot-fellows/RFCs/blob/main/text/0122-alias-origin-on-asset-transfers.md#suggested-aliasing-rules).

## Related Issue

https://github.com/galacticcouncil/hydration-node/issues/1225

## Motivation and Context

These aliasers are a suggestion since XCMv5 was released. As well as fixing the issues mentioned in the description, it will also allow doing cross-chain transfers and `Transact` in the same message once XCMv5 is supported by the chain.
It's a necessary step in making cross-chain interactions more seamless.

## How Has This Been Tested?

I've created tests in `integration-tests`. These thoroughly test the new `Aliasers` type to see what can alias into what.

## Checklist:
- [x] I have updated the documentation if necessary.
- [x] I have added tests to cover my changes, regression test if fixing an issue.
