### PR TITLE
ICE: pallet ice rewrite validate_price_consistency funtion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10572,6 +10572,7 @@ dependencies = [
  "ice-solver",
  "ice-support",
  "log",
+ "num-traits",
  "orml-tokens",
  "orml-traits",
  "pallet-broadcast",

--- a/pallets/ice/Cargo.toml
+++ b/pallets/ice/Cargo.toml
@@ -19,8 +19,9 @@ log = { workspace = true}
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 sp-core = { workspace = true }
-sp-runtime-interface = {workspace = true}
-sp-externalities = {workspace = true}
+sp-runtime-interface = { workspace = true}
+sp-externalities = { workspace = true}
+num-traits = { workspace = true }
 
 # FRAME
 frame-support = { workspace = true }
@@ -73,6 +74,7 @@ std = [
     "ice-support/std",
     "ice-solver/std",
     "amm-simulator/std",
+    "num-traits/std",
 ]
 
 runtime-benchmarks = [

--- a/pallets/ice/src/tests/mock.rs
+++ b/pallets/ice/src/tests/mock.rs
@@ -248,6 +248,7 @@ impl pallet_broadcast::Config for Test {
 
 parameter_types! {
 	pub const IceId: PalletId = PalletId(*b"iceTest#");
+	pub const BuySellTolerance: Permill = Permill::from_percent(1);
 }
 
 impl pallet_ice::Config for Test {
@@ -257,6 +258,7 @@ impl pallet_ice::Config for Test {
 	type RegistryHandler = DummyRegistry;
 	type BlockNumberProvider = System;
 	type Simulator = TestSimulatorConfig;
+	type BuyVsSellPriceTolerance = BuySellTolerance;
 	type WeightInfo = ();
 }
 

--- a/pallets/ice/src/tests/mod.rs
+++ b/pallets/ice/src/tests/mod.rs
@@ -5,6 +5,7 @@ use pretty_assertions::assert_eq;
 mod mock;
 mod ocw;
 mod submit_solution;
+mod validate_price_consistency;
 
 fn prices_to_map(prices: Vec<(AssetId, Price)>) -> sp_std::collections::btree_map::BTreeMap<AssetId, Price> {
 	let mut cp: BTreeMap<AssetId, Price> = BTreeMap::new();

--- a/pallets/ice/src/tests/ocw.rs
+++ b/pallets/ice/src/tests/ocw.rs
@@ -2173,3 +2173,341 @@ fn validate_unsingned_should_not_work_when_solution_have_intent_with_amount_out_
 			);
 		});
 }
+
+#[test]
+fn validate_unsigned_should_not_work_when_execution_prices_are_not_consistent() {
+	ExtBuilder::default()
+		.with_endowed_accounts(vec![
+			(ALICE, HDX, 10_000 * ONE_HDX),
+			(ALICE, DOT, 10_000 * ONE_DOT),
+			(BOB, HDX, 10_000 * ONE_HDX),
+			(BOB, ETH, 10_000 * ONE_QUINTIL),
+			(DAVE, HDX, 20_000 * ONE_HDX),
+			(DAVE, DOT, 20_000 * ONE_DOT),
+		])
+		.with_intents(vec![
+			(
+				ALICE,
+				Intent {
+					data: IntentData::Swap(SwapData {
+						asset_in: HDX,
+						asset_out: DOT,
+						amount_in: 5_000 * ONE_HDX,
+						amount_out: 4 * ONE_DOT,
+						swap_type: SwapType::ExactIn,
+						partial: false,
+					}),
+					deadline: MAX_INTENT_DEADLINE - ONE_SECOND,
+					on_success: None,
+					on_failure: None,
+				},
+			),
+			(
+				DAVE,
+				Intent {
+					data: IntentData::Swap(SwapData {
+						asset_in: HDX,
+						asset_out: DOT,
+						amount_in: 10_000 * ONE_HDX,
+						amount_out: 8 * ONE_DOT,
+						swap_type: SwapType::ExactOut,
+						partial: false,
+					}),
+					deadline: MAX_INTENT_DEADLINE - ONE_SECOND,
+					on_success: None,
+					on_failure: None,
+				},
+			),
+			(
+				BOB,
+				Intent {
+					data: IntentData::Swap(SwapData {
+						asset_in: ETH,
+						asset_out: HDX,
+						amount_in: ONE_QUINTIL,
+						amount_out: 16_000_000 * ONE_HDX,
+						swap_type: SwapType::ExactOut,
+						partial: false,
+					}),
+					deadline: MAX_INTENT_DEADLINE - ONE_SECOND,
+					on_success: None,
+					on_failure: None,
+				},
+			),
+		])
+		.build()
+		.execute_with(|| {
+			let resolved = vec![
+				ResolvedIntent {
+					id: 73786976294838206464002_u128,
+					data: IntentData::Swap(SwapData {
+						asset_in: ETH,
+						asset_out: HDX,
+						amount_in: 500000000000000000,
+						amount_out: 16_000_000 * ONE_HDX,
+						swap_type: SwapType::ExactOut,
+						partial: false,
+					}),
+				},
+				ResolvedIntent {
+					id: 73786976294838206464001_u128,
+					data: IntentData::Swap(SwapData {
+						asset_in: HDX,
+						asset_out: DOT,
+						amount_in: 10_000 * ONE_HDX,
+						amount_out: 8 * ONE_DOT,
+						swap_type: SwapType::ExactOut,
+						partial: false,
+					}),
+				},
+				ResolvedIntent {
+					id: 73786976294838206464000_u128,
+					data: IntentData::Swap(SwapData {
+						asset_in: HDX,
+						asset_out: DOT,
+						amount_in: 5_000 * ONE_HDX,
+						amount_out: 6 * ONE_DOT,
+						swap_type: SwapType::ExactIn,
+						partial: false,
+					}),
+				},
+			];
+
+			let trades = vec![
+				PoolTrade {
+					amount_in: 15_000 * ONE_HDX,
+					amount_out: 12 * ONE_DOT,
+					direction: SwapType::ExactIn,
+					route: vec![RTrade {
+						pool: PoolType::XYK,
+						asset_in: HDX,
+						asset_out: DOT,
+					}]
+					.try_into()
+					.unwrap(),
+				},
+				PoolTrade {
+					amount_in: ONE_QUINTIL / 2,
+					amount_out: 16_000_000 * ONE_HDX,
+					direction: SwapType::ExactOut,
+					route: vec![RTrade {
+						pool: PoolType::Omnipool,
+						asset_in: ETH,
+						asset_out: HDX,
+					}]
+					.try_into()
+					.unwrap(),
+				},
+			];
+
+			let cp = prices_to_map(vec![
+				(
+					HDX,
+					Price {
+						n: 177,
+						d: 100_000_000_000_000,
+					},
+				),
+				(
+					DOT,
+					Price {
+						n: 177,
+						d: 1_000_000_000,
+					},
+				),
+				(
+					ETH,
+					Price {
+						n: 177,
+						d: 3_125_000_000_000,
+					},
+				),
+			]);
+
+			let s = Solution {
+				resolved_intents: resolved.try_into().unwrap(),
+				trades: trades.try_into().unwrap(),
+				clearing_prices: cp,
+				score: 500_000_030_000_000_000_u128,
+			};
+
+			let call = Call::submit_solution {
+				solution: s,
+				valid_for_block: 2,
+			};
+
+			assert_noop!(
+				ICE::validate_unsigned(TransactionSource::Local, &call),
+				TransactionValidityError::Invalid(InvalidTransaction::Call)
+			);
+		});
+}
+
+#[test]
+fn validate_unsigned_should_not_work_when_intent_is_not_resolved_at_execution_price() {
+	ExtBuilder::default()
+		.with_endowed_accounts(vec![
+			(ALICE, HDX, 10_000 * ONE_HDX),
+			(ALICE, DOT, 10_000 * ONE_DOT),
+			(BOB, HDX, 10_000 * ONE_HDX),
+			(BOB, ETH, 10_000 * ONE_QUINTIL),
+			(DAVE, HDX, 20_000 * ONE_HDX),
+			(DAVE, DOT, 20_000 * ONE_DOT),
+		])
+		.with_intents(vec![
+			(
+				ALICE,
+				Intent {
+					data: IntentData::Swap(SwapData {
+						asset_in: HDX,
+						asset_out: DOT,
+						amount_in: 5_000 * ONE_HDX,
+						amount_out: 4 * ONE_DOT,
+						swap_type: SwapType::ExactIn,
+						partial: false,
+					}),
+					deadline: MAX_INTENT_DEADLINE - ONE_SECOND,
+					on_success: None,
+					on_failure: None,
+				},
+			),
+			(
+				DAVE,
+				Intent {
+					data: IntentData::Swap(SwapData {
+						asset_in: HDX,
+						asset_out: DOT,
+						amount_in: 10_000 * ONE_HDX,
+						amount_out: 8 * ONE_DOT,
+						swap_type: SwapType::ExactIn,
+						partial: false,
+					}),
+					deadline: MAX_INTENT_DEADLINE - ONE_SECOND,
+					on_success: None,
+					on_failure: None,
+				},
+			),
+			(
+				BOB,
+				Intent {
+					data: IntentData::Swap(SwapData {
+						asset_in: ETH,
+						asset_out: HDX,
+						amount_in: ONE_QUINTIL,
+						amount_out: 16_000_000 * ONE_HDX,
+						swap_type: SwapType::ExactOut,
+						partial: false,
+					}),
+					deadline: MAX_INTENT_DEADLINE - ONE_SECOND,
+					on_success: None,
+					on_failure: None,
+				},
+			),
+		])
+		.build()
+		.execute_with(|| {
+			let resolved = vec![
+				ResolvedIntent {
+					id: 73786976294838206464002_u128,
+					data: IntentData::Swap(SwapData {
+						asset_in: ETH,
+						asset_out: HDX,
+						amount_in: 500000000000000000,
+						amount_out: 16_000_000 * ONE_HDX,
+						swap_type: SwapType::ExactOut,
+						partial: false,
+					}),
+				},
+				ResolvedIntent {
+					id: 73786976294838206464001_u128,
+					data: IntentData::Swap(SwapData {
+						asset_in: HDX,
+						asset_out: DOT,
+						amount_in: 10_000 * ONE_HDX,
+						amount_out: 10 * ONE_DOT,
+						swap_type: SwapType::ExactIn,
+						partial: false,
+					}),
+				},
+				ResolvedIntent {
+					id: 73786976294838206464000_u128,
+					data: IntentData::Swap(SwapData {
+						asset_in: HDX,
+						asset_out: DOT,
+						amount_in: 5_000 * ONE_HDX,
+						amount_out: 6 * ONE_DOT,
+						swap_type: SwapType::ExactIn,
+						partial: false,
+					}),
+				},
+			];
+
+			let trades = vec![
+				PoolTrade {
+					amount_in: 15_000 * ONE_HDX,
+					amount_out: 12 * ONE_DOT,
+					direction: SwapType::ExactIn,
+					route: vec![RTrade {
+						pool: PoolType::XYK,
+						asset_in: HDX,
+						asset_out: DOT,
+					}]
+					.try_into()
+					.unwrap(),
+				},
+				PoolTrade {
+					amount_in: ONE_QUINTIL / 2,
+					amount_out: 16_000_000 * ONE_HDX,
+					direction: SwapType::ExactOut,
+					route: vec![RTrade {
+						pool: PoolType::Omnipool,
+						asset_in: ETH,
+						asset_out: HDX,
+					}]
+					.try_into()
+					.unwrap(),
+				},
+			];
+
+			let cp = prices_to_map(vec![
+				(
+					HDX,
+					Price {
+						n: 177,
+						d: 100_000_000_000_000,
+					},
+				),
+				(
+					DOT,
+					Price {
+						n: 177,
+						d: 1_000_000_000,
+					},
+				),
+				(
+					ETH,
+					Price {
+						n: 177,
+						d: 3_125_000_000_000,
+					},
+				),
+			]);
+
+			let s = Solution {
+				resolved_intents: resolved.try_into().unwrap(),
+				trades: trades.try_into().unwrap(),
+				clearing_prices: cp,
+				score: 500_000_030_000_000_000_u128,
+			};
+
+			let call = Call::submit_solution {
+				solution: s,
+				valid_for_block: 2,
+			};
+
+			assert_noop!(
+				ICE::validate_unsigned(TransactionSource::Local, &call),
+				TransactionValidityError::Invalid(InvalidTransaction::Call)
+			);
+		});
+}

--- a/pallets/ice/src/tests/submit_solution.rs
+++ b/pallets/ice/src/tests/submit_solution.rs
@@ -375,7 +375,7 @@ fn solution_execution_should_not_work_when_score_is_not_valid() {
 		});
 }
 
