### PR TITLE
feat: coretime renewal watchdog

### DIFF
--- a/scripts/coretime-alert/.dockerignore
+++ b/scripts/coretime-alert/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+.state.json
+*.log
+README.md
+lark-stack.yml
+.gitignore
+Dockerfile
+.dockerignore
+package-lock.json

--- a/scripts/coretime-alert/.gitignore
+++ b/scripts/coretime-alert/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.state.json
+*.log

--- a/scripts/coretime-alert/Dockerfile
+++ b/scripts/coretime-alert/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install --omit=dev --no-audit --no-fund && npm cache clean --force
+
+COPY check.mjs ./
+
+ENV STATE_FILE=/app/state/.state.json \
+    ALERT_COOLDOWN_HOURS=12 \
+    LEADIN_ALERT_DAYS=3 \
+    TOTAL_ALERT_DAYS=7 \
+    CHECK_INTERVAL_SECONDS=3600
+
+VOLUME ["/app/state"]
+
+# Run the check, then sleep for the configured interval, forever.
+CMD ["sh", "-c", "while true; do node check.mjs; sleep ${CHECK_INTERVAL_SECONDS:-3600}; done"]

--- a/scripts/coretime-alert/README.md
+++ b/scripts/coretime-alert/README.md
@@ -1,0 +1,147 @@
+# coretime renewal watchdog
+
+Alerts a Discord webhook when Hydration's (Polkadot, task `2034`) or Basilisk's
+(Kusama, task `2090`) bulk coretime cores are at risk of lapsing in the current
+sale.
+
+Bulk cores are **not leases** — they must be renewed every ~28-day sale cycle or
+they fall back to the open market. This watchdog watches the `broker` pallet on
+each coretime chain and pings before the renewal window closes.
+
+## what triggers an alert
+
+An alert fires for a chain only when it is **short of its target core count for
+the upcoming region** (i.e. some cores are still un-renewed) **and** the deadline
+is near:
+
+| condition | default | severity |
+|-----------|---------|----------|
+| `< TOTAL_ALERT_DAYS` until the region begins (hard deadline — renewal right is lost after) | 7 days | `URGENT` |
+| inside the lead-in period with `< LEADIN_ALERT_DAYS` left in it | 3 days | `WARNING` |
+
+"Short" = `secured cores for next region (workplan) < desired`. The alert lists the
+pending `broker.renew(core)` calls (with encoded hex) needed to close the gap.
+
+> Note: the cheapest, priority window to renew is actually the **interlude**
+> (before lead-in). These thresholds, as requested, only warn once the lead-in is
+> closing / the hard deadline is near — so treat an alert as "renew now, you're
+> past the ideal window". Lower the thresholds if you want earlier warnings.
+
+## setup
+
+```sh
+cd scripts/coretime-alert
+npm install
+export DISCORD_WEBHOOK_URL='https://discord.com/api/webhooks/XXX/YYY'
+node check.mjs            # one-shot check; alerts if within thresholds
+```
+
+### useful invocations
+
+```sh
+node check.mjs --dry-run   # print the payload instead of POSTing (no webhook needed)
+node check.mjs --test      # POST a "webhook reachable" message and exit
+node check.mjs --force     # ignore the cooldown and (re)send any active alert
+```
+
+## configuration (env vars)
+
+| var | default | meaning |
+|-----|---------|---------|
+| `DISCORD_WEBHOOK_URL` | — | **required** (unless `--dry-run`) |
+| `DISCORD_WEBHOOK_URL_FILE` | — | alternative source: read the webhook from a file (e.g. a mounted secret) |
+| `CHECK_INTERVAL_SECONDS` | `3600` | (docker image only) seconds between checks in the built-in loop |
+| `LEADIN_ALERT_DAYS` | `3` | warn when this many days are left in the lead-in period |
+| `TOTAL_ALERT_DAYS` | `7` | warn when this many days are left until the region begins |
+| `ALERT_COOLDOWN_HOURS` | `12` | minimum gap between repeat alerts for the same condition |
+| `HYDRATION_DESIRED_CORES` | `3` | target core count for task 2034 |
+| `BASILISK_DESIRED_CORES` | `3` | target core count for task 2090 |
+| `STATE_FILE` | `./.state.json` | where the throttle state is persisted |
+
+State persists across runs so a standing condition only re-pings every
+`ALERT_COOLDOWN_HOURS`; it re-alerts immediately if severity or shortfall changes,
+and clears itself once the cores are renewed.
+
+## running it as a service
+
+It's a one-shot check — schedule it. Hourly is plenty (the relevant deadlines move
+in days).
+
+### cron
+
+```cron
+0 * * * * cd /path/to/hydration-node/scripts/coretime-alert && DISCORD_WEBHOOK_URL='https://discord.com/api/webhooks/XXX/YYY' /usr/bin/node check.mjs >> /var/log/coretime-alert.log 2>&1
+```
+
+### systemd timer
+
+`/etc/systemd/system/coretime-alert.service`
+
+```ini
+[Unit]
+Description=Coretime renewal watchdog
+After=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/path/to/hydration-node/scripts/coretime-alert
+Environment=DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/XXX/YYY
+ExecStart=/usr/bin/node check.mjs
+```
+
+`/etc/systemd/system/coretime-alert.timer`
+
+```ini
+[Unit]
+Description=Run coretime renewal watchdog hourly
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+```sh
+systemctl enable --now coretime-alert.timer
+```
+
+## docker image / lark deployment
+
+A `Dockerfile` builds `galacticcouncil/coretime-alert`; the image runs the check
+on an hourly loop (`CHECK_INTERVAL_SECONDS`).
+
+```sh
+docker build -t galacticcouncil/coretime-alert:latest .
+docker push galacticcouncil/coretime-alert:latest
+# smoke test: one-shot dry-run inside the image
+docker run --rm galacticcouncil/coretime-alert:latest node check.mjs --dry-run
+```
+
+On the **lark** Swarm it's deployed as the `coretime-alert` stack from
+`lark-stack.yml` (single replica, `state` volume, `autoredeploy` on). The webhook
+is injected as `DISCORD_WEBHOOK_URL` via `$env` at deploy time and is never stored
+in the repo — see the safe-forwarding options below.
+
+### forwarding the webhook safely
+
+`$env:DISCORD_WEBHOOK_URL` resolves against the **swarmpit MCP server's**
+environment (defined in `~/.claude.json`), not your interactive shell. Pick one:
+
+- **local deploy file** — copy `lark-stack.yml` outside the repo with the real URL
+  inlined (`chmod 600`), and deploy that file. Value never enters the repo or chat.
+- **MCP server env** — add `DISCORD_WEBHOOK_URL` to the `swarmpit-lark` `env` block
+  in `~/.claude.json`, then restart so the server inherits it.
+
+Do **not** paste the URL into a chat/agent prompt — it ends up in transcripts.
+Rotate the webhook in Discord if it ever leaks.
+
+## notes
+
+- Endpoints have built-in fallbacks per chain; a failed assessment posts a (throttled)
+  `🔌 check failed` notice so the watchdog never dies silently.
+- Renewed cores get **new core indices** each cycle (the assignment to the task is
+  preserved), so the listed core numbers change after every renewal — expected.
+- Adding another para: append an entry to `CHAINS` in `check.mjs` with its task id,
+  relay, and coretime endpoints.

--- a/scripts/coretime-alert/check.mjs
+++ b/scripts/coretime-alert/check.mjs
@@ -1,0 +1,313 @@
+#!/usr/bin/env node
+// Coretime renewal watchdog.
+//
+// For each configured parachain it inspects the broker pallet on the relevant
+// coretime chain and decides whether the para's bulk cores are at risk of
+// lapsing in the current sale. It alerts a Discord webhook when, with cores
+// still un-renewed for the upcoming region, either:
+//   * we are inside the lead-in period with < LEADIN_ALERT_DAYS left, or
+//   * < TOTAL_ALERT_DAYS remain until the region begins (the hard deadline,
+//     after which the renewal right is lost).
+//
+// Designed to be run periodically (cron / systemd timer). State is persisted so
+// a persisting condition only re-pings every ALERT_COOLDOWN_HOURS.
+
+import { ApiPromise, WsProvider } from '@polkadot/api';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+// --- timeslice geometry (identical on Polkadot & Kusama) ---
+const BLOCKS_PER_TIMESLICE = 80;
+const SECONDS_PER_BLOCK = 6;
+const SECS_PER_DAY = 86400;
+const relativeDays = (relayBlocksAway) => (relayBlocksAway * SECONDS_PER_BLOCK) / SECS_PER_DAY;
+
+// --- config (overridable via env) ---
+const LEADIN_ALERT_DAYS = Number(process.env.LEADIN_ALERT_DAYS ?? 3);
+const TOTAL_ALERT_DAYS = Number(process.env.TOTAL_ALERT_DAYS ?? 7);
+const ALERT_COOLDOWN_HOURS = Number(process.env.ALERT_COOLDOWN_HOURS ?? 12);
+const STATE_FILE = process.env.STATE_FILE ?? new URL('./.state.json', import.meta.url).pathname;
+// Webhook may be given directly (env) or via a file (e.g. a mounted Swarm secret).
+function resolveWebhook() {
+  if (process.env.DISCORD_WEBHOOK_URL) return process.env.DISCORD_WEBHOOK_URL.trim();
+  const f = process.env.DISCORD_WEBHOOK_URL_FILE;
+  if (f) {
+    try {
+      return readFileSync(f, 'utf8').trim();
+    } catch (e) {
+      console.error('warn: cannot read DISCORD_WEBHOOK_URL_FILE:', e.message);
+    }
+  }
+  return undefined;
+}
+const WEBHOOK = resolveWebhook();
+
+const CHAINS = [
+  {
+    name: 'Hydration',
+    relay: 'Polkadot',
+    task: 2034,
+    desiredCores: Number(process.env.HYDRATION_DESIRED_CORES ?? 3),
+    coretime: [
+      'wss://sys.ibp.network/coretime-polkadot',
+      'wss://coretime-polkadot.dotters.network',
+      'wss://polkadot-coretime-rpc.polkadot.io',
+    ],
+  },
+  {
+    name: 'Basilisk',
+    relay: 'Kusama',
+    task: 2090,
+    desiredCores: Number(process.env.BASILISK_DESIRED_CORES ?? 3),
+    coretime: [
+      'wss://sys.ibp.network/coretime-kusama',
+      'wss://coretime-kusama.dotters.network',
+      'wss://kusama-coretime-rpc.polkadot.io',
+    ],
+  },
+];
+
+const argv = new Set(process.argv.slice(2));
+const DRY_RUN = argv.has('--dry-run');
+const FORCE = argv.has('--force');
+const TEST = argv.has('--test');
+
+const log = (...a) => console.log(new Date().toISOString(), ...a);
+
+async function connectWithFallback(endpoints) {
+  let lastErr;
+  for (const ep of endpoints) {
+    try {
+      const api = await ApiPromise.create({ provider: new WsProvider(ep), throwOnConnect: true, noInitWarn: true });
+      return { api, endpoint: ep };
+    } catch (e) {
+      lastErr = e;
+    }
+  }
+  throw new Error(`all endpoints failed: ${lastErr?.message ?? lastErr}`);
+}
+
+function formatToken(planck, decimals, symbol) {
+  const v = Number(BigInt(planck)) / 10 ** decimals;
+  return `${v.toLocaleString('en-US', { maximumFractionDigits: 4 })} ${symbol}`;
+}
+
+async function assess(chain) {
+  const { api, endpoint } = await connectWithFallback(chain.coretime);
+  try {
+    const decimals = api.registry.chainDecimals[0] ?? 10;
+    const symbol = api.registry.chainTokens[0] ?? '';
+
+    const status = (await api.query.broker.status()).toJSON();
+    const sale = (await api.query.broker.saleInfo()).toJSON();
+    const cfg = (await api.query.broker.configuration()).toJSON();
+
+    const nowTs = status.lastTimeslice;
+    const nowRelay = nowTs * BLOCKS_PER_TIMESLICE;
+    const regionBegin = sale.regionBegin; // timeslice the next region starts
+    const regionBeginRelay = regionBegin * BLOCKS_PER_TIMESLICE;
+    const leadinStart = sale.saleStart; // relay block where interlude ends / lead-in begins
+    const leadinEnd = sale.saleStart + sale.leadinLength;
+
+    const phase =
+      nowRelay < leadinStart ? 'interlude'
+      : nowRelay < leadinEnd ? 'leadin'
+      : nowRelay < regionBeginRelay ? 'fixed'
+      : 'region-open';
+
+    const daysToLeadinEnd = relativeDays(leadinEnd - nowRelay);
+    const daysToRegionBegin = relativeDays(regionBeginRelay - nowRelay);
+
+    // Active cores serving the para right now.
+    const activeCores = [];
+    for (const [k, v] of await api.query.broker.workload.entries()) {
+      if (JSON.stringify(v.toJSON()).includes(`"task":${chain.task}`)) activeCores.push(k.args[0].toNumber());
+    }
+
+    // Cores already secured for the upcoming region (regionBegin) via workplan.
+    const securedCores = [];
+    for (const [k, v] of await api.query.broker.workplan.entries()) {
+      const [ts, core] = k.args[0].toJSON();
+      if (ts === regionBegin && JSON.stringify(v.toJSON()).includes(`"task":${chain.task}`)) securedCores.push(core);
+    }
+
+    // Un-exercised renewal rights for the upcoming region (when === regionBegin).
+    const pendingRenewals = [];
+    for (const [k, v] of await api.query.broker.potentialRenewals.entries()) {
+      const key = k.args[0].toJSON();
+      const val = v.toJSON();
+      if (key.when === regionBegin && JSON.stringify(val).includes(`"task":${chain.task}`)) {
+        pendingRenewals.push({ core: key.core, price: val.price, priceFmt: formatToken(val.price, decimals, symbol) });
+      }
+    }
+
+    const shortfall = Math.max(0, chain.desiredCores - securedCores.length);
+
+    // Encoded renew calls for the pending cores (handy to paste into a signer).
+    const renewCalls = pendingRenewals.map((p) => ({
+      core: p.core,
+      callHex: api.tx.broker.renew(p.core).method.toHex(),
+    }));
+
+    return {
+      ok: true,
+      endpoint,
+      decimals,
+      symbol,
+      phase,
+      nowTs,
+      regionBegin,
+      regionEnd: sale.regionEnd,
+      daysToLeadinEnd,
+      daysToRegionBegin,
+      activeCores: activeCores.sort((a, b) => a - b),
+      securedCores: securedCores.sort((a, b) => a - b),
+      pendingRenewals,
+      renewCalls,
+      shortfall,
+    };
+  } finally {
+    await api.disconnect();
+  }
+}
+
+function decideAlert(chain, a) {
+  // Only a shortfall (cores not yet secured for next region) is actionable.
+  if (a.shortfall <= 0) return null;
+  const reasons = [];
+  let severity = null;
+  if (a.daysToRegionBegin < TOTAL_ALERT_DAYS) {
+    severity = 'URGENT';
+    reasons.push(`only ${a.daysToRegionBegin.toFixed(1)}d until the region begins — renewal right is lost after that`);
+  }
+  if (a.phase === 'leadin' && a.daysToLeadinEnd < LEADIN_ALERT_DAYS) {
+    severity = severity ?? 'WARNING';
+    reasons.push(`lead-in ends in ${a.daysToLeadinEnd.toFixed(1)}d`);
+  }
+  if (!severity) return null;
+  return { severity, reasons };
+}
+
+function buildEmbed(chain, a, alert) {
+  const color = alert.severity === 'URGENT' ? 0xe01e1e : 0xe0a020;
+  const pending = a.pendingRenewals.length
+    ? a.pendingRenewals.map((p) => `\`renew(${p.core})\` — ${p.priceFmt}`).join('\n')
+    : '*(none recorded — may require a fresh market purchase)*';
+  const calls = a.renewCalls.length
+    ? a.renewCalls.map((c) => `core ${c.core}: \`${c.callHex}\``).join('\n')
+    : '—';
+  return {
+    title: `⚠️ ${chain.name} coretime renewal — ${alert.severity}`,
+    description: alert.reasons.map((r) => `• ${r}`).join('\n'),
+    color,
+    fields: [
+      { name: 'Para / relay', value: `task ${chain.task} on ${chain.relay} coretime`, inline: true },
+      { name: 'Sale phase', value: a.phase, inline: true },
+      { name: 'Cores', value: `active: ${a.activeCores.length} (${a.activeCores.join(', ') || '—'})\nsecured next region: ${a.securedCores.length} (${a.securedCores.join(', ') || '—'})\ntarget: ${chain.desiredCores} → **shortfall ${a.shortfall}**`, inline: false },
+      { name: 'Time left', value: `lead-in ends: ${a.daysToLeadinEnd > 0 ? a.daysToLeadinEnd.toFixed(1) + 'd' : 'passed'}\nregion begins: ${a.daysToRegionBegin.toFixed(1)}d`, inline: false },
+      { name: 'Pending renewals', value: pending, inline: false },
+      { name: 'Encoded calls (sign on the coretime chain)', value: calls.slice(0, 1024), inline: false },
+    ],
+    footer: { text: `coretime watchdog • ts ${a.nowTs} • ${a.endpoint}` },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+async function sendDiscord(embeds) {
+  if (DRY_RUN || !WEBHOOK) {
+    log(DRY_RUN ? '[dry-run] would POST to Discord:' : '[no DISCORD_WEBHOOK_URL] payload:');
+    console.log(JSON.stringify({ embeds }, null, 2));
+    return;
+  }
+  const res = await fetch(WEBHOOK, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ username: 'coretime-watchdog', embeds }),
+  });
+  if (!res.ok) throw new Error(`discord webhook ${res.status}: ${await res.text()}`);
+  log(`posted ${embeds.length} alert(s) to Discord`);
+}
+
+function loadState() {
+  try {
+    return JSON.parse(readFileSync(STATE_FILE, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+function saveState(state) {
+  try {
+    mkdirSync(dirname(STATE_FILE), { recursive: true });
+    writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
+  } catch (e) {
+    log('warn: could not persist state:', e.message);
+  }
+}
+
+// Re-alert only when severity/shortfall changes or the cooldown has elapsed.
+function shouldSend(state, key, fingerprint) {
+  if (FORCE) return true;
+  const prev = state[key];
+  if (!prev) return true;
+  if (prev.fingerprint !== fingerprint) return true;
+  const ageH = (Date.now() - prev.lastSentMs) / 3_600_000;
+  return ageH >= ALERT_COOLDOWN_HOURS;
+}
+
+async function main() {
+  if (TEST) {
+    await sendDiscord([{ title: '✅ coretime watchdog test', description: 'webhook reachable', color: 0x2ecc71, timestamp: new Date().toISOString() }]);
+    return;
+  }
+  if (!WEBHOOK && !DRY_RUN) {
+    log('error: DISCORD_WEBHOOK_URL is not set (use --dry-run to print without sending)');
+    process.exit(2);
+  }
+
+  const state = loadState();
+  const toSend = [];
+  let hadError = false;
+
+  for (const chain of CHAINS) {
+    try {
+      const a = await assess(chain);
+      const alert = decideAlert(chain, a);
+      log(`${chain.name}: phase=${a.phase} active=${a.activeCores.length} secured=${a.securedCores.length}/${chain.desiredCores} shortfall=${a.shortfall} leadinEnd=${a.daysToLeadinEnd.toFixed(1)}d regionBegin=${a.daysToRegionBegin.toFixed(1)}d -> ${alert ? alert.severity : 'ok'}`);
+      if (!alert) {
+        if (state[chain.name]) delete state[chain.name]; // condition cleared
+        continue;
+      }
+      const fingerprint = `${alert.severity}:${a.shortfall}`;
+      if (shouldSend(state, chain.name, fingerprint)) {
+        toSend.push(buildEmbed(chain, a, alert));
+        state[chain.name] = { fingerprint, lastSentMs: Date.now() };
+      } else {
+        log(`${chain.name}: alert active but within cooldown — skipping resend`);
+      }
+    } catch (e) {
+      hadError = true;
+      log(`${chain.name}: assessment FAILED: ${e.message}`);
+      const fp = `error:${e.message}`.slice(0, 80);
+      if (shouldSend(state, `${chain.name}:error`, fp)) {
+        toSend.push({
+          title: `🔌 ${chain.name} coretime watchdog — check failed`,
+          description: `Could not assess renewal status: \`${e.message}\``,
+          color: 0x808080,
+          timestamp: new Date().toISOString(),
+        });
+        state[`${chain.name}:error`] = { fingerprint: fp, lastSentMs: Date.now() };
+      }
+    }
+  }
+
+  if (toSend.length) await sendDiscord(toSend);
+  else log('no alerts to send');
+
+  saveState(state);
+  if (hadError) process.exitCode = 1;
+}
+
+main().catch((e) => {
+  log('fatal:', e.message);
+  process.exit(1);
+});

--- a/scripts/coretime-alert/lark-stack.yml
+++ b/scripts/coretime-alert/lark-stack.yml
@@ -1,0 +1,43 @@
+# Swarm stack for the coretime renewal watchdog on lark.
+#
+# Runs the prebuilt galacticcouncil/coretime-alert image (built from the
+# Dockerfile in this dir). The image already loops the check hourly. The Discord
+# webhook is injected as the DISCORD_WEBHOOK_URL env var, resolved at deploy time
+# from the swarmpit MCP server's environment via $env — never stored in the repo.
+# State is persisted on a local volume so the alert cooldown survives restarts.
+#
+# Rebuild/publish: docker build -t galacticcouncil/coretime-alert:latest . && docker push …
+# autoredeploy picks up a new :latest automatically.
+
+services:
+  watchdog:
+    image: galacticcouncil/coretime-alert:latest
+    isolation: default
+    environment:
+      DISCORD_WEBHOOK_URL: $env:DISCORD_WEBHOOK_URL
+      ALERT_COOLDOWN_HOURS: '12'
+      LEADIN_ALERT_DAYS: '3'
+      TOTAL_ALERT_DAYS: '7'
+      CHECK_INTERVAL_SECONDS: '3600'
+      STATE_FILE: /app/state/.state.json
+    volumes:
+      - state:/app/state
+    networks:
+      - default
+    logging:
+      driver: json-file
+    deploy:
+      replicas: 1
+      labels:
+        swarmpit.service.deployment.autoredeploy: 'true'
+      restart_policy:
+        condition: any
+        delay: 30s
+
+networks:
+  default:
+    driver: overlay
+
+volumes:
+  state:
+    driver: local

--- a/scripts/coretime-alert/package.json
+++ b/scripts/coretime-alert/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "coretime-renew-alert",
+  "version": "1.0.0",
+  "description": "Alert (via Discord webhook) when Hydration/Basilisk coretime cores are at risk of not being renewed before the sale deadline",
+  "type": "module",
+  "main": "check.mjs",
+  "bin": {
+    "coretime-renew-alert": "check.mjs"
+  },
+  "scripts": {
+    "check": "node check.mjs",
+    "dry-run": "node check.mjs --dry-run",
+    "test-webhook": "node check.mjs --test"
+  },
+  "license": "ISC",
+  "dependencies": {
+    "@polkadot/api": "^16.5.6"
+  }
+}


### PR DESCRIPTION
## what

Adds an operational watchdog (`scripts/coretime-alert/`) that alerts a Discord webhook when Hydration's (Polkadot, task `2034`) or Basilisk's (Kusama, task `2090`) bulk coretime cores are at risk of lapsing before the current sale's renewal deadline.

Bulk cores are not leases — they must be renewed every ~28-day sale cycle or they fall back to the open market. The watchdog inspects the `broker` pallet on each coretime chain and pings before the window closes.

## alert logic

Fires for a chain only when it is short of its target core count for the upcoming region **and** the deadline is near:

- `URGENT` — `< 7d` (`TOTAL_ALERT_DAYS`) until the region begins (hard deadline; renewal right lost after)
- `WARNING` — inside the lead-in period with `< 3d` (`LEADIN_ALERT_DAYS`) left

"Short" = secured cores for next region (`workplan`) < desired (default 3). The alert lists the pending `broker.renew(core)` calls (with encoded hex) needed to close the gap. State is persisted so a standing condition only re-pings every `ALERT_COOLDOWN_HOURS` (default 12).

## contents

- `check.mjs` — the check (one-shot; cron/systemd friendly, or looped by the image)
- `Dockerfile` / `.dockerignore` — builds `galacticcouncil/coretime-alert`
- `lark-stack.yml` — Swarm stack (webhook injected via env at deploy, never in repo)
- `package.json`, `README.md`

## deployment

Built and pushed `galacticcouncil/coretime-alert:{latest,1.0.0}`; deployed as the `coretime-alert` stack on lark (single replica, hourly loop, `autoredeploy`). First check verified live against both chains.

## verification

- one-shot dry-run and forced-trigger tested against live coretime chains
- cooldown throttle and `--force` override confirmed
- the underlying renewal flow was validated on a Chopsticks fork of the Polkadot coretime chain (3-core workplan after renew)

No runtime/crate changes — scripts-only addition.