### PR TITLE
fix: don't revert claim_rewards on un-convertible dust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "426.0.0"
+version = "427.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -10388,7 +10388,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-referrals"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/pallets/referrals/Cargo.toml
+++ b/pallets/referrals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-referrals"
-version = "1.6.0"
+version = "1.6.1"
 authors = ['GalacticCouncil']
 edition = "2021"
 license = "Apache-2.0"

--- a/pallets/referrals/src/lib.rs
+++ b/pallets/referrals/src/lib.rs
@@ -482,21 +482,15 @@ pub mod pallet {
 			let who = ensure_signed(origin)?;
 			for (asset_id, _) in PendingConversions::<T>::iter() {
 				let asset_balance = T::Currency::balance(asset_id.clone(), &Self::pot_account_id());
-				let r = T::Convert::convert(
+				// Best-effort, matching `on_idle`: a slice that can't be converted (e.g. below the
+				// converter's min trading limit) is skipped, not fatal — the funds stay in the pot
+				// and the entry is dropped so it can't block this or anyone else's claim.
+				let _ = T::Convert::convert(
 					Self::pot_account_id(),
 					asset_id.clone(),
 					T::RewardAsset::get(),
 					asset_balance,
 				);
-				if let Err(error) = r {
-					// We allow these errors to continue claiming as the current amount of asset that needed to be converted
-					// has very low impact on the rewards.
-					if error != Error::<T>::ConversionMinTradingAmountNotReached.into()
-						&& error != Error::<T>::ConversionZeroAmountReceived.into()
-					{
-						return Err(error);
-					}
-				}
 				PendingConversions::<T>::remove(asset_id);
 			}
 			let referrer_shares = ReferrerShares::<T>::take(&who);

--- a/pallets/referrals/src/lib.rs
+++ b/pallets/referrals/src/lib.rs
@@ -482,9 +482,8 @@ pub mod pallet {
 			let who = ensure_signed(origin)?;
 			for (asset_id, _) in PendingConversions::<T>::iter() {
 				let asset_balance = T::Currency::balance(asset_id.clone(), &Self::pot_account_id());
-				// Best-effort, matching `on_idle`: a slice that can't be converted (e.g. below the
-				// converter's min trading limit) is skipped, not fatal — the funds stay in the pot
-				// and the entry is dropped so it can't block this or anyone else's claim.
+				// Best-effort, like `on_idle`: skip an un-convertible slice rather than revert the
+				// whole claim. Funds stay in the pot and re-queue on the next fee.
 				let _ = T::Convert::convert(
 					Self::pot_account_id(),
 					asset_id.clone(),

--- a/pallets/referrals/src/lib.rs
+++ b/pallets/referrals/src/lib.rs
@@ -298,6 +298,11 @@ pub mod pallet {
 			from: AssetAmount<T::AssetId>,
 			to: AssetAmount<T::AssetId>,
 		},
+		/// A pending asset could not be converted; skipped, not blocking.
+		ConversionFailed {
+			asset_id: T::AssetId,
+			reason: DispatchError,
+		},
 		/// Rewards claimed.
 		Claimed {
 			who: T::AccountId,
@@ -484,12 +489,17 @@ pub mod pallet {
 				let asset_balance = T::Currency::balance(asset_id.clone(), &Self::pot_account_id());
 				// Best-effort, like `on_idle`: skip an un-convertible slice rather than revert the
 				// whole claim. Funds stay in the pot and re-queue on the next fee.
-				let _ = T::Convert::convert(
+				if let Err(reason) = T::Convert::convert(
 					Self::pot_account_id(),
 					asset_id.clone(),
 					T::RewardAsset::get(),
 					asset_balance,
-				);
+				) {
+					Self::deposit_event(Event::ConversionFailed {
+						asset_id: asset_id.clone(),
+						reason,
+					});
+				}
 				PendingConversions::<T>::remove(asset_id);
 			}
 			let referrer_shares = ReferrerShares::<T>::take(&who);
@@ -616,12 +626,17 @@ pub mod pallet {
 			for asset_id in PendingConversions::<T>::iter_keys().take(max_converts as usize) {
 				let asset_balance = T::Currency::balance(asset_id.clone(), &Self::pot_account_id());
 				// remove the asset_id from PendingConversions even when the conversion fails
-				let _ = T::Convert::convert(
+				if let Err(reason) = T::Convert::convert(
 					Self::pot_account_id(),
 					asset_id.clone(),
 					T::RewardAsset::get(),
 					asset_balance,
-				);
+				) {
+					Self::deposit_event(Event::ConversionFailed {
+						asset_id: asset_id.clone(),
+						reason,
+					});
+				}
 				PendingConversions::<T>::remove(asset_id);
 				actual_converts += 1;
 			}

--- a/pallets/referrals/src/tests.rs
+++ b/pallets/referrals/src/tests.rs
@@ -70,9 +70,7 @@ thread_local! {
 	pub static TIER_VOLUME: RefCell<HashMap<Level, Option<Balance>>> = RefCell::new(HashMap::default());
 	pub static TIER_REWARDS: RefCell<HashMap<Level, FeeDistribution>> = RefCell::new(HashMap::default());
 	pub static SEED_AMOUNT: RefCell<Balance> = RefCell::new(Balance::zero());
-	// Mirrors the runtime `MinTradingLimit`: `AssetConvert` rejects sub-minimum amounts with a
-	// non-referrals error, exactly as `ConvertViaOmnipool` -> `Omnipool::sell` does in production.
-	// 0 disables the gate so existing tests are unaffected.
+	// Mirrors runtime `MinTradingLimit`: reject sub-minimum amounts. 0 = disabled.
 	pub static CONVERT_MIN_AMOUNT: RefCell<Balance> = RefCell::new(Balance::zero());
 }
 
@@ -380,9 +378,7 @@ impl Convert<AccountId, AssetId, Balance> for AssetConvert {
 	) -> Result<Balance, Self::Error> {
 		let min_amount = CONVERT_MIN_AMOUNT.with(|v| *v.borrow());
 		if amount > 0 && amount < min_amount {
-			// Production parity: the omnipool-backed converter rejects sub-`MinTradingLimit`
-			// amounts with `pallet_omnipool::Error::InsufficientTradingAmount` — an error that
-			// is *not* one of the two referrals-specific variants `claim_rewards` tolerates.
+			// Like `ConvertViaOmnipool`: sub-min amounts fail with a non-referrals error.
 			return Err(DispatchError::Other("InsufficientTradingAmount"));
 		}
 		let price = CONVERSION_RATE

--- a/pallets/referrals/src/tests.rs
+++ b/pallets/referrals/src/tests.rs
@@ -70,6 +70,10 @@ thread_local! {
 	pub static TIER_VOLUME: RefCell<HashMap<Level, Option<Balance>>> = RefCell::new(HashMap::default());
 	pub static TIER_REWARDS: RefCell<HashMap<Level, FeeDistribution>> = RefCell::new(HashMap::default());
 	pub static SEED_AMOUNT: RefCell<Balance> = RefCell::new(Balance::zero());
+	// Mirrors the runtime `MinTradingLimit`: `AssetConvert` rejects sub-minimum amounts with a
+	// non-referrals error, exactly as `ConvertViaOmnipool` -> `Omnipool::sell` does in production.
+	// 0 disables the gate so existing tests are unaffected.
+	pub static CONVERT_MIN_AMOUNT: RefCell<Balance> = RefCell::new(Balance::zero());
 }
 
 construct_runtime!(
@@ -218,6 +222,10 @@ impl Default for ExtBuilder {
 			v.borrow_mut().clear();
 		});
 
+		CONVERT_MIN_AMOUNT.with(|v| {
+			*v.borrow_mut() = 0u128;
+		});
+
 		Self {
 			endowed_accounts: vec![(ALICE, HDX, INITIAL_ALICE_BALANCE)],
 			referrer_shares: vec![],
@@ -257,6 +265,12 @@ impl ExtBuilder {
 			let mut m = v.borrow_mut();
 			m.insert(pair, price);
 			m.insert((pair.1, pair.0), price.inverted());
+		});
+		self
+	}
+	pub fn with_convert_min_amount(self, amount: Balance) -> Self {
+		CONVERT_MIN_AMOUNT.with(|v| {
+			*v.borrow_mut() = amount;
 		});
 		self
 	}
@@ -364,6 +378,13 @@ impl Convert<AccountId, AssetId, Balance> for AssetConvert {
 		asset_to: AssetId,
 		amount: Balance,
 	) -> Result<Balance, Self::Error> {
+		let min_amount = CONVERT_MIN_AMOUNT.with(|v| *v.borrow());
+		if amount > 0 && amount < min_amount {
+			// Production parity: the omnipool-backed converter rejects sub-`MinTradingLimit`
+			// amounts with `pallet_omnipool::Error::InsufficientTradingAmount` — an error that
+			// is *not* one of the two referrals-specific variants `claim_rewards` tolerates.
+			return Err(DispatchError::Other("InsufficientTradingAmount"));
+		}
 		let price = CONVERSION_RATE
 			.with(|v| v.borrow().get(&(asset_to, asset_from)).copied())
 			.ok_or(Error::<Test>::ConversionMinTradingAmountNotReached)?;

--- a/pallets/referrals/src/tests/claim.rs
+++ b/pallets/referrals/src/tests/claim.rs
@@ -74,11 +74,7 @@ fn claim_rewards_should_remove_assets_from_the_list_when_not_successful() {
 		});
 }
 
-// Regression: a sub-`MinTradingLimit` dust balance of a non-reward asset in `PendingConversions`
-// must not block reward claims. The converter rejects the dust with a non-referrals error
-// (`InsufficientTradingAmount`), which the claim loop only tolerates for its own two legacy
-// variants — so today it reverts the whole claim instead of skipping the dust like `on_idle`
-// does. This test asserts the desired self-healing behaviour and currently FAILS, proving the bug.
+// Regression: sub-`MinTradingLimit` dust in `PendingConversions` must not block reward claims.
 #[test]
 fn claim_rewards_should_succeed_when_pending_asset_balance_is_below_min_trading_limit() {
 	ExtBuilder::default()

--- a/pallets/referrals/src/tests/claim.rs
+++ b/pallets/referrals/src/tests/claim.rs
@@ -100,6 +100,11 @@ fn claim_rewards_should_succeed_when_pending_asset_balance_is_below_min_trading_
 			assert_eq!(Tokens::free_balance(HDX, &BOB), 5_000_000_000_000);
 			// The dust entry is dropped rather than left to block future claims.
 			assert_eq!(PendingConversions::<Test>::count(), 0);
+			// The skipped conversion is surfaced as an event, not silently swallowed.
+			assert!(System::events().iter().any(|r| matches!(
+				&r.event,
+				RuntimeEvent::Referrals(Event::ConversionFailed { asset_id, .. }) if *asset_id == DAI
+			)));
 		});
 }
 

--- a/pallets/referrals/src/tests/claim.rs
+++ b/pallets/referrals/src/tests/claim.rs
@@ -74,6 +74,39 @@ fn claim_rewards_should_remove_assets_from_the_list_when_not_successful() {
 		});
 }
 
+// Regression: a sub-`MinTradingLimit` dust balance of a non-reward asset in `PendingConversions`
+// must not block reward claims. The converter rejects the dust with a non-referrals error
+// (`InsufficientTradingAmount`), which the claim loop only tolerates for its own two legacy
+// variants — so today it reverts the whole claim instead of skipping the dust like `on_idle`
+// does. This test asserts the desired self-healing behaviour and currently FAILS, proving the bug.
+#[test]
+fn claim_rewards_should_succeed_when_pending_asset_balance_is_below_min_trading_limit() {
+	ExtBuilder::default()
+		.with_endowed_accounts(vec![
+			(Pallet::<Test>::pot_account_id(), HDX, 20_000_000_000_000),
+			// 500 raw units of DAI — below the converter's min trading limit (1_000).
+			(Pallet::<Test>::pot_account_id(), DAI, 500),
+		])
+		.with_referrer_shares(vec![(BOB, 5_000_000_000_000), (ALICE, 15_000_000_000_000)])
+		.with_assets(vec![DAI])
+		// Price present so the converter reaches the min-amount check (not the no-price branch,
+		// whose error the claim loop happens to tolerate).
+		.with_conversion_price((HDX, DAI), EmaPrice::new(1_000_000_000_000, 1_000_000_000_000_000_000))
+		.with_convert_min_amount(1_000)
+		.build()
+		.execute_with(|| {
+			assert_eq!(PendingConversions::<Test>::count(), 1);
+
+			// Bob can still claim his share despite the un-convertible dust asset.
+			assert_ok!(Referrals::claim_rewards(RuntimeOrigin::signed(BOB)));
+
+			// Bob received his portion of the HDX reward reserve.
+			assert_eq!(Tokens::free_balance(HDX, &BOB), 5_000_000_000_000);
+			// The dust entry is dropped rather than left to block future claims.
+			assert_eq!(PendingConversions::<Test>::count(), 0);
+		});
+}
+
 #[test]
 fn claim_rewards_should_calculate_correct_portion_when_claimed() {
 	ExtBuilder::default()

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "426.0.0"
+version = "427.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -129,7 +129,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("hydradx"),
 	impl_name: Cow::Borrowed("hydradx"),
 	authoring_version: 1,
-	spec_version: 426,
+	spec_version: 427,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
## problem

`claim_rewards` iterates the global `PendingConversions` map and converts each pending asset to the reward asset before paying out shares. it only tolerates two conversion errors — `ConversionMinTradingAmountNotReached` and `ConversionZeroAmountReceived` — and reverts the whole call on anything else.

the v49 fee-flow refactor moved conversion to `ConvertViaOmnipool`, which **dropped** the old explicit min-amount pre-check (that returned `ConversionMinTradingAmountNotReached`). it now calls `Omnipool::sell` directly → for a pot balance below `MinTradingLimit` (1_000 raw units) it propagates the raw `pallet_omnipool::Error::InsufficientTradingAmount`, which is **not** in the tolerated set.

result → any sub-`MinTradingLimit` dust balance of a non-reward asset in `PendingConversions` makes `claim_rewards` revert:

- since extrinsics run before `on_idle`, a dust entry left by a trade earlier in the same block blocks every `claim_rewards` in that block
- weaponizable as a cheap, permissionless same-block front-run grief against reward claimers (self-link + tiny linked trade tuned so the 5% slice lands in `[1, 999]` of an obscure asset)
- also causes incidental spurious claim failures for honest users
- no funds lost — rewards stay claimable next block — but it's a real correctness/griefing defect

regression vs v48: the old `convert` returned `ConversionMinTradingAmountNotReached` for sub-min amounts (which the claim loop tolerated); the new converter returns `InsufficientTradingAmount`, and the claim loop's tolerated-error list was never updated.

## fix

make the claim loop best-effort, identical to the sibling `on_idle` hook (which already does `let _ = T::Convert::convert(...)`): skip an un-convertible slice instead of reverting, and drop the entry either way. a skipped conversion now emits a `ConversionFailed { asset_id, reason }` event (in both `claim_rewards` and `on_idle`) so it is surfaced rather than silently swallowed — mirroring the fee-processor.

- the conversion is genuinely best-effort → funds stay in the pot, reward accounting is share-based and independent of the swap, and the asset re-queues on the next fee
- removes the `claim_rewards` ↔ `on_idle` tolerance divergence by construction

### why not extend the exact-match list instead?

the alternative is to keep the `if let Err` propagation and add the new tolerated variants (`InsufficientTradingAmount`, `ConversionFailed`, `PriceNotAvailable`). rejected because:

- **it's what caused this bug.** the tolerated list was coupled to the converter's exact error variants; when the converter impl changed, the list silently went stale and started reverting. any new list carries the same drift risk on the next converter change.
- **it can't be written cleanly here.** `pallet-referrals` constrains its converter to `Convert<…, Error = DispatchError>` and does **not** depend on `pallet-omnipool`/`pallet-fee-processor`. matching their error variants would mean either adding those deps (bad layering for a generic rewards pallet) or matching raw `DispatchError::Module` discriminants (fragile).
- **the swallow-all matches `on_idle`**, which already abandoned exact-match — so both cleanup paths now behave identically.

the visibility that exact-match gave (surfacing an unexpected converter error rather than dropping it) is preserved by the `ConversionFailed` event, without re-introducing the coupling.

## test

`claim_rewards_should_succeed_when_pending_asset_balance_is_below_min_trading_limit` → a 500-unit (sub-min) DAI dust entry no longer blocks an unrelated user's claim, and a `ConversionFailed` event is emitted for it. the mock `AssetConvert` now models the production min-trading-limit rejection (returns a non-referrals error for sub-min amounts), gated behind a new `with_convert_min_amount` builder defaulting to disabled so existing tests are unaffected.

- red before the one-line fix, green after; all 60 referrals tests pass

## versions

- `pallet-referrals` 1.6.0 → 1.6.1
- runtime spec_version 426 → 427, `hydradx-runtime` 426.0.0 → 427.0.0