-#[ignore = "This is temporarily, unignore when allowing clearing price validtion again"]
+#[ignore = "This is temporary, unignore when allowing clearing price validation again"]
 #[test]
 fn solution_execution_should_not_work_when_clearing_price_is_missing() {
 	ExtBuilder::default()
@@ -2260,6 +2260,370 @@ fn solution_execution_should_not_work_when_solution_have_intent_with_amount_out_
 			assert_noop!(
 				ICE::submit_solution(RuntimeOrigin::none(), s, 1),
 				Error::<Test>::InvalidAmount
+			);
+		});
+}
+
+#[test]
+fn solution_execution_should_not_work_when_intent_is_not_resolved_at_execution_price() {
+	ExtBuilder::default()
+		.with_endowed_accounts(vec![
+			(ALICE, HDX, 10_000 * ONE_HDX),
+			(ALICE, DOT, 10_000 * ONE_DOT),
+			(BOB, HDX, 10_000 * ONE_HDX),
+			(BOB, ETH, 10_000 * ONE_QUINTIL),
+			(DAVE, HDX, 20_000 * ONE_HDX),
+			(DAVE, DOT, 20_000 * ONE_DOT),
+		])
+		.with_intents(vec![
+			(
+				ALICE,
+				Intent {
+					data: IntentData::Swap(SwapData {
+						asset_in: HDX,
+						asset_out: DOT,
+						amount_in: 5_000 * ONE_HDX,
+						amount_out: 4 * ONE_DOT,
+						swap_type: SwapType::ExactIn,
+						partial: false,
+					}),
+					deadline: MAX_INTENT_DEADLINE - ONE_SECOND,
+					on_success: None,
+					on_failure: None,
+				},
+			),
+			(
+				DAVE,
+				Intent {
+					data: IntentData::Swap(SwapData {
+						asset_in: HDX,
+						asset_out: DOT,
+						amount_in: 10_000 * ONE_HDX,
+						amount_out: 8 * ONE_DOT,
+						swap_type: SwapType::ExactIn,
+						partial: false,
+					}),
+					deadline: MAX_INTENT_DEADLINE - ONE_SECOND,
+					on_success: None,
+					on_failure: None,
+				},
+			),
+			(
+				BOB,
+				Intent {
+					data: IntentData::Swap(SwapData {
+						asset_in: ETH,
+						asset_out: HDX,
+						amount_in: ONE_QUINTIL,
+						amount_out: 16_000_000 * ONE_HDX,
+						swap_type: SwapType::ExactOut,
+						partial: false,
+					}),
+					deadline: MAX_INTENT_DEADLINE - ONE_SECOND,
+					on_success: None,
+					on_failure: None,
+				},
+			),
+		])
+		.with_router_settlement(
+			SwapType::ExactIn,
+			PoolType::XYK,
+			HDX,
+			DOT,
+			15_000 * ONE_HDX,
+			15_000 * ONE_HDX,
+			16 * ONE_DOT,
+		)
+		.with_router_settlement(
+			SwapType::ExactOut,
+			PoolType::Omnipool,
+			ETH,
+			HDX,
+			16_000_000 * ONE_HDX,
+			ONE_QUINTIL / 2,
+			16_000_000 * ONE_HDX,
+		)
+		.build()
+		.execute_with(|| {
+			let resolved = vec![
+				ResolvedIntent {
+					id: 73786976294838206464002_u128,
+					data: IntentData::Swap(SwapData {
+						asset_in: ETH,
+						asset_out: HDX,
+						amount_in: 500000000000000000,
+						amount_out: 16_000_000 * ONE_HDX,
+						swap_type: SwapType::ExactOut,
+						partial: false,
+					}),
+				},
+				ResolvedIntent {
+					id: 73786976294838206464001_u128,
+					data: IntentData::Swap(SwapData {
+						asset_in: HDX,
+						asset_out: DOT,
+						amount_in: 10_000 * ONE_HDX,
+						amount_out: 10 * ONE_DOT,
+						swap_type: SwapType::ExactIn,
+						partial: false,
+					}),
+				},
+				ResolvedIntent {
+					id: 73786976294838206464000_u128,
+					data: IntentData::Swap(SwapData {
+						asset_in: HDX,
+						asset_out: DOT,
+						amount_in: 5_000 * ONE_HDX,
+						amount_out: 6 * ONE_DOT,
+						swap_type: SwapType::ExactIn,
+						partial: false,
+					}),
+				},
+			];
+
+			let trades = vec![
+				PoolTrade {
+					amount_in: 15_000 * ONE_HDX,
+					amount_out: 12 * ONE_DOT,
+					direction: SwapType::ExactIn,
+					route: vec![RTrade {
+						pool: PoolType::XYK,
+						asset_in: HDX,
+						asset_out: DOT,
+					}]
+					.try_into()
+					.unwrap(),
+				},
+				PoolTrade {
+					amount_in: ONE_QUINTIL / 2,
+					amount_out: 16_000_000 * ONE_HDX,
+					direction: SwapType::ExactOut,
+					route: vec![RTrade {
+						pool: PoolType::Omnipool,
+						asset_in: ETH,
+						asset_out: HDX,
+					}]
+					.try_into()
+					.unwrap(),
+				},
+			];
+
+			let cp = prices_to_map(vec![
+				(
+					HDX,
+					Price {
+						n: 177,
+						d: 100_000_000_000_000,
+					},
+				),
+				(
+					DOT,
+					Price {
+						n: 177,
+						d: 1_000_000_000,
+					},
+				),
+				(
+					ETH,
+					Price {
+						n: 177,
+						d: 3_125_000_000_000,
+					},
+				),
+			]);
+
+			let s = Solution {
+				resolved_intents: resolved.try_into().unwrap(),
+				trades: trades.try_into().unwrap(),
+				clearing_prices: cp,
+				score: 500_000_030_000_000_000_u128,
+			};
+
+			assert_noop!(
+				ICE::submit_solution(RuntimeOrigin::none(), s, 1),
+				Error::<Test>::PriceInconsistency
+			);
+		});
+}
+
+#[test]
+fn solution_execution_should_not_work_when_execution_prices_are_not_consistent() {
+	ExtBuilder::default()
+		.with_endowed_accounts(vec![
+			(ALICE, HDX, 10_000 * ONE_HDX),
+			(ALICE, DOT, 10_000 * ONE_DOT),
+			(BOB, HDX, 10_000 * ONE_HDX),
+			(BOB, ETH, 10_000 * ONE_QUINTIL),
+			(DAVE, HDX, 20_000 * ONE_HDX),
+			(DAVE, DOT, 20_000 * ONE_DOT),
+		])
+		.with_intents(vec![
+			(
+				ALICE,
+				Intent {
+					data: IntentData::Swap(SwapData {
+						asset_in: HDX,
+						asset_out: DOT,
+						amount_in: 5_000 * ONE_HDX,
+						amount_out: 4 * ONE_DOT,
+						swap_type: SwapType::ExactIn,
+						partial: false,
+					}),
+					deadline: MAX_INTENT_DEADLINE - ONE_SECOND,
+					on_success: None,
+					on_failure: None,
+				},
+			),
+			(
+				DAVE,
+				Intent {
+					data: IntentData::Swap(SwapData {
+						asset_in: HDX,
+						asset_out: DOT,
+						amount_in: 10_000 * ONE_HDX,
+						amount_out: 8 * ONE_DOT,
+						swap_type: SwapType::ExactOut,
+						partial: false,
+					}),
+					deadline: MAX_INTENT_DEADLINE - ONE_SECOND,
+					on_success: None,
+					on_failure: None,
+				},
+			),
+			(
+				BOB,
+				Intent {
+					data: IntentData::Swap(SwapData {
+						asset_in: ETH,
+						asset_out: HDX,
+						amount_in: ONE_QUINTIL,
+						amount_out: 16_000_000 * ONE_HDX,
+						swap_type: SwapType::ExactOut,
+						partial: false,
+					}),
+					deadline: MAX_INTENT_DEADLINE - ONE_SECOND,
+					on_success: None,
+					on_failure: None,
+				},
+			),
+		])
+		.with_router_settlement(
+			SwapType::ExactIn,
+			PoolType::XYK,
+			HDX,
+			DOT,
+			15_000 * ONE_HDX,
+			15_000 * ONE_HDX,
+			16 * ONE_DOT,
+		)
+		.with_router_settlement(
+			SwapType::ExactOut,
+			PoolType::Omnipool,
+			ETH,
+			HDX,
+			16_000_000 * ONE_HDX,
+			ONE_QUINTIL / 2,
+			16_000_000 * ONE_HDX,
+		)
+		.build()
+		.execute_with(|| {
+			let resolved = vec![
+				ResolvedIntent {
+					id: 73786976294838206464002_u128,
+					data: IntentData::Swap(SwapData {
+						asset_in: ETH,
+						asset_out: HDX,
+						amount_in: 500000000000000000,
+						amount_out: 16_000_000 * ONE_HDX,
+						swap_type: SwapType::ExactOut,
+						partial: false,
+					}),
+				},
+				ResolvedIntent {
+					id: 73786976294838206464001_u128,
+					data: IntentData::Swap(SwapData {
+						asset_in: HDX,
+						asset_out: DOT,
+						amount_in: 10_000 * ONE_HDX,
+						amount_out: 8 * ONE_DOT,
+						swap_type: SwapType::ExactOut,
+						partial: false,
+					}),
+				},
+				ResolvedIntent {
+					id: 73786976294838206464000_u128,
+					data: IntentData::Swap(SwapData {
+						asset_in: HDX,
+						asset_out: DOT,
+						amount_in: 5_000 * ONE_HDX,
+						amount_out: 6 * ONE_DOT,
+						swap_type: SwapType::ExactIn,
+						partial: false,
+					}),
+				},
+			];
+
+			let trades = vec![
+				PoolTrade {
+					amount_in: 15_000 * ONE_HDX,
+					amount_out: 12 * ONE_DOT,
+					direction: SwapType::ExactIn,
+					route: vec![RTrade {
+						pool: PoolType::XYK,
+						asset_in: HDX,
+						asset_out: DOT,
+					}]
+					.try_into()
+					.unwrap(),
+				},
+				PoolTrade {
+					amount_in: ONE_QUINTIL / 2,
+					amount_out: 16_000_000 * ONE_HDX,
+					direction: SwapType::ExactOut,
+					route: vec![RTrade {
+						pool: PoolType::Omnipool,
+						asset_in: ETH,
+						asset_out: HDX,
+					}]
+					.try_into()
+					.unwrap(),
+				},
+			];
+
+			let cp = prices_to_map(vec![
+				(
+					HDX,
+					Price {
+						n: 177,
+						d: 100_000_000_000_000,
+					},
+				),
+				(
+					DOT,
+					Price {
+						n: 177,
+						d: 1_000_000_000,
+					},
+				),
+				(
+					ETH,
+					Price {
+						n: 177,
+						d: 3_125_000_000_000,
+					},
+				),
+			]);
+
+			let s = Solution {
+				resolved_intents: resolved.try_into().unwrap(),
+				trades: trades.try_into().unwrap(),
+				clearing_prices: cp,
+				score: 500_000_030_000_000_000_u128,
+			};
+
+			assert_noop!(
+				ICE::submit_solution(RuntimeOrigin::none(), s, 1),
+				Error::<Test>::PriceToleranceInconsistency
 			);
 		});
 }

