### PR TITLE
fix: wasm compression level bumped to 22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1086,7 +1086,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "asset-test-utils"
 version = "24.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -1116,7 +1116,7 @@ dependencies = [
 [[package]]
 name = "assets-common"
 version = "0.22.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "cumulus-primitives-core",
  "ethereum-standards",
@@ -1482,7 +1482,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "binary-merkle-tree"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "hash-db",
  "log",
@@ -1779,7 +1779,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.21.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -1796,7 +1796,7 @@ dependencies = [
 [[package]]
 name = "bp-messages"
 version = "0.21.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -1812,7 +1812,7 @@ dependencies = [
 [[package]]
 name = "bp-parachains"
 version = "0.21.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -1829,7 +1829,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-core"
 version = "0.21.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1846,7 +1846,7 @@ dependencies = [
 [[package]]
 name = "bp-relayers"
 version = "0.21.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1864,7 +1864,7 @@ dependencies = [
 [[package]]
 name = "bp-runtime"
 version = "0.21.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1887,7 +1887,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.21.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -1907,7 +1907,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub"
 version = "0.7.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1924,7 +1924,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-common"
 version = "0.14.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1955,7 +1955,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-test-utils"
 version = "0.23.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "asset-test-utils",
  "bp-header-chain",
@@ -1997,7 +1997,7 @@ dependencies = [
 [[package]]
 name = "bridge-runtime-common"
 version = "0.22.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -2928,7 +2928,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-bootnodes"
 version = "0.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel 1.9.0",
@@ -2954,7 +2954,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.24.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -2971,7 +2971,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.24.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -2994,7 +2994,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.24.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -3041,7 +3041,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.24.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -3073,7 +3073,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.20.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3088,7 +3088,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.24.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -3111,7 +3111,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.24.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -3138,7 +3138,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3159,7 +3159,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.24.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3187,7 +3187,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.25.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-channel 1.9.0",
  "cumulus-client-cli",
@@ -3227,7 +3227,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.21.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -3244,7 +3244,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.21.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
@@ -3261,7 +3261,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.21.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "array-bytes 6.2.2",
  "bytes",
@@ -3299,7 +3299,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -3310,7 +3310,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "22.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3323,7 +3323,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-solo-to-para"
 version = "0.21.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -3338,7 +3338,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-weight-reclaim"
 version = "0.3.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "derive-where",
@@ -3357,7 +3357,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.20.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3372,7 +3372,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.21.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "approx",
  "bounded-collections 0.2.4",
@@ -3398,7 +3398,7 @@ dependencies = [
 [[package]]
 name = "cumulus-ping"
 version = "0.21.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-primitives-core",
@@ -3413,7 +3413,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -3422,7 +3422,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -3439,7 +3439,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3453,7 +3453,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.13.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -3463,7 +3463,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "12.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -3480,7 +3480,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.20.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -3490,7 +3490,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.21.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3507,7 +3507,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.25.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -3535,7 +3535,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.24.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3555,7 +3555,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.25.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel 1.9.0",
@@ -3591,7 +3591,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.24.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3632,7 +3632,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-streams"
 version = "0.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "cumulus-relay-chain-interface",
  "futures",
@@ -3646,7 +3646,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.20.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -4416,7 +4416,7 @@ dependencies = [
 [[package]]
 name = "ethereum-standards"
 version = "0.1.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "alloy-core",
 ]
@@ -4921,7 +4921,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -5059,7 +5059,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "41.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -5083,7 +5083,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "49.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.2",
@@ -5148,7 +5148,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-pallet-pov"
 version = "31.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5176,7 +5176,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "16.1.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -5187,7 +5187,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -5204,7 +5204,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "41.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -5246,7 +5246,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.9.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "array-bytes 6.2.2",
  "const-hex",
@@ -5262,7 +5262,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.52.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "futures",
  "indicatif",
@@ -5284,7 +5284,7 @@ dependencies = [
 [[package]]
 name = "frame-storage-access-test-runtime"
 version = "0.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "parity-scale-codec",
@@ -5298,7 +5298,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "41.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "aquamarine",
  "array-bytes 6.2.2",
@@ -5339,7 +5339,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -5359,7 +5359,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.1.0",
@@ -5371,7 +5371,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5381,7 +5381,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "41.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "cfg-if",
  "docify",
@@ -5400,7 +5400,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5414,7 +5414,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -5424,7 +5424,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.47.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -8452,7 +8452,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "46.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "futures",
  "log",
@@ -8471,7 +8471,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -9295,7 +9295,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-alliance"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "array-bytes 6.2.2",
  "frame-benchmarking",
@@ -9315,7 +9315,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "23.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9333,7 +9333,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-ops"
 version = "0.9.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9351,7 +9351,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-tx-payment"
 version = "23.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9409,7 +9409,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rewards"
 version = "0.3.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9443,7 +9443,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "43.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "ethereum-standards",
  "frame-benchmarking",
@@ -9461,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-freezer"
 version = "0.8.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "log",
  "pallet-assets",
@@ -9473,7 +9473,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-holder"
 version = "0.3.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9488,7 +9488,7 @@ dependencies = [
 [[package]]
 name = "pallet-atomic-swap"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9498,7 +9498,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9514,7 +9514,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9542,7 +9542,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9565,7 +9565,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "aquamarine",
  "docify",
@@ -9586,7 +9586,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "42.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "42.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9621,7 +9621,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "42.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "array-bytes 6.2.2",
  "binary-merkle-tree",
@@ -9670,7 +9670,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9687,7 +9687,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.21.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -9706,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.21.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -9725,7 +9725,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-parachains"
 version = "0.21.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-relayers"
 version = "0.21.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -9788,7 +9788,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.20.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -9806,7 +9806,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9899,7 +9899,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "22.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9918,7 +9918,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9935,7 +9935,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective-content"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9949,7 +9949,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -9980,7 +9980,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-mock-network"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10011,7 +10011,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "23.0.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10021,7 +10021,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-uapi"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -10032,7 +10032,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "pallet-core-fellowship"
 version = "25.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10140,7 +10140,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "8.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10175,7 +10175,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10192,7 +10192,7 @@ dependencies = [
 [[package]]
 name = "pallet-dev-mode"
 version = "23.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10260,7 +10260,7 @@ dependencies = [
 [[package]]
 name = "pallet-dummy-dim"
 version = "0.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10359,7 +10359,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-block"
 version = "0.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10380,7 +10380,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10401,7 +10401,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10414,7 +10414,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "42.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10654,7 +10654,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10690,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "pallet-glutton"
 version = "27.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "blake2 0.10.6",
  "frame-benchmarking",
@@ -10708,7 +10708,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10781,7 +10781,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -10797,7 +10797,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10816,7 +10816,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10831,7 +10831,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "29.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10996,7 +10996,7 @@ dependencies = [
 [[package]]
 name = "pallet-lottery"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11009,7 +11009,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11025,7 +11025,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "44.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -11044,7 +11044,7 @@ dependencies = [
 [[package]]
 name = "pallet-meta-tx"
 version = "0.3.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11062,7 +11062,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11081,7 +11081,7 @@ dependencies = [
 [[package]]
 name = "pallet-mixnet"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -11095,7 +11095,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -11107,7 +11107,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -11138,7 +11138,7 @@ dependencies = [
 [[package]]
 name = "pallet-nft-fractionalization"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "log",
  "pallet-assets",
@@ -11151,7 +11151,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts"
 version = "35.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -11168,7 +11168,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts-runtime-api"
 version = "27.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -11177,7 +11177,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -11187,7 +11187,7 @@ dependencies = [
 [[package]]
 name = "pallet-node-authorization"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -11198,7 +11198,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11216,7 +11216,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11236,7 +11236,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -11246,7 +11246,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11261,7 +11261,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11344,7 +11344,7 @@ dependencies = [
 [[package]]
 name = "pallet-origin-restriction"
 version = "0.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11416,7 +11416,7 @@ dependencies = [
 [[package]]
 name = "pallet-paged-list"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -11428,7 +11428,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.12.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11459,7 +11459,7 @@ dependencies = [
 [[package]]
 name = "pallet-people"
 version = "0.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11477,7 +11477,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11493,7 +11493,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -11503,7 +11503,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "41.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11521,7 +11521,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -11531,7 +11531,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -11585,7 +11585,7 @@ dependencies = [
 [[package]]
 name = "pallet-remark"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11601,7 +11601,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive"
 version = "0.7.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "alloy-core",
  "derive_more 0.99.20",
@@ -11647,7 +11647,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-fixtures"
 version = "0.4.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -11661,7 +11661,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-proc-macro"
 version = "0.3.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11671,7 +11671,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-uapi"
 version = "0.5.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bitflags 1.3.2",
  "pallet-revive-proc-macro",
@@ -11683,7 +11683,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-offences"
 version = "38.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11699,7 +11699,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11739,7 +11739,7 @@ dependencies = [
 [[package]]
 name = "pallet-safe-mode"
 version = "22.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "docify",
  "pallet-balances",
@@ -11753,7 +11753,7 @@ dependencies = [
 [[package]]
 name = "pallet-salary"
 version = "26.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "log",
  "pallet-ranked-collective",
@@ -11765,7 +11765,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "42.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11782,7 +11782,7 @@ dependencies = [
 [[package]]
 name = "pallet-scored-pool"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11795,7 +11795,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11816,7 +11816,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11850,7 +11850,7 @@ dependencies = [
 [[package]]
 name = "pallet-skip-feeless-payment"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11862,7 +11862,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11938,7 +11938,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11960,7 +11960,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async"
 version = "0.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11983,7 +11983,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-ah-client"
 version = "0.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -12002,7 +12002,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-rc-client"
 version = "0.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -12019,7 +12019,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-reward-fn"
 version = "0.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -12028,7 +12028,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-runtime-api"
 version = "0.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -12038,7 +12038,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "23.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -12047,7 +12047,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "27.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -12057,7 +12057,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "46.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12073,7 +12073,7 @@ dependencies = [
 [[package]]
 name = "pallet-statement"
 version = "23.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -12090,7 +12090,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -12105,7 +12105,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -12123,7 +12123,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12211,7 +12211,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12226,7 +12226,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "44.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -12242,7 +12242,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -12254,7 +12254,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-storage"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "array-bytes 6.2.2",
  "frame-benchmarking",
@@ -12274,7 +12274,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -12293,7 +12293,7 @@ dependencies = [
 [[package]]
 name = "pallet-tx-pause"
 version = "22.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -12304,7 +12304,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12318,7 +12318,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12334,7 +12334,7 @@ dependencies = [
 [[package]]
 name = "pallet-verify-signature"
 version = "0.4.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12349,7 +12349,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12363,7 +12363,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -12373,7 +12373,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "20.1.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bounded-collections 0.2.4",
  "frame-benchmarking",
@@ -12399,7 +12399,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "21.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12416,7 +12416,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -12438,7 +12438,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub-router"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-benchmarking",
@@ -12511,7 +12511,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "22.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -12540,7 +12540,7 @@ dependencies = [
 [[package]]
 name = "parachains-runtimes-test-utils"
 version = "23.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -12898,7 +12898,7 @@ dependencies = [
 [[package]]
 name = "polkadot-approval-distribution"
 version = "24.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12916,7 +12916,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12931,7 +12931,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "fatality",
  "futures",
@@ -12954,7 +12954,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "fatality",
@@ -12987,7 +12987,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "25.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -13011,7 +13011,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bitvec",
  "fatality",
@@ -13034,7 +13034,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13045,7 +13045,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "fatality",
  "futures",
@@ -13067,7 +13067,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -13081,7 +13081,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "24.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "futures",
  "futures-timer",
@@ -13102,7 +13102,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -13125,7 +13125,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -13143,7 +13143,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -13175,7 +13175,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting-parallel"
 version = "0.7.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "futures",
@@ -13199,7 +13199,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bitvec",
  "futures",
@@ -13218,7 +13218,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bitvec",
  "fatality",
@@ -13239,7 +13239,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -13254,7 +13254,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "futures",
@@ -13276,7 +13276,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -13290,7 +13290,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "futures",
  "futures-timer",
@@ -13306,7 +13306,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "fatality",
  "futures",
@@ -13324,7 +13324,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "futures",
@@ -13341,7 +13341,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "23.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "fatality",
  "futures",
@@ -13355,7 +13355,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bitvec",
  "fatality",
@@ -13372,7 +13372,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "always-assert",
  "array-bytes 6.2.2",
@@ -13400,7 +13400,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -13413,7 +13413,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "cpu-time",
  "futures",
@@ -13439,7 +13439,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -13454,7 +13454,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bs58",
  "futures",
@@ -13471,7 +13471,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -13496,7 +13496,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "20.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -13520,7 +13520,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
@@ -13529,7 +13529,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -13557,7 +13557,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "24.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "fatality",
  "futures",
@@ -13588,7 +13588,7 @@ dependencies = [
 [[package]]
 name = "polkadot-omni-node-lib"
 version = "0.7.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "clap",
@@ -13674,7 +13674,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "futures",
@@ -13694,7 +13694,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bounded-collections 0.2.4",
  "derive_more 0.99.20",
@@ -13710,7 +13710,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bitvec",
  "bounded-collections 0.2.4",
@@ -13739,7 +13739,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "25.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -13772,7 +13772,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -13822,7 +13822,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "21.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -13834,7 +13834,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "20.0.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -13882,7 +13882,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk"
 version = "2506.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "asset-test-utils",
  "assets-common",
@@ -14121,7 +14121,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.10.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -14156,7 +14156,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "25.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -14264,7 +14264,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bitvec",
  "fatality",
@@ -14284,7 +14284,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -15445,7 +15445,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "24.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -15543,7 +15543,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "21.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -16110,7 +16110,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "32.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "log",
  "sp-core",
@@ -16121,7 +16121,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.51.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "futures",
@@ -16152,7 +16152,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.50.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "futures",
  "log",
@@ -16173,7 +16173,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -16188,7 +16188,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "44.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "array-bytes 6.2.2",
  "clap",
@@ -16215,7 +16215,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -16226,7 +16226,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.53.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "array-bytes 6.2.2",
  "chrono",
@@ -16268,7 +16268,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "fnv",
  "futures",
@@ -16294,7 +16294,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.47.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -16322,7 +16322,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.50.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "futures",
@@ -16345,7 +16345,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.51.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "futures",
@@ -16374,7 +16374,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.51.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -16410,7 +16410,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.51.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -16432,7 +16432,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "30.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel 1.9.0",
@@ -16466,7 +16466,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "30.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -16486,7 +16486,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.50.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -16499,7 +16499,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.36.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "ahash",
  "array-bytes 6.2.2",
@@ -16543,7 +16543,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.36.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -16563,7 +16563,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.52.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -16598,7 +16598,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.50.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "futures",
@@ -16621,7 +16621,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.43.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -16644,7 +16644,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.39.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "polkavm 0.24.0",
  "sc-allocator",
@@ -16657,7 +16657,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.36.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "log",
  "polkavm 0.24.0",
@@ -16668,7 +16668,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.39.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "anyhow",
  "log",
@@ -16684,7 +16684,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.50.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "console",
  "futures",
@@ -16700,7 +16700,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "36.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "array-bytes 6.2.2",
  "parking_lot 0.12.3",
@@ -16714,7 +16714,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.21.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "array-bytes 6.2.2",
  "arrayvec 0.7.4",
@@ -16742,7 +16742,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.51.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel 1.9.0",
@@ -16792,7 +16792,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.49.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -16802,7 +16802,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.51.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "ahash",
  "futures",
@@ -16821,7 +16821,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.50.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel 1.9.0",
@@ -16842,7 +16842,7 @@ dependencies = [
 [[package]]
 name = "sc-network-statement"
 version = "0.33.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel 1.9.0",
@@ -16863,7 +16863,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.50.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel 1.9.0",
@@ -16898,7 +16898,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.50.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "array-bytes 6.2.2",
  "futures",
@@ -16917,7 +16917,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bs58",
  "bytes",
@@ -16938,7 +16938,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "46.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bytes",
  "fnv",
@@ -16972,7 +16972,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -16981,7 +16981,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "46.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -17013,7 +17013,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.50.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -17033,7 +17033,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "23.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -17057,7 +17057,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.51.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "array-bytes 6.2.2",
  "futures",
@@ -17090,7 +17090,7 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.3.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
@@ -17105,7 +17105,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.52.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "directories",
@@ -17169,7 +17169,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.39.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -17180,7 +17180,7 @@ dependencies = [
 [[package]]
 name = "sc-statement-store"
 version = "22.3.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "log",
  "parity-db",
@@ -17200,7 +17200,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.25.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "clap",
  "fs4",
@@ -17213,7 +17213,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.51.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -17232,7 +17232,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "43.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "derive_more 0.99.20",
  "futures",
@@ -17252,7 +17252,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "29.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "chrono",
  "futures",
@@ -17271,7 +17271,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "40.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "chrono",
  "console",
@@ -17301,7 +17301,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -17312,7 +17312,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "40.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "futures",
@@ -17343,7 +17343,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "futures",
@@ -17360,7 +17360,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -18115,7 +18115,7 @@ dependencies = [
 [[package]]
 name = "slot-range-helper"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -18378,7 +18378,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-core"
 version = "0.14.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bp-relayers",
  "frame-support",
@@ -18463,7 +18463,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "docify",
  "hash-db",
@@ -18485,7 +18485,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "23.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -18499,7 +18499,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18511,7 +18511,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "27.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -18525,7 +18525,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18537,7 +18537,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -18547,7 +18547,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -18568,7 +18568,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.43.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "futures",
@@ -18582,7 +18582,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.43.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -18598,7 +18598,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.43.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -18616,7 +18616,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "25.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18636,7 +18636,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -18653,7 +18653,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-pow"
 version = "0.43.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -18664,7 +18664,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.43.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18675,7 +18675,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "ark-vrf",
  "array-bytes 6.2.2",
@@ -18723,7 +18723,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "sp-crypto-hashing",
 ]
@@ -18731,7 +18731,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.16.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -18751,7 +18751,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -18764,7 +18764,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
@@ -18774,7 +18774,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -18783,7 +18783,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -18793,7 +18793,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.30.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -18803,7 +18803,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18815,7 +18815,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -18828,7 +18828,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "41.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bytes",
  "docify",
@@ -18854,7 +18854,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "42.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -18864,7 +18864,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.43.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -18875,7 +18875,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -18884,7 +18884,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.11.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-metadata 23.0.1",
  "parity-scale-codec",
@@ -18894,7 +18894,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.15.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18905,7 +18905,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -18922,7 +18922,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18935,7 +18935,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -18945,7 +18945,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "backtrace",
  "regex",
@@ -18954,7 +18954,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "35.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -18964,7 +18964,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "42.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -18993,7 +18993,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "30.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -19012,7 +19012,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "Inflector",
  "expander",
@@ -19025,7 +19025,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -19039,7 +19039,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -19052,7 +19052,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.46.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "hash-db",
  "log",
@@ -19072,7 +19072,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "21.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -19096,12 +19096,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -19113,7 +19113,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -19125,7 +19125,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -19136,7 +19136,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -19145,7 +19145,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -19159,7 +19159,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "ahash",
  "foldhash 0.1.5",
@@ -19184,7 +19184,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -19201,7 +19201,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -19213,7 +19213,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "22.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -19225,7 +19225,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "32.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "bounded-collections 0.2.4",
  "parity-scale-codec",
@@ -19302,7 +19302,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-chain-spec-builder"
 version = "12.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "clap",
  "docify",
@@ -19315,7 +19315,7 @@ dependencies = [
 [[package]]
 name = "staging-node-inspect"
 version = "0.29.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -19333,7 +19333,7 @@ dependencies = [
 [[package]]
 name = "staging-parachain-info"
 version = "0.21.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -19346,7 +19346,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "array-bytes 6.2.2",
  "bounded-collections 0.2.4",
@@ -19367,7 +19367,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "21.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "environmental",
  "frame-support",
@@ -19391,7 +19391,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "20.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -19506,7 +19506,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -19531,12 +19531,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "45.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -19556,7 +19556,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.6"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "http-body-util",
  "hyper 1.5.1",
@@ -19570,7 +19570,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.50.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -19600,7 +19600,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "44.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -19617,7 +19617,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "27.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "array-bytes 6.2.2",
  "build-helper",
@@ -20055,7 +20055,7 @@ dependencies = [
 [[package]]
 name = "testnet-parachains-constants"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -20568,7 +20568,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -20579,7 +20579,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "expander",
  "proc-macro-crate 3.1.0",
@@ -21493,7 +21493,7 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 [[package]]
 name = "westend-runtime"
 version = "24.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -21600,7 +21600,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "21.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -22207,7 +22207,7 @@ dependencies = [
 [[package]]
 name = "xcm-emulator"
 version = "0.20.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "array-bytes 6.2.2",
  "cumulus-pallet-parachain-system",
@@ -22241,7 +22241,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -22252,7 +22252,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.8.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -22266,7 +22266,7 @@ dependencies = [
 [[package]]
 name = "xcm-simulator"
 version = "21.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-8-patch#109cf4be54a560a61e3d3803ce14cf8c7ecf07e1"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-9-patch#9a05c9e7ff2c49cd7e05a6eb2444c3c76f0bd651"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,112 +175,112 @@ pallet-evm-precompile-flash-loan = { path = "precompiles/flash-loan", default-fe
 precompile-utils = { path = "precompiles/utils", default-features = false }
 
 # Frame
-frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-frame-benchmarking-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-frame-executive = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-frame-remote-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-frame-support = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false, features = ["tuples-96"] }
-frame-support-procedural = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false, features = ["tuples-96"] }
-frame-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-frame-system-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-frame-try-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-frame-metadata-hash-extension = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-arithmetic = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-authority-discovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-block-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-genesis-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-blockchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-consensus-babe = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-consensus-beefy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-inherents = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-io = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-npos-elections = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sc-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-runtime-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-runtime-interface-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-staking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-std = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-storage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-state-machine = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-trie = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-version = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-weights = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-crypto-hashing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-crypto-ec-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sp-wasm-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
+frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+frame-benchmarking-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+frame-executive = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+frame-remote-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+frame-support = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false, features = ["tuples-96"] }
+frame-support-procedural = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false, features = ["tuples-96"] }
+frame-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+frame-system-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+frame-try-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+frame-metadata-hash-extension = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-arithmetic = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-authority-discovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-block-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-genesis-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-blockchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-consensus-babe = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-consensus-beefy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-inherents = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-io = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-npos-elections = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sc-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-runtime-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-runtime-interface-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-staking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-std = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-storage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-state-machine = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-trie = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-version = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-weights = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-crypto-hashing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-crypto-ec-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sp-wasm-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
 
-sc-basic-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sc-chain-spec = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sc-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sc-client-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sc-client-db = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sc-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sc-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sc-consensus-grandpa = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sc-executor = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sc-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sc-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sc-network-sync = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sc-network-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sc-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sc-rpc-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sc-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sc-telemetry = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sc-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sc-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sc-transaction-pool-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-sc-sysinfo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
+sc-basic-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sc-chain-spec = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sc-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sc-client-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sc-client-db = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sc-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sc-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sc-consensus-grandpa = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sc-executor = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sc-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sc-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sc-network-sync = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sc-network-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sc-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sc-rpc-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sc-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sc-telemetry = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sc-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sc-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sc-transaction-pool-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+sc-sysinfo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
 
 # Substrate Pallets
-pallet-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-balances = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-bags-list = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-collective = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-conviction-voting = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-elections-phragmen = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-identity = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-migrations = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-multisig = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-preimage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-proxy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-referenda = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-scheduler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-sudo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-tips = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-transaction-payment-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-treasury = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-uniques = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-im-online = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-message-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-state-trie-migration = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-whitelist = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
+pallet-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-balances = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-bags-list = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-collective = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-conviction-voting = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-elections-phragmen = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-identity = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-migrations = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-multisig = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-preimage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-proxy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-referenda = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-scheduler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-sudo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-tips = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-transaction-payment-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-treasury = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-uniques = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-im-online = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-message-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-state-trie-migration = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-whitelist = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
 
-substrate-build-script-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-substrate-frame-rpc-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-substrate-prometheus-endpoint = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-substrate-rpc-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-substrate-wasm-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-substrate-state-trie-migration-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
+substrate-build-script-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+substrate-frame-rpc-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+substrate-prometheus-endpoint = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+substrate-rpc-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+substrate-wasm-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+substrate-state-trie-migration-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
 
 #TODO: We use our custom ORML as it contains the fix of bug for reducible_balance check, for Preserve mode. Once the official ORML pushes a new version with the fix, we can use that again
 # ORML dependencies
@@ -298,33 +298,33 @@ orml-xcm-support = { git = "https://github.com/galacticcouncil/open-runtime-modu
 orml-xtokens = { git = "https://github.com/galacticcouncil/open-runtime-module-library", branch = "polkadot-stable2506", default-features = false }
 
 # Cumulus dependencies
-cumulus-client-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-cumulus-client-collator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-cumulus-client-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-cumulus-client-consensus-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-cumulus-client-consensus-proposer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-cumulus-client-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-cumulus-client-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-cumulus-pallet-aura-ext = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-cumulus-pallet-parachain-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-cumulus-pallet-weight-reclaim = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-cumulus-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-cumulus-pallet-xcmp-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-cumulus-primitives-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-cumulus-primitives-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-cumulus-primitives-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-cumulus-primitives-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-cumulus-relay-chain-inprocess-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-cumulus-relay-chain-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-cumulus-relay-chain-minimal-node = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-collator-selection = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-staging-parachain-info = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-xcm-emulator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-xcm-runtime-apis = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-parachains-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
+cumulus-client-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+cumulus-client-collator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+cumulus-client-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+cumulus-client-consensus-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+cumulus-client-consensus-proposer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+cumulus-client-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+cumulus-client-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+cumulus-pallet-aura-ext = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+cumulus-pallet-parachain-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+cumulus-pallet-weight-reclaim = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+cumulus-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+cumulus-primitives-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+cumulus-primitives-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+cumulus-primitives-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+cumulus-relay-chain-inprocess-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+cumulus-relay-chain-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+cumulus-relay-chain-minimal-node = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-collator-selection = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+staging-parachain-info = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+xcm-emulator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+xcm-runtime-apis = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+parachains-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
 
 # Frontier
 fc-consensus = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-stable2506", default-features = false }
@@ -359,36 +359,36 @@ ethereum = { version = "0.18.2", default-features = false, features = [
 ethereum-types = { version = "0.15.1", default-features = false }
 
 # Polkadot dependencies
-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-pallet-xcm-benchmarks = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-polkadot-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-core-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-polkadot-parachain = { package = "polkadot-parachain-primitives", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false, features = [
+pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+pallet-xcm-benchmarks = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+polkadot-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-core-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+polkadot-parachain = { package = "polkadot-parachain-primitives", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false, features = [
     "wasm-api",
 ] }
-polkadot-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-polkadot-runtime-parachains = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-polkadot-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-polkadot-xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
+polkadot-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+polkadot-runtime-parachains = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+polkadot-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+polkadot-xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
 
-polkadot-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-node-core-pvf = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-node-network-protocol = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-node-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-node-subsystem = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-node-subsystem-util = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-overseer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-runtime-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch", default-features = false }
-polkadot-statement-table = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-rococo-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
+polkadot-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-node-core-pvf = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-node-network-protocol = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-node-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-node-subsystem = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-node-subsystem-util = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-overseer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-runtime-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch", default-features = false }
+polkadot-statement-table = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+rococo-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
 
-cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
+cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
 
 # Hyperbridge
 pallet-hyperbridge = { version = "2506.1.1", default-features = false }
@@ -417,481 +417,481 @@ orml-xcm-support = { git = "https://github.com/galacticcouncil/open-runtime-modu
 orml-xtokens = { git = "https://github.com/galacticcouncil/open-runtime-module-library", branch = "polkadot-stable2506" }
 
 [patch."https://github.com/moonbeam-foundation/polkadot-sdk"]
-frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-benchmarking-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-executive = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-remote-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-support = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-support-procedural = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-system-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-system-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-try-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-metadata-hash-extension = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-arithmetic = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-authority-discovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-block-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-genesis-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-blockchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-consensus-babe = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-inherents = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-io = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-npos-elections = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-runtime-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-runtime-interface-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-wasm-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-panic-handler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-database = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-staking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-std = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-storage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-trie = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-version = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-basic-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-chain-spec = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-client-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-client-db = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-consensus-grandpa = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-executor = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-network-sync = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-network-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-rpc-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-telemetry = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-transaction-pool-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-sysinfo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-state-machine = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-weights = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-crypto-hashing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
+frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-benchmarking-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-executive = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-remote-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-support = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-support-procedural = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-system-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-system-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-try-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-metadata-hash-extension = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-arithmetic = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-authority-discovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-block-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-genesis-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-blockchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-consensus-babe = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-inherents = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-io = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-npos-elections = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-runtime-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-runtime-interface-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-wasm-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-panic-handler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-database = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-staking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-std = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-storage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-trie = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-version = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-basic-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-chain-spec = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-client-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-client-db = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-consensus-grandpa = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-executor = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-network-sync = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-network-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-rpc-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-telemetry = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-transaction-pool-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-sysinfo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-state-machine = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-weights = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-crypto-hashing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
 
 # Substrate Pallets
-pallet-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-balances = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-collective = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-elections-phragmen = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-identity = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-multisig = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-preimage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-proxy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-scheduler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-sudo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-tips = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-transaction-payment = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-transaction-payment-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-treasury = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-uniques = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-im-online = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-message-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-state-trie-migration = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
+pallet-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-balances = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-collective = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-elections-phragmen = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-identity = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-multisig = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-preimage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-proxy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-scheduler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-sudo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-tips = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-transaction-payment = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-transaction-payment-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-treasury = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-uniques = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-im-online = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-message-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-state-trie-migration = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
 
-substrate-build-script-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-substrate-frame-rpc-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-substrate-prometheus-endpoint = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-substrate-rpc-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-substrate-wasm-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-substrate-state-trie-migration-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
+substrate-build-script-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+substrate-frame-rpc-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+substrate-prometheus-endpoint = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+substrate-rpc-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+substrate-wasm-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+substrate-state-trie-migration-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
 
 # Cumulus dependencies
-cumulus-client-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-client-collator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-client-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-client-consensus-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-client-consensus-proposer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-client-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-client-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-pallet-aura-ext = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-pallet-parachain-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-pallet-xcmp-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-primitives-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-primitives-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-primitives-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-relay-chain-inprocess-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-relay-chain-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-relay-chain-minimal-node = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-collator-selection = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-staging-parachain-info = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-xcm-emulator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-parachains-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-xcm-runtime-apis = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
+cumulus-client-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-client-collator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-client-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-client-consensus-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-client-consensus-proposer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-client-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-client-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-pallet-aura-ext = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-pallet-parachain-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-primitives-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-primitives-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-primitives-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-relay-chain-inprocess-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-relay-chain-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-relay-chain-minimal-node = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-collator-selection = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+staging-parachain-info = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+xcm-emulator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+parachains-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+xcm-runtime-apis = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
 
 # Polkadot dependencies
-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-xcm-benchmarks = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-core-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-parachain = { package = "polkadot-parachain-primitives", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-runtime-parachains = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
+pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-xcm-benchmarks = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-core-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-parachain = { package = "polkadot-parachain-primitives", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-runtime-parachains = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
 
-polkadot-node-core-pvf = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-node-network-protocol = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-node-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-node-subsystem = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-node-subsystem-util = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-overseer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-runtime-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-statement-table = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-rococo-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
+polkadot-node-core-pvf = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-node-network-protocol = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-node-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-node-subsystem = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-node-subsystem-util = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-overseer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-runtime-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-statement-table = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+rococo-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
 
-cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
+cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
 
 [patch."https://github.com/paritytech/polkadot-sdk"]
-polkadot-sdk = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-benchmarking-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-executive = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-remote-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-support = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-support-procedural = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-system-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-system-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-try-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-metadata-hash-extension = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-arithmetic = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-authority-discovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-block-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-genesis-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-blockchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-consensus-babe = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-inherents = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-io = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-npos-elections = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-runtime-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-runtime-interface-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-wasm-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-panic-handler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-database = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-staking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-std = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-storage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-trie = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-version = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-basic-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-chain-spec = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-client-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-client-db = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-consensus-grandpa = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-executor = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-network-sync = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-network-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-rpc-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-telemetry = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-transaction-pool-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-sysinfo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-state-machine = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-weights = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-crypto-hashing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
+polkadot-sdk = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-benchmarking-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-executive = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-remote-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-support = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-support-procedural = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-system-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-system-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-try-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-metadata-hash-extension = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-arithmetic = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-authority-discovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-block-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-genesis-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-blockchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-consensus-babe = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-inherents = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-io = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-npos-elections = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-runtime-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-runtime-interface-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-wasm-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-panic-handler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-database = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-staking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-std = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-storage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-trie = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-version = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-basic-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-chain-spec = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-client-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-client-db = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-consensus-grandpa = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-executor = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-network-sync = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-network-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-rpc-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-telemetry = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-transaction-pool-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-sysinfo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-state-machine = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-weights = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-crypto-hashing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
 
 # Substrate Pallets
-pallet-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-balances = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-collective = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-elections-phragmen = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-identity = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-multisig = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-preimage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-proxy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-scheduler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-sudo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-tips = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-transaction-payment = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-transaction-payment-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-treasury = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-uniques = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-im-online = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-message-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-state-trie-migration = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
+pallet-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-balances = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-collective = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-elections-phragmen = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-identity = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-multisig = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-preimage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-proxy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-scheduler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-sudo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-tips = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-transaction-payment = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-transaction-payment-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-treasury = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-uniques = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-im-online = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-message-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-state-trie-migration = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
 
-substrate-build-script-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-substrate-frame-rpc-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-substrate-prometheus-endpoint = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-substrate-rpc-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-substrate-wasm-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-substrate-state-trie-migration-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
+substrate-build-script-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+substrate-frame-rpc-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+substrate-prometheus-endpoint = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+substrate-rpc-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+substrate-wasm-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+substrate-state-trie-migration-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
 
 # Cumulus dependencies
-cumulus-client-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-client-collator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-client-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-client-consensus-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-client-consensus-proposer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-client-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-client-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-pallet-aura-ext = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-pallet-parachain-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-pallet-xcmp-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-primitives-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-primitives-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-primitives-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-relay-chain-inprocess-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-relay-chain-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-relay-chain-minimal-node = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-collator-selection = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-staging-parachain-info = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-xcm-emulator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-parachains-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-xcm-runtime-apis = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
+cumulus-client-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-client-collator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-client-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-client-consensus-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-client-consensus-proposer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-client-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-client-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-pallet-aura-ext = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-pallet-parachain-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-primitives-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-primitives-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-primitives-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-relay-chain-inprocess-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-relay-chain-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-relay-chain-minimal-node = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-collator-selection = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+staging-parachain-info = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+xcm-emulator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+parachains-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+xcm-runtime-apis = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
 
 # Polkadot dependencies
-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-xcm-benchmarks = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-core-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-parachain = { package = "polkadot-parachain-primitives", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-runtime-parachains = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
+pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-xcm-benchmarks = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-core-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-parachain = { package = "polkadot-parachain-primitives", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-runtime-parachains = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
 
-polkadot-node-core-pvf = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-node-network-protocol = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-node-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-node-subsystem = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-node-subsystem-util = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-overseer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-runtime-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-statement-table = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-rococo-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
+polkadot-node-core-pvf = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-node-network-protocol = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-node-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-node-subsystem = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-node-subsystem-util = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-overseer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-runtime-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-statement-table = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+rococo-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
 
-cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
+cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
 
 [patch.crates-io]
-polkadot-sdk = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-consensus-epochs = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-benchmarking-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-executive = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-remote-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-support = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-support-procedural = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-system-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-system-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-try-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-frame-metadata-hash-extension = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-arithmetic = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-authority-discovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-block-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-genesis-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-blockchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-consensus-babe = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-inherents = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-io = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-npos-elections = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-runtime-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-runtime-interface-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-wasm-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-panic-handler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-database = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-staking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-std = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-storage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-trie = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-version = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-basic-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-chain-spec = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-client-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-client-db = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-consensus-grandpa = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-executor = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-network-sync = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-network-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-rpc-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-telemetry = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-transaction-pool-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-sysinfo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sc-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-state-machine = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-weights = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-sp-crypto-hashing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
+polkadot-sdk = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-consensus-epochs = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-benchmarking-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-executive = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-remote-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-support = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-support-procedural = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-system-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-system-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-try-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+frame-metadata-hash-extension = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-arithmetic = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-authority-discovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-block-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-genesis-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-blockchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-consensus-babe = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-externalities = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-inherents = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-io = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-npos-elections = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-offchain = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-runtime-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-runtime-interface-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-wasm-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-panic-handler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-database = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-staking = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-std = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-storage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-trie = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-version = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-basic-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-chain-spec = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-client-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-client-db = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-consensus = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-consensus-grandpa = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-executor = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-keystore = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-network-sync = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-network-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-rpc-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-telemetry = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-tracing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-transaction-pool = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-transaction-pool-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-sysinfo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sc-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-state-machine = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-weights = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+sp-crypto-hashing = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
 
 # Substrate Pallets
-pallet-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-balances = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-collective = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-elections-phragmen = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-identity = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-multisig = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-preimage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-proxy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-scheduler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-sudo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-tips = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-transaction-payment = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-transaction-payment-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-treasury = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-uniques = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-im-online = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-message-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-state-trie-migration = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
+pallet-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-authorship = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-balances = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-collective = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-elections-phragmen = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-identity = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-multisig = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-preimage = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-proxy = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-scheduler = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-session = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-sudo = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-tips = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-transaction-payment = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-transaction-payment-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-treasury = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-uniques = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-im-online = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-message-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-state-trie-migration = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
 
-substrate-build-script-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-substrate-frame-rpc-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-substrate-prometheus-endpoint = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-substrate-rpc-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-substrate-wasm-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-substrate-state-trie-migration-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
+substrate-build-script-utils = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+substrate-frame-rpc-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+substrate-prometheus-endpoint = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+substrate-rpc-client = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+substrate-wasm-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+substrate-state-trie-migration-rpc = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
 
 # Cumulus dependencies
-cumulus-client-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-client-collator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-client-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-client-consensus-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-client-consensus-proposer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-client-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-client-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-pallet-aura-ext = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-pallet-parachain-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-pallet-xcmp-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-primitives-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-primitives-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-primitives-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-relay-chain-inprocess-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-relay-chain-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-relay-chain-minimal-node = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-collator-selection = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-staging-parachain-info = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-xcm-emulator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-parachains-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-xcm-runtime-apis = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
+cumulus-client-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-client-collator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-client-consensus-aura = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-client-consensus-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-client-consensus-proposer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-client-network = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-client-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-pallet-aura-ext = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-pallet-parachain-system = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-primitives-core = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-primitives-timestamp = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-primitives-utility = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-relay-chain-inprocess-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-relay-chain-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-relay-chain-minimal-node = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-collator-selection = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+staging-parachain-info = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+xcm-emulator = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+parachains-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+xcm-runtime-apis = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
 
 # Polkadot dependencies
-pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-pallet-xcm-benchmarks = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-core-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-parachain = { package = "polkadot-parachain-primitives", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-runtime-parachains = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
+pallet-xcm = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+pallet-xcm-benchmarks = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-cli = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-core-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-parachain = { package = "polkadot-parachain-primitives", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-runtime-parachains = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-service = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+xcm = { package = "staging-xcm", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
 
-polkadot-node-core-pvf = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-node-network-protocol = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-node-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-node-subsystem = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-node-subsystem-util = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-overseer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-runtime-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-polkadot-statement-table = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-rococo-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
+polkadot-node-core-pvf = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-node-network-protocol = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-node-primitives = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-node-subsystem = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-node-subsystem-util = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-overseer = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-runtime-common = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+polkadot-statement-table = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+rococo-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
 
-cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
-cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-8-patch" }
+cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
+cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-9-patch" }
 
 [patch."https://github.com/bifrost-io/open-runtime-module-library"]
 orml-xcm-support = { git = "https://github.com/galacticcouncil/open-runtime-module-library", branch = "polkadot-stable2506" }


### PR DESCRIPTION
runtime is getting fat

- 2,254,810 bytes (2.15 MB) compressed — down from 2,992,819 with level 3.                                       
     
```                                                                                                            
  before (zstd 3):  2,992,819 bytes  (2.85 MB)                                                                   
  after  (zstd 22): 2,254,810 bytes  (2.15 MB)                                                                   
                     ─────────                                                                                   
  saved:              738,009 bytes  (721 KB, -24.7%)                                                            
```

that puts the runtime back to roughly v35 levels (feb 2025) in terms of compressed size, while carrying 10 releases worth of features.       


https://github.com/galacticcouncil/polkadot-sdk/commit/9a05c9e7ff
backport of https://github.com/paritytech/polkadot-sdk/pull/9875