### PR TITLE
fix: reduce undeciding timeout from 14 days to 2 days

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "411.0.0"
+version = "412.0.0"
 dependencies = [
  "alloy-primitives 0.7.7",
  "alloy-sol-types 0.7.7",

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "411.0.0"
+version = "412.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/governance/mod.rs
+++ b/runtime/hydradx/src/governance/mod.rs
@@ -213,7 +213,7 @@ impl pallet_whitelist::Config for Runtime {
 parameter_types! {
 	pub const AlarmInterval: BlockNumber = 1;
 	pub const SubmissionDeposit: Balance = DOLLARS;
-	pub const UndecidingTimeout: BlockNumber = 14 * DAYS;
+	pub const UndecidingTimeout: BlockNumber = 2 * DAYS;
 }
 
 impl pallet_referenda::Config for Runtime {

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -129,7 +129,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("hydradx"),
 	impl_name: Cow::Borrowed("hydradx"),
 	authoring_version: 1,
-	spec_version: 411,
+	spec_version: 412,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
## Description

Reduces `pallet_referenda::UndecidingTimeout` from 14 days (201,600 blocks) to 2 days (28,800 blocks).

When a referendum is submitted but no decision deposit is placed, it currently lingers for 14 days before auto-rejecting. This shortens that window to 48h so mistakenly-submitted referenda clear out promptly while still leaving a legitimate submitter time to gather the decision deposit. Submission deposit handling is unchanged — it's returned to the submitter on timeout.

## Motivation and Context

Mistakenly-submitted referenda currently sit in the queue for two weeks, cluttering the governance UI. Two days is enough headroom for a serious submitter to raise a decision deposit (e.g. omnipool_admin = 250k HDX, root = 1M HDX) while keeping cleanup fast for accidental submissions.

## How Has This Been Tested?

The change is a single-constant tweak; existing upstream `pallet_referenda` tests cover the timeout state machine itself.

Bumps `spec_version` 411 → 412 and `hydradx-runtime` 411.0.0 → 412.0.0.

## Checklist:

- [x] I have updated the documentation if necessary.
- [ ] I have added tests to cover my changes, regression test if fixing an issue.
- [ ] This is a breaking change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)