--- a/pallets/ice/src/tests/validate_price_consistency.rs
+++ b/pallets/ice/src/tests/validate_price_consistency.rs
@@ -1,0 +1,281 @@
+use crate::tests::mock::*;
+use crate::*;
+use frame_support::assert_err;
+use frame_support::assert_ok;
+use ice_support::AssetId;
+use ice_support::Price;
+use ice_support::SwapData;
+use ice_support::SwapType;
+use num_traits::SaturatingAdd;
+use pretty_assertions::assert_eq;
+use sp_std::collections::btree_map::BTreeMap;
+
+#[test]
+fn should_work_when_price_wasnt_computed_yet_and_reverse_price_is_missing() {
+	let asset_in = HDX;
+	let asset_out = DOT;
+	let swap_type = SwapType::ExactIn;
+	let amount_in = 100 * ONE_HDX;
+	let amount_out = 200 * ONE_DOT;
+
+	let resolve = IntentData::Swap(SwapData {
+		asset_in,
+		asset_out,
+		amount_in,
+		amount_out,
+		swap_type,
+		partial: false,
+	});
+
+	let mut exec_prices: BTreeMap<(AssetId, AssetId, SwapType), Price> = BTreeMap::new();
+	assert_ok!(ICE::validate_price_consitency(&mut exec_prices, &resolve));
+
+	assert_eq!(
+		*exec_prices
+			.get(&(asset_in, asset_out, swap_type))
+			.expect("excution price to exists"),
+		Ratio::new(amount_out, amount_in)
+	);
+
+	let swap_type = SwapType::ExactOut;
+	let resolve = IntentData::Swap(SwapData {
+		asset_in,
+		asset_out,
+		amount_in,
+		amount_out,
+		swap_type,
+		partial: false,
+	});
+
+	let mut exec_prices: BTreeMap<(AssetId, AssetId, SwapType), Price> = BTreeMap::new();
+	assert_ok!(ICE::validate_price_consitency(&mut exec_prices, &resolve));
+
+	assert_eq!(
+		*exec_prices
+			.get(&(asset_in, asset_out, swap_type))
+			.expect("excution price to exists"),
+		Ratio::new(amount_out, amount_in)
+	);
+}
+
+#[test]
+fn should_work_when_computes_new_price_and_is_within_price_tolerance_or_reverse_trade() {
+	let asset_in = HDX;
+	let asset_out = DOT;
+	let swap_type = SwapType::ExactIn;
+	let amount_in = 100 * ONE_HDX;
+	let amount_out = 200 * ONE_DOT;
+
+	//Compute new exactIn price
+	let resolve = IntentData::Swap(SwapData {
+		asset_in,
+		asset_out,
+		amount_in,
+		amount_out,
+		swap_type,
+		partial: false,
+	});
+
+	let mut exec_prices: BTreeMap<(AssetId, AssetId, SwapType), Price> = BTreeMap::new();
+	exec_prices.insert(
+		(asset_in, asset_out, swap_type.reverse()),
+		Ratio::new(amount_out, amount_in),
+	);
+
+	assert_ok!(ICE::validate_price_consitency(&mut exec_prices, &resolve));
+
+	assert_eq!(
+		*exec_prices
+			.get(&(asset_in, asset_out, swap_type))
+			.expect("excution price to exists"),
+		Ratio::new(amount_out, amount_in)
+	);
+
+	assert_eq!(
+		exec_prices.get(&(asset_in, asset_out, swap_type)),
+		exec_prices.get(&(asset_in, asset_out, swap_type.reverse()))
+	);
+
+	assert_eq!(exec_prices.len(), 2);
+
+	//Compute new exectOut price
+	let swap_type = SwapType::ExactOut;
+	let resolve = IntentData::Swap(SwapData {
+		asset_in,
+		asset_out,
+		amount_in,
+		amount_out,
+		swap_type,
+		partial: false,
+	});
+
+	let mut exec_prices: BTreeMap<(AssetId, AssetId, SwapType), Price> = BTreeMap::new();
+	exec_prices.insert(
+		(asset_in, asset_out, swap_type.reverse()),
+		Ratio::new(amount_out, amount_in),
+	);
+
+	assert_ok!(ICE::validate_price_consitency(&mut exec_prices, &resolve));
+
+	assert_eq!(
+		*exec_prices
+			.get(&(asset_in, asset_out, swap_type))
+			.expect("excution price to exists"),
+		Ratio::new(amount_out, amount_in)
+	);
+
+	assert_eq!(
+		exec_prices.get(&(asset_in, asset_out, swap_type)),
+		exec_prices.get(&(asset_in, asset_out, swap_type.reverse()))
+	);
+
+	assert_eq!(exec_prices.len(), 2);
+}
+
+#[test]
+fn should_not_work_when_computes_new_price_and_is_not_within_price_tolerance_or_reverse_trade() {
+	let asset_in = HDX;
+	let asset_out = DOT;
+	let swap_type = SwapType::ExactIn;
+	let amount_in = 100 * ONE_HDX;
+	let amount_out = 200 * ONE_DOT;
+
+	let resolve = IntentData::Swap(SwapData {
+		asset_in,
+		asset_out,
+		amount_in,
+		amount_out,
+		swap_type,
+		partial: false,
+	});
+
+	let mut exec_prices: BTreeMap<(AssetId, AssetId, SwapType), Price> = BTreeMap::new();
+	let mut reverse_price = Ratio::new(amount_out, amount_in);
+	let tolerance =
+		reverse_price.saturating_mul(&(BuySellTolerance::get().saturating_add(Permill::from_percent(1))).into());
+	reverse_price = reverse_price.saturating_add(&tolerance);
+	exec_prices.insert((asset_in, asset_out, swap_type.reverse()), reverse_price);
+
+	assert_err!(
+		ICE::validate_price_consitency(&mut exec_prices, &resolve),
+		Error::<Test>::PriceToleranceInconsistency
+	);
+
+	assert_eq!(exec_prices.len(), 1);
+
+	assert_eq!(exec_prices.get(&(asset_in, asset_out, swap_type)), None);
+	assert_eq!(
+		*exec_prices
+			.get(&(asset_in, asset_out, swap_type.reverse()))
+			.expect("execution price to exists"),
+		reverse_price
+	);
+}
+
+#[test]
+fn should_fail_when_not_resolved_at_execution_price() {
+	let asset_in = HDX;
+	let asset_out = DOT;
+	let swap_type = SwapType::ExactIn;
+	let amount_in = 100 * ONE_HDX;
+	let amount_out = 200 * ONE_DOT;
+
+	let resolve = IntentData::Swap(SwapData {
+		asset_in,
+		asset_out,
+		amount_in,
+		amount_out: amount_out + 2,
+		swap_type,
+		partial: false,
+	});
+
+	let mut exec_prices: BTreeMap<(AssetId, AssetId, SwapType), Price> = BTreeMap::new();
+	exec_prices.insert((asset_in, asset_out, swap_type), Ratio::new(amount_out, amount_in));
+
+	assert_err!(
+		ICE::validate_price_consitency(&mut exec_prices, &resolve),
+		Error::<Test>::PriceInconsistency
+	);
+
+	assert_eq!(exec_prices.len(), 1);
+	assert_eq!(
+		*exec_prices
+			.get(&(asset_in, asset_out, swap_type))
+			.expect("execution price to exists"),
+		Ratio::new(amount_out, amount_in)
+	);
+}
+
+#[test]
+fn should_work_when_not_resolved_within_execution_price_tolerance() {
+	let asset_in = HDX;
+	let asset_out = DOT;
+	let swap_type = SwapType::ExactIn;
+	let amount_in = 100 * ONE_HDX;
+	let amount_out = 200 * ONE_DOT;
+
+	let resolve = IntentData::Swap(SwapData {
+		asset_in,
+		asset_out,
+		amount_in,
+		//NOTE: we have hadrcoded +-1 in case of rounding error
+		amount_out: amount_out - 1,
+		swap_type,
+		partial: false,
+	});
+
+	let mut exec_prices: BTreeMap<(AssetId, AssetId, SwapType), Price> = BTreeMap::new();
+	exec_prices.insert((asset_in, asset_out, swap_type), Ratio::new(amount_out, amount_in));
+
+	assert_ok!(ICE::validate_price_consitency(&mut exec_prices, &resolve),);
+
+	assert_eq!(exec_prices.len(), 1);
+	assert_eq!(
+		*exec_prices
+			.get(&(asset_in, asset_out, swap_type))
+			.expect("execution price to exists"),
+		Ratio::new(amount_out, amount_in)
+	);
+}
+
+#[test]
+fn should_work_when_price_and_amount_are_within_tolerances() {
+	let asset_in = HDX;
+	let asset_out = DOT;
+	let swap_type = SwapType::ExactIn;
+	let amount_in = 100 * ONE_HDX;
+	let amount_out = 200 * ONE_DOT;
+
+	let resolve = IntentData::Swap(SwapData {
+		asset_in,
+		asset_out,
+		amount_in,
+		amount_out: amount_out + 1,
+		swap_type,
+		partial: false,
+	});
+
+	let mut exec_prices: BTreeMap<(AssetId, AssetId, SwapType), Price> = BTreeMap::new();
+	let mut reverse_price = Ratio::new(amount_out, amount_in);
+	let tolerance =
+		reverse_price.saturating_mul(&(BuySellTolerance::get().saturating_sub(Permill::from_percent(1))).into());
+	reverse_price = reverse_price.saturating_add(&tolerance);
+	exec_prices.insert((asset_in, asset_out, swap_type.reverse()), reverse_price);
+
+	assert_ok!(ICE::validate_price_consitency(&mut exec_prices, &resolve));
+
+	assert_eq!(exec_prices.len(), 2);
+
+	assert_eq!(
+		*exec_prices
+			.get(&(asset_in, asset_out, swap_type))
+			.expect("execution price to exists"),
+		Ratio::new(amount_out + 1, amount_in)
+	);
+	assert_eq!(
+		*exec_prices
+			.get(&(asset_in, asset_out, swap_type.reverse()))
+			.expect("execution price to exists"),
+		reverse_price
+	);
+}

