### PR TITLE
feat(bonds)!: restrict issuance to Treasurer track or Root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5779,7 +5779,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "418.0.0"
+version = "419.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -8865,7 +8865,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-bonds"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8865,7 +8865,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-bonds"
-version = "2.5.0"
+version = "3.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -13799,7 +13799,7 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "runtime-integration-tests"
-version = "1.83.0"
+version = "1.84.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "1.83.0"
+version = "1.84.0"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/src/bonds.rs
+++ b/integration-tests/src/bonds.rs
@@ -5,32 +5,32 @@ use crate::polkadot_test_net::*;
 
 use frame_support::storage::with_transaction;
 use frame_support::{assert_noop, assert_ok};
-use frame_system::RawOrigin;
 use hydradx_traits::registry::{AssetKind, Create};
 use orml_traits::MultiCurrency;
 use sp_runtime::{DispatchResult, TransactionOutcome};
 use xcm_emulator::TestExt;
 
-use hydradx_runtime::{AssetRegistry, Bonds, Currencies, MultiTransactionPayment, Runtime, RuntimeOrigin, Tokens};
+use hydradx_runtime::{AssetRegistry, Balances, Bonds, Currencies, Runtime, RuntimeOrigin, Treasury};
 use primitives::constants::time::unix_time::MONTH;
 
 #[test]
 fn issue_bonds_should_work_when_issued_for_native_asset() {
 	Hydra::execute_with(|| {
 		// Arrange
-		set_fee_asset_and_fund(ALICE.into(), BTC, 1_000_000);
-
 		let amount = 100 * UNITS;
-		let fee = <Runtime as pallet_bonds::Config>::ProtocolFee::get().mul_ceil(amount);
-		let amount_without_fee: Balance = amount.checked_sub(fee).unwrap();
-		let initial_fee_receiver_balance =
-			Currencies::free_balance(HDX, &<Runtime as pallet_bonds::Config>::FeeReceiver::get());
+		let treasury = Treasury::account_id();
+		let initial_treasury_hdx = Currencies::free_balance(HDX, &treasury);
+		assert_ok!(Balances::force_set_balance(
+			RuntimeOrigin::root(),
+			treasury.clone(),
+			initial_treasury_hdx + amount,
+		));
 
 		let maturity = NOW + MONTH;
 
 		// Act
 		let bond_id = AssetRegistry::next_asset_id().unwrap();
-		assert_ok!(Bonds::issue(RuntimeOrigin::signed(ALICE.into()), HDX, amount, maturity));
+		assert_ok!(Bonds::issue(RuntimeOrigin::root(), HDX, amount, maturity));
 
 		// Assert
 		assert_eq!(Bonds::bond(bond_id).unwrap(), (HDX, maturity));
@@ -44,16 +44,9 @@ fn issue_bonds_should_work_when_issued_for_native_asset() {
 		);
 		assert_eq!(bond_asset_details.existential_deposit, NativeExistentialDeposit::get());
 
-		assert_balance!(&ALICE.into(), HDX, ALICE_INITIAL_NATIVE_BALANCE - amount);
-		assert_balance!(&ALICE.into(), bond_id, amount_without_fee);
-
-		assert_balance!(
-			&<Runtime as pallet_bonds::Config>::FeeReceiver::get(),
-			HDX,
-			initial_fee_receiver_balance + fee
-		);
-
-		assert_balance!(&Bonds::pallet_account_id(), HDX, amount_without_fee);
+		assert_balance!(&treasury, HDX, initial_treasury_hdx);
+		assert_balance!(&treasury, bond_id, amount);
+		assert_balance!(&Bonds::pallet_account_id(), HDX, amount);
 	});
 }
 
@@ -62,12 +55,8 @@ fn issue_bonds_should_work_when_issued_for_share_asset() {
 	Hydra::execute_with(|| {
 		let _ = with_transaction(|| {
 			// Arrange
-			set_fee_asset_and_fund(ALICE.into(), BTC, 1_000_000);
-
 			let amount = 100 * UNITS;
-			let fee = <Runtime as pallet_bonds::Config>::ProtocolFee::get().mul_ceil(amount);
-			let amount_without_fee: Balance = amount.checked_sub(fee).unwrap();
-
+			let treasury = Treasury::account_id();
 			let maturity = NOW + MONTH;
 
 			let name = b"SHARED".to_vec();
@@ -82,16 +71,11 @@ fn issue_bonds_should_work_when_issued_for_share_asset() {
 				None,
 			)
 			.unwrap();
-			assert_ok!(Currencies::deposit(share_asset_id, &ALICE.into(), amount,));
+			assert_ok!(Currencies::deposit(share_asset_id, &treasury, amount));
 
 			// Act
 			let bond_id = AssetRegistry::next_asset_id().unwrap();
-			assert_ok!(Bonds::issue(
-				RuntimeOrigin::signed(ALICE.into()),
-				share_asset_id,
-				amount,
-				maturity
-			));
+			assert_ok!(Bonds::issue(RuntimeOrigin::root(), share_asset_id, amount, maturity));
 
 			// Assert
 			assert_eq!(Bonds::bond(bond_id).unwrap(), (share_asset_id, maturity));
@@ -105,16 +89,9 @@ fn issue_bonds_should_work_when_issued_for_share_asset() {
 			);
 			assert_eq!(bond_asset_details.existential_deposit, 1_000);
 
-			assert_balance!(&ALICE.into(), share_asset_id, 0);
-			assert_balance!(&ALICE.into(), bond_id, amount_without_fee);
-
-			assert_balance!(
-				&<Runtime as pallet_bonds::Config>::FeeReceiver::get(),
-				share_asset_id,
-				fee
-			);
-
-			assert_balance!(&Bonds::pallet_account_id(), share_asset_id, amount_without_fee);
+			assert_balance!(&treasury, share_asset_id, 0);
+			assert_balance!(&treasury, bond_id, amount);
+			assert_balance!(&Bonds::pallet_account_id(), share_asset_id, amount);
 
 			TransactionOutcome::Commit(DispatchResult::Ok(()))
 		});
@@ -142,35 +119,13 @@ fn issue_bonds_should_not_work_when_issued_for_bond_asset() {
 			)
 			.unwrap();
 
-			assert_ok!(Currencies::deposit(underlying_asset_id, &ALICE.into(), amount,));
-
 			// Act & Assert
 			assert_noop!(
-				Bonds::issue(
-					RuntimeOrigin::signed(ALICE.into()),
-					underlying_asset_id,
-					amount,
-					maturity
-				),
-				pallet_bonds::Error::<hydradx_runtime::Runtime>::DisallowedAsset
+				Bonds::issue(RuntimeOrigin::root(), underlying_asset_id, amount, maturity),
+				pallet_bonds::Error::<Runtime>::DisallowedAsset
 			);
 
 			TransactionOutcome::Commit(DispatchResult::Ok(()))
 		});
 	});
