### PR TITLE
fix: use AssetHub as reserve for xtokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5535,7 +5535,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "357.0.0"
+version = "358.0.0"
 dependencies = [
  "alloy-primitives 0.7.7",
  "alloy-sol-types 0.7.7",

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "357.0.0"
+version = "358.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -122,7 +122,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 357,
+	spec_version: 358,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/hydradx/src/xcm.rs
+++ b/runtime/hydradx/src/xcm.rs
@@ -399,6 +399,25 @@ parameter_type_with_key! {
 	};
 }
 
+pub struct CustomReserveProvider;
+impl orml_traits::location::Reserve for CustomReserveProvider {
+	fn reserve(asset: &Asset) -> Option<Location> {
+		if let Asset {
+			id: AssetId(location),
+			fun: Fungible(_),
+		} = asset
+		{
+			if location.parents == 1 && location.interior == Here {
+				// Use Asset Hub as reserve for DOT
+				return Some(AssetHubLocation::get());
+			}
+		}
+
+		// For all other assets, use absolute reserve provider
+		AbsoluteReserveProvider::reserve(asset)
+	}
+}
+
 impl orml_xtokens::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Balance = Balance;
@@ -411,7 +430,7 @@ impl orml_xtokens::Config for Runtime {
 	type BaseXcmWeight = BaseXcmWeight;
 	type MaxAssetsForTransfer = MaxAssetsForTransfer;
 	type LocationsFilter = Everything;
-	type ReserveProvider = AbsoluteReserveProvider;
+	type ReserveProvider = CustomReserveProvider;
 	type MinXcmFee = ParachainMinFee;
 	type UniversalLocation = UniversalLocation;
 	type RateLimiter = (); // do not use rate limiter


### PR DESCRIPTION
This PR sets AssetHub as ReserveProvider for DOT in orml_xtokens