--- a/pallets/ice/support/src/lib.rs
+++ b/pallets/ice/support/src/lib.rs
@@ -113,6 +113,12 @@ impl IntentData {
 			},
 		}
 	}
+
+	pub fn swap_type(&self) -> SwapType {
+		let IntentData::Swap(s) = &self;
+
+		s.swap_type
+	}
 }
 
 #[derive(Clone, DecodeWithMemTracking, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
@@ -125,10 +131,33 @@ pub struct SwapData {
 	pub partial: bool,
 }
 
-#[derive(Copy, DecodeWithMemTracking, Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+#[derive(
+	Copy,
+	DecodeWithMemTracking,
+	Clone,
+	Encode,
+	Decode,
+	Eq,
+	PartialEq,
+	RuntimeDebug,
+	MaxEncodedLen,
+	TypeInfo,
+	PartialOrd,
+	Ord,
+)]
 pub enum SwapType {
 	ExactIn,
 	ExactOut,
+}
+
+impl SwapType {
+	pub fn reverse(&self) -> Self {
+		if *self == SwapType::ExactIn {
+			return SwapType::ExactOut;
+		}
+
+		Self::ExactIn
+	}
 }
 
 #[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, DecodeWithMemTracking, Eq)]

--- a/runtime/hydradx/src/assets.rs
+++ b/runtime/hydradx/src/assets.rs
@@ -1898,7 +1898,7 @@ impl pallet_intent::Config for Runtime {
 parameter_types! {
 	pub const IcePalletId: PalletId = PalletId(*b"ice_ice#");
 	pub const SimulatorHubAsset: AssetId = 0;
-
+	pub const BuySellPriceTolerance: Permill = Permill::from_percent(20);
 }
 
 /// Simulator configuration for the ICE pallet
@@ -1922,6 +1922,7 @@ impl pallet_ice::Config for Runtime {
 	type BlockNumberProvider = System;
 	type RegistryHandler = AssetRegistry;
 	type Simulator = HydrationSimulatorConfig;
+	type BuyVsSellPriceTolerance = BuySellPriceTolerance;
 	type WeightInfo = weights::pallet_ice::HydraWeight<Runtime>;
 }
 


### PR DESCRIPTION
This PR changes `validate_price_consistency` function.
 New price validation doesn't rely on clearing prices, it calculates prices for buy/sell and ensures these prices are withing tolerance.
It also ensures all intents of the same type(e.g sell(a, b)) are executed at same price +-1 for rounding errors.