### PR TITLE
fix: quick benchmark tests job

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15664,7 +15664,7 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "runtime-integration-tests"
-version = "1.80.0"
+version = "1.80.1"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6379,7 +6379,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "412.0.0"
+version = "413.0.0"
 dependencies = [
  "alloy-primitives 0.7.7",
  "alloy-sol-types 0.7.7",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "1.80.0"
+version = "1.80.1"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/src/parameters.rs
+++ b/integration-tests/src/parameters.rs
@@ -71,7 +71,7 @@ fn is_testnet_sets_correct_referenda_params_when_testnet() {
 			.find(|track| track.id == 0)
 			.expect("Root track should exist");
 
-		assert_eq!(root_track.info.prepare_period, 1);
+		assert_eq!(root_track.info.prepare_period, 2);
 		assert_eq!(root_track.info.confirm_period, 1);
 		assert_eq!(root_track.info.min_enactment_period, 1);
 	});

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "412.0.0"
+version = "413.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/governance/tracks.rs
+++ b/runtime/hydradx/src/governance/tracks.rs
@@ -197,7 +197,9 @@ const TESTNET_TRACKS_DATA: [Track<u16, Balance, BlockNumber>; 10] = [
 			name: s("root"),
 			max_deciding: 3,
 			decision_deposit: 1_000_000 * UNITS,
-			prepare_period: 1,
+			// Must be > 1 so that `pallet_referenda::nudge_referendum_preparing` benchmark stays
+			// in the prepare phase across the framework's block 0 -> 1 advance.
+			prepare_period: 2,
 			decision_period: 7 * DAYS,
 			confirm_period: 1,
 			min_enactment_period: 1,

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -129,7 +129,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("hydradx"),
 	impl_name: Cow::Borrowed("hydradx"),
 	authoring_version: 1,
-	spec_version: 412,
+	spec_version: 413,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
 ## Summary

  Bump `TESTNET_TRACKS_DATA[0].prepare_period` from `1` to `2` so the `pallet_referenda::nudge_referendum_preparing` benchmark passes.

  ## Why

  Substrate's benchmark framework advances the block from 0 to 1 between setup and the timed call. With `prepare_period: 1`, that bump pushes the referendum out of `Preparing`, which fails the benchmark's `deciding: None` assertion. Started failing after the `polkadot-stable2506-10` SDK upgrade tightened that check.