-}
-
-fn set_fee_asset_and_fund(who: AccountId, fee_asset: AssetId, amount: Balance) {
-	assert_ok!(Tokens::set_balance(
-		RawOrigin::Root.into(),
-		who.clone(),
-		fee_asset,
-		amount,
-		0,
-	));
-
-	assert_ok!(MultiTransactionPayment::set_currency(
-		hydradx_runtime::RuntimeOrigin::signed(who),
-		fee_asset
-	));
 }

--- a/integration-tests/src/bonds.rs
+++ b/integration-tests/src/bonds.rs
@@ -56,6 +56,7 @@ fn issue_bonds_should_work_when_issued_for_share_asset() {
 		let _ = with_transaction(|| {
 			// Arrange
 			let amount = 100 * UNITS;
+			let ed = 1_000;
 			let treasury = Treasury::account_id();
 			let maturity = NOW + MONTH;
 
@@ -64,14 +65,24 @@ fn issue_bonds_should_work_when_issued_for_share_asset() {
 				None,
 				Some(name.try_into().unwrap()),
 				AssetKind::XYK,
-				Some(1_000),
+				Some(ed),
 				None,
 				None,
 				None,
 				None,
 			)
 			.unwrap();
-			assert_ok!(Currencies::deposit(share_asset_id, &treasury, amount));
+			// Fund treasury with `amount + ed` — treasury can't be reaped (has consumers from
+			// holding HDX), so the transfer must leave at least ED behind.
+			assert_ok!(Currencies::deposit(share_asset_id, &treasury, amount + ed));
+			// Treasury is in DustRemovalWhitelist, so `SufficiencyCheck` charges the destination
+			// (bonds pallet account) an HDX-denominated ED when receiving an insufficient asset.
+			// Fund it so the hook succeeds.
+			assert_ok!(Balances::force_set_balance(
+				RuntimeOrigin::root(),
+				Bonds::pallet_account_id(),
+				10 * UNITS,
+			));
 
 			// Act
 			let bond_id = AssetRegistry::next_asset_id().unwrap();
@@ -87,9 +98,9 @@ fn issue_bonds_should_work_when_issued_for_share_asset() {
 				bond_asset_details.name.unwrap().into_inner(),
 				Bonds::bond_name(share_asset_id, maturity)
 			);
-			assert_eq!(bond_asset_details.existential_deposit, 1_000);
+			assert_eq!(bond_asset_details.existential_deposit, ed);
 
-			assert_balance!(&treasury, share_asset_id, 0);
+			assert_balance!(&treasury, share_asset_id, ed);
 			assert_balance!(&treasury, bond_id, amount);
 			assert_balance!(&Bonds::pallet_account_id(), share_asset_id, amount);
 

--- a/integration-tests/src/omnipool_liquidity_mining.rs
+++ b/integration-tests/src/omnipool_liquidity_mining.rs
@@ -3137,12 +3137,7 @@ fn liquidity_mining_should_work_when_farm_distribute_bonds() {
 
 		let maturity = NOW + MONTH;
 		let bond_id = AssetRegistry::next_asset_id().unwrap();
-		assert_ok!(Bonds::issue(
-			RuntimeOrigin::signed(Treasury::account_id()),
-			HDX,
-			2_000_000 * UNITS,
-			maturity
-		));
+		assert_ok!(Bonds::issue(RuntimeOrigin::root(), HDX, 2_000_000 * UNITS, maturity));
 		assert_eq!(AssetRegistry::assets(bond_id).unwrap().asset_type, AssetType::Bond);
 		//NOTE: make bond sufficient because treasury account is whitelisted. In this case farm
 		//would have to pay ED for receiving insufficicient bods and farm's account has no balance.

--- a/integration-tests/src/xyk_liquidity_mining.rs
+++ b/integration-tests/src/xyk_liquidity_mining.rs
@@ -1057,12 +1057,7 @@ fn liquidity_mining_should_work_when_farm_distribute_bonds() {
 
 		let maturity = NOW + MONTH;
 		let bond_id = AssetRegistry::next_asset_id().unwrap();
-		assert_ok!(Bonds::issue(
-			RuntimeOrigin::signed(Treasury::account_id()),
-			HDX,
-			2_000_000 * UNITS,
-			maturity
-		));
+		assert_ok!(Bonds::issue(RuntimeOrigin::root(), HDX, 2_000_000 * UNITS, maturity));
 		assert_eq!(AssetRegistry::assets(bond_id).unwrap().asset_type, AssetType::Bond);
 		//NOTE: make bond sufficient because treasury account is whitelisted. In this case farm
 		//would have to pay ED for receiving insufficicient bods and farm's account has no balance.

--- a/pallets/bonds/Cargo.toml
+++ b/pallets/bonds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-bonds"
-version = "2.4.0"
+version = "2.5.0"
 authors = ['GalacticCouncil']
 edition = "2021"
 license = "Apache-2.0"

--- a/pallets/bonds/Cargo.toml
+++ b/pallets/bonds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-bonds"
-version = "2.5.0"
+version = "3.0.0"
 authors = ['GalacticCouncil']
 edition = "2021"
 license = "Apache-2.0"

--- a/pallets/bonds/src/benchmarks.rs
+++ b/pallets/bonds/src/benchmarks.rs
@@ -20,7 +20,7 @@
 use super::*;
 
 use frame_benchmarking::benchmarks;
-use frame_support::{assert_ok, traits::EnsureOrigin};
+use frame_support::assert_ok;
 use frame_system::RawOrigin;
 
 use orml_traits::MultiCurrency;
@@ -42,14 +42,13 @@ benchmarks! {
 	issue {
 		pallet_timestamp::Pallet::<T>::set_timestamp(NOW.into());
 
-		let origin = T::IssueOrigin::try_successful_origin().unwrap();
-		let issuer = T::IssueOrigin::ensure_origin(origin).unwrap();
+		let issuer = T::IssuerAccount::get();
 		let amount: T::Balance = (200 * ONE).into();
 		let maturity = NOW + MONTH;
 
 		T::Currency::deposit(HDX, &issuer, amount)?;
 
-	}: _(RawOrigin::Signed(issuer), HDX, (100 * ONE).into(), maturity)
+	}: _(RawOrigin::Root, HDX, (100 * ONE).into(), maturity)
 	verify {
 		assert!(BondIds::<T>::get::<(AssetId, Moment)>((HDX, maturity)).is_some());
 	}
@@ -57,24 +56,20 @@ benchmarks! {
 	redeem {
 		pallet_timestamp::Pallet::<T>::set_timestamp(NOW.into());
 
-		let origin = T::IssueOrigin::try_successful_origin().unwrap();
-		let issuer = T::IssueOrigin::ensure_origin(origin).unwrap();
+		let issuer = T::IssuerAccount::get();
 		let amount: T::Balance = (200 * ONE).into();
-		//NOTE: bonds are insufficient so issuer must ED for it
+		// NOTE: bonds are insufficient so issuer must ED for it
 		T::Currency::deposit(HDX, &issuer, amount + (100 * ONE).into())?;
 
 		let maturity = NOW + MONTH;
 
-		assert_ok!(crate::Pallet::<T>::issue(RawOrigin::Signed(issuer.clone()).into(), HDX, amount, maturity));
-
-		let fee = <T as Config>::ProtocolFee::get().mul_ceil(amount);
-		let amount_without_fee: T::Balance = amount.checked_sub(&fee).unwrap();
+		assert_ok!(crate::Pallet::<T>::issue(RawOrigin::Root.into(), HDX, amount, maturity));
 
 		pallet_timestamp::Pallet::<T>::set_timestamp((NOW + 2 * MONTH).into());
 
 		let bond_id = Bonds::<T>::iter_keys().next().unwrap();
 
-	}: _(RawOrigin::Signed(issuer.clone()), bond_id, amount_without_fee)
+	}: _(RawOrigin::Signed(issuer.clone()), bond_id, amount)
 	verify {
 		assert_eq!(T::Currency::free_balance(bond_id, &issuer), 0u32.into());
 	}

--- a/pallets/bonds/src/lib.rs
+++ b/pallets/bonds/src/lib.rs
@@ -28,10 +28,10 @@
 //! * It's possible to create multiple bonds for the same underlying asset.
 //! * Bonds can be issued for all available asset types permitted by `AssetTypeWhitelist`.
 //! * The existential deposit of the bonds is the same as of the underlying asset.
-//! * A user receives the same amount of bonds as the amount of the underlying asset he provided, minus the protocol fee.
+//! * The amount of bonds issued is 1:1 to the amount of the underlying asset provided.
+//! * The underlying asset is debited from `T::IssuerAccount`, and the bonds are credited to the same account.
 //! * Maturity of bonds is represented using the Unix time in milliseconds.
 //! * Underlying assets are stored in the pallet account until redeemed.
-//! * Protocol fee is applied to the amount of the underlying asset and transferred to the fee receiver.
 //! * It's possible to issue new bonds for bonds that are already mature.
 //!
 //! ## Redeeming of new bonds
@@ -46,13 +46,13 @@ use frame_support::{
 	ensure,
 	pallet_prelude::{DispatchResult, Get},
 	sp_runtime::{
-		traits::{AccountIdConversion, AtLeast32BitUnsigned, CheckedAdd, CheckedSub},
-		DispatchError, Permill, Saturating,
+		traits::{AccountIdConversion, AtLeast32BitUnsigned, CheckedAdd, CheckedSub, Zero},
+		DispatchError,
 	},
 	traits::{Contains, ExistenceRequirement, Time},
 	PalletId,
 };
-use frame_system::{ensure_signed, pallet_prelude::OriginFor};
+use frame_system::{ensure_root, ensure_signed, pallet_prelude::OriginFor};
 use sp_core::MaxEncodedLen;
 use sp_std::{mem, vec::Vec};
 
@@ -113,19 +113,15 @@ pub mod pallet {
 		#[pallet::constant]
 		type PalletId: Get<PalletId>;
 
-		/// The origin which can issue new bonds.
-		type IssueOrigin: EnsureOrigin<Self::RuntimeOrigin, Success = Self::AccountId>;
+		/// Origin permitted to issue new bonds, in addition to Root.
+		type IssueOrigin: EnsureOrigin<Self::RuntimeOrigin>;
+
+		/// Account that pays the underlying asset and receives the bonds when `issue` is called.
+		#[pallet::constant]
+		type IssuerAccount: Get<Self::AccountId>;
 
 		/// Asset types that are permitted to be used as underlying assets.
 		type AssetTypeWhitelist: Contains<AssetKind>;
-
-		/// Protocol fee.
-		#[pallet::constant]
-		type ProtocolFee: Get<Permill>;
-
-		/// Protocol fee receiver.
-		#[pallet::constant]
-		type FeeReceiver: Get<Self::AccountId>;
 
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
@@ -191,18 +187,18 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		/// Issue new fungible bonds.
 		/// New asset id is registered and assigned to the bonds.
-		/// The number of bonds the issuer receives is 1:1 to the `amount` of the underlying asset
-		/// minus the protocol fee.
+		/// The number of bonds issued is 1:1 to the `amount` of the underlying asset.
 		/// The bond asset is registered with the empty string for the asset name,
 		/// and with the same existential deposit as of the underlying asset.
 		/// Bonds can be redeemed for the underlying asset once mature.
-		/// Protocol fee is applied to the amount, and transferred to `T::FeeReceiver`.
+		/// The underlying asset is debited from `T::IssuerAccount`, and the bonds are credited to
+		/// the same account.
 		/// When issuing new bonds with the underlying asset and maturity that matches existing bonds,
 		/// new amount of these existing bonds is issued, instead of registering new bonds.
 		/// It's possible to issue new bonds for bonds that are already mature.
 		///
 		/// Parameters:
-		/// - `origin`: issuer of new bonds, needs to be `T::IssueOrigin`
+		/// - `origin`: must be Root or `T::IssueOrigin`.
 		/// - `asset_id`: underlying asset id
 		/// - `amount`: the amount of the underlying asset
 		/// - `maturity`: Unix time in milliseconds, when the bonds will be mature.
@@ -213,7 +209,10 @@ pub mod pallet {
 		#[pallet::call_index(0)]
 		#[pallet::weight(<T as Config>::WeightInfo::issue())]
 		pub fn issue(origin: OriginFor<T>, asset_id: AssetId, amount: T::Balance, maturity: Moment) -> DispatchResult {
-			let who = T::IssueOrigin::ensure_origin(origin)?;
+			if ensure_root(origin.clone()).is_err() {
+				T::IssueOrigin::ensure_origin(origin)?;
+			}
+			let who = T::IssuerAccount::get();
 
 			ensure!(
 				T::AssetTypeWhitelist::contains(
@@ -222,8 +221,6 @@ pub mod pallet {
 				Error::<T>::DisallowedAsset
 			);
 
-			let fee = T::ProtocolFee::get().mul_ceil(amount);
-			let amount_without_fee = amount.saturating_sub(fee);
 			let pallet_account = Self::pallet_account_id();
 
 			let bond_id = match BondIds::<T>::get((asset_id, maturity)) {
@@ -259,27 +256,14 @@ pub mod pallet {
 				}
 			};
 
-			T::Currency::transfer(
-				asset_id,
-				&who,
-				&pallet_account,
-				amount_without_fee,
-				ExistenceRequirement::AllowDeath,
-			)?;
-			T::Currency::transfer(
-				asset_id,
-				&who,
-				&T::FeeReceiver::get(),
-				fee,
-				ExistenceRequirement::AllowDeath,
-			)?;
-			T::Currency::deposit(bond_id, &who, amount_without_fee)?;
+			T::Currency::transfer(asset_id, &who, &pallet_account, amount, ExistenceRequirement::AllowDeath)?;
+			T::Currency::deposit(bond_id, &who, amount)?;
 
 			Self::deposit_event(Event::Issued {
 				issuer: who,
 				bond_id,
-				amount: amount_without_fee,
-				fee,
+				amount,
+				fee: Zero::zero(),
 			});
 
 			Ok(())

--- a/pallets/bonds/src/lib.rs
+++ b/pallets/bonds/src/lib.rs
@@ -52,7 +52,7 @@ use frame_support::{
 	traits::{Contains, ExistenceRequirement, Time},
 	PalletId,
 };
-use frame_system::{ensure_root, ensure_signed, pallet_prelude::OriginFor};
+use frame_system::{ensure_signed, pallet_prelude::OriginFor};
 use sp_core::MaxEncodedLen;
 use sp_std::{mem, vec::Vec};
 
@@ -198,7 +198,7 @@ pub mod pallet {
 		/// It's possible to issue new bonds for bonds that are already mature.
 		///
 		/// Parameters:
-		/// - `origin`: must be Root or `T::IssueOrigin`.
+		/// - `origin`: must be `T::IssueOrigin`.
 		/// - `asset_id`: underlying asset id
 		/// - `amount`: the amount of the underlying asset
 		/// - `maturity`: Unix time in milliseconds, when the bonds will be mature.
@@ -209,9 +209,7 @@ pub mod pallet {
 		#[pallet::call_index(0)]
 		#[pallet::weight(<T as Config>::WeightInfo::issue())]
 		pub fn issue(origin: OriginFor<T>, asset_id: AssetId, amount: T::Balance, maturity: Moment) -> DispatchResult {
-			if ensure_root(origin.clone()).is_err() {
-				T::IssueOrigin::ensure_origin(origin)?;
-			}
+			T::IssueOrigin::ensure_origin(origin)?;
 			let who = T::IssuerAccount::get();
 
 			ensure!(
@@ -256,7 +254,13 @@ pub mod pallet {
 				}
 			};
 
-			T::Currency::transfer(asset_id, &who, &pallet_account, amount, ExistenceRequirement::AllowDeath)?;
+			T::Currency::transfer(
+				asset_id,
+				&who,
+				&pallet_account,
+				amount,
+				ExistenceRequirement::AllowDeath,
+			)?;
 			T::Currency::deposit(bond_id, &who, amount)?;
 
 			Self::deposit_event(Event::Issued {

--- a/pallets/bonds/src/tests/issue.rs
+++ b/pallets/bonds/src/tests/issue.rs
@@ -18,12 +18,11 @@
 use crate::tests::mock::*;
 use crate::*;
 pub type Bonds = Pallet<Test>;
-use frame_support::sp_runtime::traits::Zero;
 use frame_support::{assert_noop, assert_ok};
 pub use pretty_assertions::assert_eq;
 
 #[test]
-fn issue_bonds_should_work_when_fee_is_zero() {
+fn issue_bonds_should_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		// Arrange
 		let maturity = NOW + MONTH;
@@ -57,127 +56,76 @@ fn issue_bonds_should_work_when_fee_is_zero() {
 		assert_eq!(Tokens::free_balance(HDX, &ALICE), INITIAL_BALANCE - amount);
 		assert_eq!(Tokens::free_balance(bond_id, &ALICE), amount);
 
-		assert_eq!(Tokens::free_balance(HDX, &<Test as Config>::FeeReceiver::get()), 0);
-
 		assert_eq!(Tokens::free_balance(HDX, &Bonds::pallet_account_id()), amount);
 	});
 }
 
 #[test]
-fn issue_bonds_should_work_when_fee_is_non_zero() {
-	ExtBuilder::default()
-		.with_protocol_fee(Permill::from_percent(10))
-		.build()
-		.execute_with(|| {
-			// Arrange
-			let maturity = NOW + MONTH;
-			let amount: Balance = ONE;
-			let fee = <Test as Config>::ProtocolFee::get().mul_ceil(amount);
-			let amount_without_fee: Balance = amount.checked_sub(fee).unwrap();
+fn issue_bonds_should_work_when_called_from_root() {
+	ExtBuilder::default().build().execute_with(|| {
+		let maturity = NOW + MONTH;
+		let amount = ONE;
 
-			// Act
-			let bond_id = next_asset_id();
-			assert_ok!(Bonds::issue(RuntimeOrigin::signed(ALICE), HDX, amount, maturity));
+		let bond_id = next_asset_id();
+		assert_ok!(Bonds::issue(RuntimeOrigin::root(), HDX, amount, maturity));
 
-			// Assert
-			expect_events(vec![
-				Event::TokenCreated {
-					issuer: ALICE,
-					asset_id: HDX,
-					bond_id,
-					maturity,
-				}
-				.into(),
-				Event::Issued {
-					issuer: ALICE,
-					bond_id,
-					amount: amount_without_fee,
-					fee,
-				}
-				.into(),
-			]);
-
-			assert_eq!(Bonds::bond(bond_id), Some((HDX, maturity)));
-			assert_eq!(Bonds::bond_id((HDX, maturity)), Some(bond_id));
-
-			assert_eq!(Tokens::free_balance(HDX, &ALICE), INITIAL_BALANCE - amount);
-			assert_eq!(Tokens::free_balance(bond_id, &ALICE), amount_without_fee);
-
-			assert_eq!(Tokens::free_balance(HDX, &<Test as Config>::FeeReceiver::get()), fee);
-
-			assert_eq!(
-				Tokens::free_balance(HDX, &Bonds::pallet_account_id()),
-				amount_without_fee
-			);
-		});
+		assert_eq!(Tokens::free_balance(HDX, &ALICE), INITIAL_BALANCE - amount);
+		assert_eq!(Tokens::free_balance(bond_id, &ALICE), amount);
+	});
 }
 
 #[test]
 fn issue_bonds_should_issue_new_bonds_when_bonds_are_already_registered() {
-	ExtBuilder::default()
-		.with_protocol_fee(Permill::from_percent(10))
-		.build()
-		.execute_with(|| {
-			// Arrange
-			let maturity = NOW + MONTH;
-			let amount: Balance = ONE;
-			let fee = <Test as Config>::ProtocolFee::get().mul_ceil(amount);
-			let amount_without_fee: Balance = amount.checked_sub(fee).unwrap();
+	ExtBuilder::default().build().execute_with(|| {
+		// Arrange
+		let maturity = NOW + MONTH;
+		let amount: Balance = ONE;
 
-			let bond_id = next_asset_id();
-			assert_ok!(Bonds::issue(RuntimeOrigin::signed(ALICE), HDX, amount, maturity));
+		let bond_id = next_asset_id();
+		assert_ok!(Bonds::issue(RuntimeOrigin::signed(ALICE), HDX, amount, maturity));
 
-			// Act
-			assert_ok!(Bonds::issue(RuntimeOrigin::signed(ALICE), HDX, amount, maturity));
+		// Act
+		assert_ok!(Bonds::issue(RuntimeOrigin::signed(ALICE), HDX, amount, maturity));
 
-			// Assert
-			expect_events(vec![
-				Event::TokenCreated {
-					issuer: ALICE,
-					asset_id: HDX,
-					bond_id,
-					maturity,
-				}
-				.into(),
-				Event::Issued {
-					issuer: ALICE,
-					bond_id,
-					amount: amount_without_fee,
-					fee,
-				}
-				.into(),
-				Event::Issued {
-					issuer: ALICE,
-					bond_id,
-					amount: amount_without_fee,
-					fee,
-				}
-				.into(),
-			]);
+		// Assert
+		expect_events(vec![
+			Event::TokenCreated {
+				issuer: ALICE,
+				asset_id: HDX,
+				bond_id,
+				maturity,
+			}
+			.into(),
+			Event::Issued {
+				issuer: ALICE,
+				bond_id,
+				amount,
+				fee: 0,
+			}
+			.into(),
+			Event::Issued {
+				issuer: ALICE,
+				bond_id,
+				amount,
+				fee: 0,
+			}
+			.into(),
+		]);
 
-			assert_eq!(Bonds::bond(bond_id), Some((HDX, maturity)));
-			assert_eq!(Bonds::bond_id((HDX, maturity)), Some(bond_id));
+		assert_eq!(Bonds::bond(bond_id), Some((HDX, maturity)));
+		assert_eq!(Bonds::bond_id((HDX, maturity)), Some(bond_id));
 
-			assert_eq!(Tokens::free_balance(HDX, &ALICE), INITIAL_BALANCE - 2 * amount);
+		assert_eq!(Tokens::free_balance(HDX, &ALICE), INITIAL_BALANCE - 2 * amount);
 
-			assert_eq!(Tokens::free_balance(bond_id, &ALICE), 2 * amount_without_fee);
+		assert_eq!(Tokens::free_balance(bond_id, &ALICE), 2 * amount);
 
-			assert_eq!(
-				Tokens::free_balance(HDX, &<Test as Config>::FeeReceiver::get()),
-				2 * fee
-			);
-
-			assert_eq!(
-				Tokens::free_balance(HDX, &Bonds::pallet_account_id()),
-				2 * amount_without_fee
-			);
-		});
+		assert_eq!(Tokens::free_balance(HDX, &Bonds::pallet_account_id()), 2 * amount);
+	});
 }
 
 #[test]
 fn issue_bonds_should_register_new_bonds_when_underlying_asset_is_different() {
 	ExtBuilder::default()
-		.with_protocol_fee(Permill::from_percent(10))
 		.with_registered_asset(DAI, NATIVE_EXISTENTIAL_DEPOSIT, AssetKind::Token)
 		.add_endowed_accounts(vec![(ALICE, DAI, INITIAL_BALANCE)])
 		.build()
@@ -185,8 +133,6 @@ fn issue_bonds_should_register_new_bonds_when_underlying_asset_is_different() {
 			// Arrange
 			let maturity = NOW + MONTH;
 			let amount: Balance = ONE;
-			let fee = <Test as Config>::ProtocolFee::get().mul_ceil(amount);
-			let amount_without_fee: Balance = amount.checked_sub(fee).unwrap();
 
 			let first_bond_id = next_asset_id();
 			assert_ok!(Bonds::issue(RuntimeOrigin::signed(ALICE), HDX, amount, maturity));
@@ -207,8 +153,8 @@ fn issue_bonds_should_register_new_bonds_when_underlying_asset_is_different() {
 				Event::Issued {
 					issuer: ALICE,
 					bond_id: first_bond_id,
-					amount: amount_without_fee,
-					fee,
+					amount,
+					fee: 0,
 				}
 				.into(),
 				Event::TokenCreated {
@@ -221,8 +167,8 @@ fn issue_bonds_should_register_new_bonds_when_underlying_asset_is_different() {
 				Event::Issued {
 					issuer: ALICE,
 					bond_id: second_bond_id,
-					amount: amount_without_fee,
-					fee,
+					amount,
+					fee: 0,
 				}
 				.into(),
 			]);
@@ -236,27 +182,17 @@ fn issue_bonds_should_register_new_bonds_when_underlying_asset_is_different() {
 			assert_eq!(Tokens::free_balance(HDX, &ALICE), INITIAL_BALANCE - amount);
 			assert_eq!(Tokens::free_balance(DAI, &ALICE), INITIAL_BALANCE - amount);
 
-			assert_eq!(Tokens::free_balance(first_bond_id, &ALICE), amount_without_fee);
-			assert_eq!(Tokens::free_balance(second_bond_id, &ALICE), amount_without_fee);
+			assert_eq!(Tokens::free_balance(first_bond_id, &ALICE), amount);
+			assert_eq!(Tokens::free_balance(second_bond_id, &ALICE), amount);
 
-			assert_eq!(Tokens::free_balance(HDX, &<Test as Config>::FeeReceiver::get()), fee);
-			assert_eq!(Tokens::free_balance(DAI, &<Test as Config>::FeeReceiver::get()), fee);
-
-			assert_eq!(
-				Tokens::free_balance(HDX, &Bonds::pallet_account_id()),
-				amount_without_fee
-			);
-			assert_eq!(
-				Tokens::free_balance(DAI, &Bonds::pallet_account_id()),
-				amount_without_fee
-			);
+			assert_eq!(Tokens::free_balance(HDX, &Bonds::pallet_account_id()), amount);
+			assert_eq!(Tokens::free_balance(DAI, &Bonds::pallet_account_id()), amount);
 		});
 }
 
 #[test]
 fn issue_bonds_should_register_new_bonds_when_maturity_is_different() {
 	ExtBuilder::default()
-		.with_protocol_fee(Permill::from_percent(10))
 		.with_registered_asset(DAI, NATIVE_EXISTENTIAL_DEPOSIT, AssetKind::Token)
 		.add_endowed_accounts(vec![(ALICE, DAI, INITIAL_BALANCE)])
 		.build()
@@ -265,8 +201,6 @@ fn issue_bonds_should_register_new_bonds_when_maturity_is_different() {
 			let next_month = NOW + MONTH;
 			let next_week = NOW + WEEK;
 			let amount: Balance = ONE;
-			let fee = <Test as Config>::ProtocolFee::get().mul_ceil(amount);
-			let amount_without_fee: Balance = amount.checked_sub(fee).unwrap();
 
 			let first_bond_id = next_asset_id();
 			assert_ok!(Bonds::issue(RuntimeOrigin::signed(ALICE), HDX, amount, next_month));
@@ -287,8 +221,8 @@ fn issue_bonds_should_register_new_bonds_when_maturity_is_different() {
 				Event::Issued {
 					issuer: ALICE,
 					bond_id: first_bond_id,
-					amount: amount_without_fee,
-					fee,
+					amount,
+					fee: 0,
 				}
 				.into(),
 				Event::TokenCreated {
@@ -301,8 +235,8 @@ fn issue_bonds_should_register_new_bonds_when_maturity_is_different() {
 				Event::Issued {
 					issuer: ALICE,
 					bond_id: second_bond_id,
-					amount: amount_without_fee,
-					fee,
+					amount,
+					fee: 0,
 				}
 				.into(),
 			]);
@@ -315,18 +249,10 @@ fn issue_bonds_should_register_new_bonds_when_maturity_is_different() {
 
 			assert_eq!(Tokens::free_balance(HDX, &ALICE), INITIAL_BALANCE - 2 * amount);
 
-			assert_eq!(Tokens::free_balance(first_bond_id, &ALICE), amount_without_fee);
-			assert_eq!(Tokens::free_balance(second_bond_id, &ALICE), amount_without_fee);
+			assert_eq!(Tokens::free_balance(first_bond_id, &ALICE), amount);
+			assert_eq!(Tokens::free_balance(second_bond_id, &ALICE), amount);
 
-			assert_eq!(
-				Tokens::free_balance(HDX, &<Test as Config>::FeeReceiver::get()),
-				2 * fee
-			);
-
-			assert_eq!(
-				Tokens::free_balance(HDX, &Bonds::pallet_account_id()),
-				2 * amount_without_fee
-			);
+			assert_eq!(Tokens::free_balance(HDX, &Bonds::pallet_account_id()), 2 * amount);
 		});
 }
 
@@ -375,8 +301,6 @@ fn issue_bonds_should_work_when_bonds_are_mature() {
 
 		assert_eq!(Tokens::free_balance(HDX, &ALICE), INITIAL_BALANCE - 2 * amount);
 		assert_eq!(Tokens::free_balance(bond_id, &ALICE), 2 * amount);
-
-		assert_eq!(Tokens::free_balance(HDX, &<Test as Config>::FeeReceiver::get()), 0);
 
 		assert_eq!(Tokens::free_balance(HDX, &Bonds::pallet_account_id()), 2 * amount);
 	});
@@ -440,8 +364,6 @@ fn reissuance_of_bonds_should_work_again_when_all_bonds_were_redeemed() {
 		assert_eq!(Tokens::free_balance(HDX, &ALICE), INITIAL_BALANCE - amount);
 		assert_eq!(Tokens::free_balance(bond_id, &ALICE), amount);
 
-		assert_eq!(Tokens::free_balance(HDX, &<Test as Config>::FeeReceiver::get()), 0);
-
 		assert_eq!(Tokens::free_balance(HDX, &Bonds::pallet_account_id()), amount);
 	});
 }
@@ -479,10 +401,10 @@ fn issue_bonds_should_fail_when_maturity_is_in_the_past() {
 }
 
 #[test]
-fn issue_bonds_should_fail_when_insufficient_balance() {
+fn issue_bonds_should_fail_when_issuer_has_insufficient_balance() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_noop!(
-			Bonds::issue(RuntimeOrigin::signed(BOB), HDX, ONE, NOW + MONTH),
+			Bonds::issue(RuntimeOrigin::signed(ALICE), HDX, INITIAL_BALANCE + 1, NOW + MONTH),
 			orml_tokens::Error::<Test>::BalanceTooLow
 		);
 	});

--- a/pallets/bonds/src/tests/mock.rs
+++ b/pallets/bonds/src/tests/mock.rs
@@ -24,9 +24,9 @@ use frame_support::{
 		traits::{BlakeTwo256, IdentityLookup},
 		BuildStorage,
 	},
-	traits::{ConstU32, ConstU64, Everything, SortedMembers},
+	traits::{ConstU32, ConstU64, EitherOfDiverse, Everything, SortedMembers},
 };
-use frame_system::EnsureSignedBy;
+use frame_system::{EnsureRoot, EnsureSignedBy};
 use sp_core::H256;
 use sp_runtime::BoundedVec;
 use std::{cell::RefCell, collections::HashMap};
@@ -106,7 +106,7 @@ impl pallet_bonds::Config for Test {
 	type ExistentialDeposits = ExistentialDeposits;
 	type TimestampProvider = Timestamp;
 	type PalletId = BondsPalletId;
-	type IssueOrigin = EnsureSignedBy<AliceOrBob, AccountId>;
+	type IssueOrigin = EitherOfDiverse<EnsureRoot<AccountId>, EnsureSignedBy<AliceOrBob, AccountId>>;
 	type IssuerAccount = IssuerAccount;
 	type AssetTypeWhitelist = AssetTypeWhitelist;
 	type WeightInfo = ();

--- a/pallets/bonds/src/tests/mock.rs
+++ b/pallets/bonds/src/tests/mock.rs
@@ -56,14 +56,12 @@ pub const INITIAL_BALANCE: Balance = 1_000 * ONE;
 
 pub const ALICE: AccountId = 1;
 pub const BOB: AccountId = 2;
-pub const TREASURY: AccountId = 400;
 
 pub const NOW: Moment = 1689844300000; // unix time in milliseconds
 
 thread_local! {
 	// maps AssetId -> existential deposit
 	pub static REGISTERED_ASSETS: RefCell<HashMap<AssetId, (Balance, AssetKind)>> = RefCell::new(HashMap::default());
-	pub static PROTOCOL_FEE: RefCell<Permill> = const { RefCell::new(Permill::from_percent(0)) };
 }
 
 construct_runtime!(
@@ -77,8 +75,7 @@ construct_runtime!(
 );
 
 parameter_types! {
-	pub ProtocolFee: Permill = PROTOCOL_FEE.with(|v| *v.borrow());
-	pub TreasuryAccount: AccountId = TREASURY;
+	pub IssuerAccount: AccountId = ALICE;
 	pub const BondsPalletId: PalletId = PalletId(*b"pltbonds");
 }
 
@@ -110,9 +107,8 @@ impl pallet_bonds::Config for Test {
 	type TimestampProvider = Timestamp;
 	type PalletId = BondsPalletId;
 	type IssueOrigin = EnsureSignedBy<AliceOrBob, AccountId>;
+	type IssuerAccount = IssuerAccount;
 	type AssetTypeWhitelist = AssetTypeWhitelist;
-	type ProtocolFee = ProtocolFee;
-	type FeeReceiver = TreasuryAccount;
 	type WeightInfo = ();
 }
 
@@ -266,19 +262,13 @@ impl<T: Config> Inspect for DummyRegistry<T> {
 pub struct ExtBuilder {
 	endowed_accounts: Vec<(AccountId, AssetId, Balance)>,
 	registered_assets: Vec<(AssetId, (Balance, AssetKind))>,
-	protocol_fee: Permill,
 }
 
 impl Default for ExtBuilder {
 	fn default() -> Self {
-		PROTOCOL_FEE.with(|v| {
-			*v.borrow_mut() = Permill::from_percent(0);
-		});
-
 		Self {
 			endowed_accounts: vec![(ALICE, HDX, 1_000 * ONE)],
 			registered_assets: vec![(HDX, (NATIVE_EXISTENTIAL_DEPOSIT, AssetKind::Token))],
-			protocol_fee: Permill::from_percent(0),
 		}
 	}
 }
@@ -294,10 +284,6 @@ impl ExtBuilder {
 		self.registered_assets.push((asset, (ed, asset_kind)));
 		self
 	}
-	pub fn with_protocol_fee(mut self, fee: Permill) -> Self {
-		self.protocol_fee = fee;
-		self
-	}
 
 	pub fn build(self) -> sp_io::TestExternalities {
 		let mut t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
@@ -306,10 +292,6 @@ impl ExtBuilder {
 			self.registered_assets.iter().for_each(|(asset, existential_details)| {
 				v.borrow_mut().insert(*asset, *existential_details);
 			});
-		});
-
-		PROTOCOL_FEE.with(|v| {
-			*v.borrow_mut() = self.protocol_fee;
 		});
 
 		orml_tokens::GenesisConfig::<Test> {

--- a/pallets/bonds/src/tests/redeem.rs
+++ b/pallets/bonds/src/tests/redeem.rs
@@ -22,7 +22,7 @@ use frame_support::{assert_noop, assert_ok};
 pub use pretty_assertions::assert_eq;
 
 #[test]
-fn partially_redeem_bonds_should_work_when_fee_is_zero() {
+fn partially_redeem_bonds_should_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		// Arrange
 		let maturity = NOW + MONTH;
@@ -54,8 +54,6 @@ fn partially_redeem_bonds_should_work_when_fee_is_zero() {
 		);
 		assert_eq!(Tokens::free_balance(bond_id, &ALICE), amount - redeem_amount);
 
-		assert_eq!(Tokens::free_balance(HDX, &<Test as Config>::FeeReceiver::get()), 0);
-
 		assert_eq!(
 			Tokens::free_balance(HDX, &Bonds::pallet_account_id()),
 			amount - redeem_amount
@@ -64,57 +62,7 @@ fn partially_redeem_bonds_should_work_when_fee_is_zero() {
 }
 
 #[test]
-fn partially_redeem_bonds_should_work_when_fee_is_non_zero() {
-	ExtBuilder::default()
-		.with_protocol_fee(Permill::from_percent(10))
-		.build()
-		.execute_with(|| {
-			// Arrange
-			let maturity = NOW + MONTH;
-			let amount = ONE;
-			let fee = <Test as Config>::ProtocolFee::get().mul_ceil(amount);
-			let amount_without_fee: Balance = amount.checked_sub(fee).unwrap();
-			let redeem_amount = amount_without_fee.checked_div(4).unwrap();
-
-			let bond_id = next_asset_id();
-			assert_ok!(Bonds::issue(RuntimeOrigin::signed(ALICE), HDX, amount, maturity));
-
-			Timestamp::set_timestamp(NOW + 2 * MONTH);
-
-			// Act
-			assert_ok!(Bonds::redeem(RuntimeOrigin::signed(ALICE), bond_id, redeem_amount));
-
-			// Assert
-			expect_events(vec![Event::Redeemed {
-				who: ALICE,
-				bond_id,
-				amount: redeem_amount,
-			}
-			.into()]);
-
-			assert_eq!(Bonds::bond(bond_id), Some((HDX, maturity)));
-			assert_eq!(Bonds::bond_id((HDX, maturity)), Some(bond_id));
-
-			assert_eq!(
-				Tokens::free_balance(HDX, &ALICE),
-				INITIAL_BALANCE - amount + redeem_amount
-			);
-			assert_eq!(
-				Tokens::free_balance(bond_id, &ALICE),
-				amount_without_fee - redeem_amount
-			);
-
-			assert_eq!(Tokens::free_balance(HDX, &<Test as Config>::FeeReceiver::get()), fee);
-
-			assert_eq!(
-				Tokens::free_balance(HDX, &Bonds::pallet_account_id()),
-				amount_without_fee - redeem_amount
-			);
-		});
-}
-
-#[test]
-fn fully_redeem_bonds_should_work_when_fee_is_zero() {
+fn fully_redeem_bonds_should_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		// Arrange
 		let maturity = NOW + MONTH;
@@ -142,50 +90,8 @@ fn fully_redeem_bonds_should_work_when_fee_is_zero() {
 		assert_eq!(Tokens::free_balance(HDX, &ALICE), INITIAL_BALANCE);
 		assert_eq!(Tokens::free_balance(bond_id, &ALICE), 0);
 
-		assert_eq!(Tokens::free_balance(HDX, &<Test as Config>::FeeReceiver::get()), 0);
-
 		assert_eq!(Tokens::free_balance(HDX, &Bonds::pallet_account_id()), 0);
 	});
-}
-
-#[test]
-fn fully_redeem_bonds_should_work_when_fee_is_non_zero() {
-	ExtBuilder::default()
-		.with_protocol_fee(Permill::from_percent(10))
-		.build()
-		.execute_with(|| {
-			// Arrange
-			let maturity = NOW + MONTH;
-			let amount = ONE;
-			let fee = <Test as Config>::ProtocolFee::get().mul_ceil(amount);
-			let amount_without_fee: Balance = amount.checked_sub(fee).unwrap();
-
-			let bond_id = next_asset_id();
-			assert_ok!(Bonds::issue(RuntimeOrigin::signed(ALICE), HDX, amount, maturity));
-
-			Timestamp::set_timestamp(NOW + 2 * MONTH);
-
-			// Act
-			assert_ok!(Bonds::redeem(RuntimeOrigin::signed(ALICE), bond_id, amount_without_fee));
-
-			// Assert
-			expect_events(vec![Event::Redeemed {
-				who: ALICE,
-				bond_id,
-				amount: amount_without_fee,
-			}
-			.into()]);
-
-			assert!(crate::Bonds::<Test>::contains_key(bond_id));
-			assert!(crate::BondIds::<Test>::contains_key((HDX, maturity)));
-
-			assert_eq!(Tokens::free_balance(HDX, &ALICE), INITIAL_BALANCE - fee);
-			assert_eq!(Tokens::free_balance(bond_id, &ALICE), 0);
-
-			assert_eq!(Tokens::free_balance(HDX, &<Test as Config>::FeeReceiver::get()), fee);
-
-			assert_eq!(Tokens::free_balance(HDX, &Bonds::pallet_account_id()), 0);
-		});
 }
 
 #[test]
@@ -222,8 +128,6 @@ fn redeem_bonds_should_work_when_redeemed_from_non_issuer_account() {
 
 		assert_eq!(Tokens::free_balance(HDX, &BOB), redeem_amount);
 		assert_eq!(Tokens::free_balance(bond_id, &BOB), 0);
-
-		assert_eq!(Tokens::free_balance(HDX, &<Test as Config>::FeeReceiver::get()), 0);
 
 		assert_eq!(
 			Tokens::free_balance(HDX, &Bonds::pallet_account_id()),

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "418.0.0"
+version = "419.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/assets.rs
+++ b/runtime/hydradx/src/assets.rs
@@ -1592,7 +1592,7 @@ impl pallet_bonds::Config for Runtime {
 	type ExistentialDeposits = AssetRegistry;
 	type TimestampProvider = Timestamp;
 	type PalletId = BondsPalletId;
-	type IssueOrigin = Treasurer;
+	type IssueOrigin = EitherOf<EnsureRoot<Self::AccountId>, Treasurer>;
 	type IssuerAccount = TreasuryAccount;
 	type AssetTypeWhitelist = AssetTypeWhitelist;
 	type WeightInfo = weights::pallet_bonds::HydraWeight<Runtime>;

--- a/runtime/hydradx/src/assets.rs
+++ b/runtime/hydradx/src/assets.rs
@@ -18,7 +18,7 @@
 use super::*;
 use crate::evm::precompiles::erc20_mapping::SetCodeForErc20Precompile;
 use crate::evm::Erc20Currency;
-use crate::origins::{EconomicParameters, GeneralAdmin, OmnipoolAdmin};
+use crate::origins::{EconomicParameters, GeneralAdmin, OmnipoolAdmin, Treasurer};
 use crate::system::NativeAssetId;
 use crate::Stableswap;
 use core::ops::RangeInclusive;
@@ -36,7 +36,7 @@ use frame_support::{
 	},
 	BoundedVec, PalletId,
 };
-use frame_system::{EnsureRoot, EnsureSigned, RawOrigin};
+use frame_system::{EnsureRoot, RawOrigin};
 use hydradx_adapters::{
 	stableswap_peg_oracle::PegOracle, AssetFeeOraclePriceProvider, EmaOraclePriceAdapter, FreezableNFT,
 	MultiCurrencyLockedBalance, OmnipoolHookAdapter, OmnipoolRawOracleAssetVolumeProvider, OraclePriceProvider,
@@ -1572,14 +1572,16 @@ impl pallet_stableswap::Config for Runtime {
 
 // Bonds
 parameter_types! {
-	pub ProtocolFee: Permill = Permill::from_percent(2);
 	pub const BondsPalletId: PalletId = PalletId(*b"pltbonds");
 }
 
 pub struct AssetTypeWhitelist;
 impl Contains<AssetKind> for AssetTypeWhitelist {
 	fn contains(t: &AssetKind) -> bool {
-		matches!(t, AssetKind::Token | AssetKind::XYK | AssetKind::StableSwap)
+		matches!(
+			t,
+			AssetKind::Token | AssetKind::XYK | AssetKind::StableSwap | AssetKind::Erc20
+		)
 	}
 }
 
@@ -1590,10 +1592,9 @@ impl pallet_bonds::Config for Runtime {
 	type ExistentialDeposits = AssetRegistry;
 	type TimestampProvider = Timestamp;
 	type PalletId = BondsPalletId;
-	type IssueOrigin = EnsureSigned<AccountId>;
+	type IssueOrigin = Treasurer;
+	type IssuerAccount = TreasuryAccount;
 	type AssetTypeWhitelist = AssetTypeWhitelist;
-	type ProtocolFee = ProtocolFee;
-	type FeeReceiver = TreasuryAccount;
 	type WeightInfo = weights::pallet_bonds::HydraWeight<Runtime>;
 }
 

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -128,7 +128,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("hydradx"),
 	impl_name: Cow::Borrowed("hydradx"),
 	authoring_version: 1,
-	spec_version: 418,
+	spec_version: 419,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
## Summary

Refactors the bonds pallet so that bond issuance is gated to **Root or the Treasurer governance track**, removes the protocol fee, and lets the runtime accept Erc20 underlyings.

### Pallet (`pallet-bonds`) — breaking config changes
- `IssueOrigin: EnsureOrigin<...>` — bound relaxed; success type no longer constrained. The pallet now gates `issue` on `ensure_root || T::IssueOrigin::ensure_origin`.
- **New** `IssuerAccount: Get<Self::AccountId>` — the account that pays the underlying and receives the bonds.
- **Removed** `ProtocolFee` and `FeeReceiver` config items. The fee math is gone from `issue`; `Event::Issued.fee` is retained for event-ABI stability and always emitted as zero.

### Runtime (`hydradx-runtime`)
- `IssueOrigin = Treasurer` (custom OpenGov origin), `IssuerAccount = TreasuryAccount`.
- `AssetTypeWhitelist` now matches `AssetKind::Token | XYK | StableSwap | Erc20`.
- `spec_version` 418 → 419, `hydradx-runtime` 418.0.0 → 419.0.0.

### Tests / benchmarks
- Pallet unit tests: dropped non-zero-fee variants (no longer reachable), stripped `FeeReceiver` assertions, rewrote the insufficient-balance test for the new semantics, added a Root-origin success case. 23/23 pass.
- Benchmarks: use `T::IssuerAccount::get()` for funding and `RawOrigin::Root` to satisfy the gate.
- Integration tests: `integration-tests/src/bonds.rs` rewritten to fund Treasury and dispatch as Root; the two LM tests now use `RuntimeOrigin::root()` for `Bonds::issue`.

## Test plan

- [x] `cargo test -p pallet-bonds --locked` — 23/23 pass
- [x] `cargo check -p pallet-bonds --features runtime-benchmarks`
- [x] `cargo check -p hydradx-runtime`
- [x] `cargo check --tests -p runtime-integration-tests`
- [ ] CI: full integration-test suite (failed locally due to autoconf rejecting a space in my repo path; CI runs in a clean path)
- [ ] CI: clippy / fmt
- [ ] Fork-test bond issuance against an Erc20 underlying (HOLLAR) end-to-end before mainnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)