### PR TITLE
fix: dispatcher index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5779,7 +5779,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "416.0.0"
+version = "417.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -9231,7 +9231,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-dispatcher"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/pallets/dispatcher/Cargo.toml
+++ b/pallets/dispatcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-dispatcher"
-version = "1.7.3"
+version = "1.7.4"
 authors = ['GalacticCouncil']
 edition = "2021"
 license = "Apache-2.0"

--- a/pallets/dispatcher/src/lib.rs
+++ b/pallets/dispatcher/src/lib.rs
@@ -381,7 +381,7 @@ pub mod pallet {
 			Ok(actual_weight.into())
 		}
 
-		#[pallet::call_index(6)]
+		#[pallet::call_index(7)]
 		#[pallet::weight({
 			let call_weight = call.get_dispatch_info().call_weight;
 			let call_len = call.encoded_size() as u32;

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "416.0.0"
+version = "417.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -128,7 +128,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("hydradx"),
 	impl_name: Cow::Borrowed("hydradx"),
 	authoring_version: 1,
-	spec_version: 416,
+	spec_version: 417,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
 we cannot change id of existing extrinsics and events
 we are risking that someone will sign something that they dont expect

so this PR fixes dispatcher changed indexes back