### PR TITLE
feat(signet): feeless allowlisted respond [ignore benchmarks]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "428.0.0"
+version = "429.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -10599,7 +10599,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-signet"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "ethereum",
  "frame-benchmarking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "429.0.0"
+version = "430.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -9259,7 +9259,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-dispenser"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "alloy-primitives 0.7.7",
  "alloy-sol-types 0.7.7",

--- a/pallets/dispenser/Cargo.toml
+++ b/pallets/dispenser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-dispenser"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 [package.metadata.docs.rs]

--- a/pallets/dispenser/src/benchmarking.rs
+++ b/pallets/dispenser/src/benchmarking.rs
@@ -140,7 +140,7 @@ mod benches {
 		let path = SIGNING_PATH.to_vec();
 
 		// CAIP-2 chain ID format
-		let caip2_id = alloc::format!("eip155:{}", tx.chain_id);
+		let caip2_id = alloc::string::String::from(ETH_MAINNET_CAIP2);
 
 		let req_id = Pallet::<T>::generate_request_id(
 			&Pallet::<T>::account_id(),

--- a/pallets/dispenser/src/lib.rs
+++ b/pallets/dispenser/src/lib.rs
@@ -280,7 +280,7 @@ pub mod pallet {
 			let path = SIGNING_PATH.to_vec();
 
 			// CAIP-2 chain ID (e.g., "eip155:1" for Ethereum mainnet)
-			let caip2_id = alloc::format!("eip155:{}", tx.chain_id);
+			let caip2_id = alloc::string::String::from(ETH_MAINNET_CAIP2);
 
 			// Derive canonical request ID and compare with user-supplied one.
 			let req_id = Self::generate_request_id(&pallet_acc, &rlp, &caip2_id, 0, &path, ECDSA, ETHEREUM, b"")?;

--- a/pallets/dispenser/src/tests/utils.rs
+++ b/pallets/dispenser/src/tests/utils.rs
@@ -67,7 +67,7 @@ pub fn compute_request_id(
 	let sender_ss58 = account_id32.to_ss58check_with_version(sp_core::crypto::Ss58AddressFormat::custom(0));
 
 	// CAIP-2 chain ID format
-	let caip2_id = format!("eip155:{}", tx_params.chain_id);
+	let caip2_id = crate::ETH_MAINNET_CAIP2.to_string();
 
 	let packed = (
 		sender_ss58.as_str(),

--- a/pallets/dispenser/src/types.rs
+++ b/pallets/dispenser/src/types.rs
@@ -9,6 +9,8 @@ pub type BalanceOf<T> =
 pub const ECDSA: &[u8] = b"ecdsa";
 pub const ETHEREUM: &[u8] = b"ethereum";
 
+pub const ETH_MAINNET_CAIP2: &str = "eip155:1";
+
 /// Fixed signing derivation path — all dispenser requests use the same
 /// MPC-derived key so that only one EVM wallet needs to be funded and
 /// whitelisted on the faucet contract.

--- a/pallets/signet/Cargo.toml
+++ b/pallets/signet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-signet"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["Signet"]
 edition = "2021"
 license = "Apache-2.0"

--- a/pallets/signet/src/benchmarks.rs
+++ b/pallets/signet/src/benchmarks.rs
@@ -141,6 +141,7 @@ mod benches {
 	#[benchmark]
 	fn respond() {
 		let responder: T::AccountId = whitelisted_caller();
+		Signers::<T>::insert(&responder, ());
 
 		let mut ids: Vec<[u8; 32]> = Vec::with_capacity(MAX_BATCH_SIZE as usize);
 		let mut sigs: Vec<Signature> = Vec::with_capacity(MAX_BATCH_SIZE as usize);
@@ -171,6 +172,7 @@ mod benches {
 	#[benchmark]
 	fn respond_error() {
 		let responder: T::AccountId = whitelisted_caller();
+		Signers::<T>::insert(&responder, ());
 
 		let mut errs: Vec<ErrorResponse> = Vec::with_capacity(MAX_BATCH_SIZE as usize);
 
@@ -198,6 +200,7 @@ mod benches {
 	#[benchmark]
 	fn respond_bidirectional() {
 		let responder: T::AccountId = whitelisted_caller();
+		Signers::<T>::insert(&responder, ());
 
 		let request_id: [u8; 32] = [7u8; 32];
 		let output_vec = vec![8u8; MAX_SERIALIZED_OUTPUT_LENGTH as usize];
@@ -220,6 +223,28 @@ mod benches {
 			serialized_output,
 			signature,
 		);
+	}
+
+	#[benchmark]
+	fn add_signer() {
+		let who: T::AccountId = whitelisted_caller();
+
+		#[extrinsic_call]
+		add_signer(RawOrigin::Root, who.clone());
+
+		assert!(Signers::<T>::contains_key(&who));
+	}
+
+	#[benchmark]
+	fn remove_signer() {
+		let who: T::AccountId = whitelisted_caller();
+		Signers::<T>::insert(&who, ());
+		SignerCount::<T>::put(1);
+
+		#[extrinsic_call]
+		remove_signer(RawOrigin::Root, who.clone());
+
+		assert!(!Signers::<T>::contains_key(&who));
 	}
 
 	#[benchmark]

--- a/pallets/signet/src/lib.rs
+++ b/pallets/signet/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![allow(clippy::useless_conversion)]
 
 use ethereum::{AccessListItem, EIP1559TransactionMessage, TransactionAction};
 use frame_support::{
@@ -412,12 +413,12 @@ pub mod pallet {
 
 		/// Respond to signature requests (batch support)
 		#[pallet::call_index(4)]
-		#[pallet::weight((<T as Config>::WeightInfo::respond(), Pays::No))]
+		#[pallet::weight(<T as Config>::WeightInfo::respond())]
 		pub fn respond(
 			origin: OriginFor<T>,
 			request_ids: BoundedVec<[u8; 32], ConstU32<MAX_BATCH_SIZE>>,
 			signatures: BoundedVec<Signature, ConstU32<MAX_BATCH_SIZE>>,
-		) -> DispatchResult {
+		) -> DispatchResultWithPostInfo {
 			let responder = ensure_signed(origin)?;
 			ensure!(Signers::<T>::contains_key(&responder), Error::<T>::NotAuthorizedSigner);
 
@@ -431,16 +432,16 @@ pub mod pallet {
 				});
 			}
 
-			Ok(())
+			Ok(Pays::No.into())
 		}
 
 		/// Report signature generation errors (batch support)
 		#[pallet::call_index(5)]
-		#[pallet::weight((<T as Config>::WeightInfo::respond_error(), Pays::No))]
+		#[pallet::weight(<T as Config>::WeightInfo::respond_error())]
 		pub fn respond_error(
 			origin: OriginFor<T>,
 			errors: BoundedVec<ErrorResponse, ConstU32<MAX_BATCH_SIZE>>,
-		) -> DispatchResult {
+		) -> DispatchResultWithPostInfo {
 			let responder = ensure_signed(origin)?;
 			ensure!(Signers::<T>::contains_key(&responder), Error::<T>::NotAuthorizedSigner);
 
@@ -452,18 +453,18 @@ pub mod pallet {
 				});
 			}
 
-			Ok(())
+			Ok(Pays::No.into())
 		}
 
 		/// Provide a read response with signature
 		#[pallet::call_index(6)]
-		#[pallet::weight((<T as Config>::WeightInfo::respond_bidirectional(), Pays::No))]
+		#[pallet::weight(<T as Config>::WeightInfo::respond_bidirectional())]
 		pub fn respond_bidirectional(
 			origin: OriginFor<T>,
 			request_id: [u8; 32],
 			serialized_output: BoundedVec<u8, ConstU32<MAX_SERIALIZED_OUTPUT_LENGTH>>,
 			signature: Signature,
-		) -> DispatchResult {
+		) -> DispatchResultWithPostInfo {
 			let responder = ensure_signed(origin)?;
 			ensure!(Signers::<T>::contains_key(&responder), Error::<T>::NotAuthorizedSigner);
 
@@ -474,7 +475,7 @@ pub mod pallet {
 				signature,
 			});
 
-			Ok(())
+			Ok(Pays::No.into())
 		}
 
 		/// Pause the signet so that no new signing requests can be made.

--- a/pallets/signet/src/lib.rs
+++ b/pallets/signet/src/lib.rs
@@ -2,6 +2,7 @@
 
 use ethereum::{AccessListItem, EIP1559TransactionMessage, TransactionAction};
 use frame_support::{
+	dispatch::Pays,
 	pallet_prelude::*,
 	traits::{Currency, ExistenceRequirement},
 	PalletId,
@@ -31,6 +32,9 @@ const MAX_ERROR_MESSAGE_LENGTH: u32 = 1024;
 
 /// Maximum batch sizes
 const MAX_BATCH_SIZE: u32 = 100;
+
+/// Maximum number of authorized responder (MPC signer) accounts.
+const MAX_SIGNERS: u32 = 64;
 
 /// Hard upper bound for chain ID length (used as BoundedVec bound)
 pub const MAX_CHAIN_ID_LENGTH: u32 = 128;
@@ -130,6 +134,14 @@ pub mod pallet {
 	#[pallet::getter(fn signet_config)]
 	pub type SignetConfig<T: Config> = StorageValue<_, SignetConfigData<BalanceOf<T>>, OptionQuery>;
 
+	/// Accounts authorized to submit signature responses.
+	#[pallet::storage]
+	pub type Signers<T: Config> = StorageMap<_, Blake2_128Concat, T::AccountId, (), OptionQuery>;
+
+	/// Number of authorized signer accounts currently registered.
+	#[pallet::storage]
+	pub type SignerCount<T: Config> = StorageValue<_, u32, ValueQuery>;
+
 	// ========================================
 	// Events
 	// ========================================
@@ -205,6 +217,11 @@ pub mod pallet {
 			serialized_output: Vec<u8>,
 			signature: Signature,
 		},
+
+		/// A new responder account has been authorized.
+		SignerAdded { who: T::AccountId },
+		/// A responder account has been deauthorized.
+		SignerRemoved { who: T::AccountId },
 	}
 
 	// ========================================
@@ -229,6 +246,14 @@ pub mod pallet {
 		InvalidAddress,
 		/// Priority fee cannot exceed max fee per gas (EIP-1559 requirement)
 		InvalidGasPrice,
+		/// Responder is not in the authorized signer set.
+		NotAuthorizedSigner,
+		/// The account is already an authorized signer.
+		SignerAlreadyExists,
+		/// The account is not an authorized signer.
+		SignerNotFound,
+		/// The maximum number of authorized signers has been reached.
+		TooManySigners,
 	}
 
 	// ========================================
@@ -387,13 +412,14 @@ pub mod pallet {
 
 		/// Respond to signature requests (batch support)
 		#[pallet::call_index(4)]
-		#[pallet::weight(<T as Config>::WeightInfo::respond())]
+		#[pallet::weight((<T as Config>::WeightInfo::respond(), Pays::No))]
 		pub fn respond(
 			origin: OriginFor<T>,
 			request_ids: BoundedVec<[u8; 32], ConstU32<MAX_BATCH_SIZE>>,
 			signatures: BoundedVec<Signature, ConstU32<MAX_BATCH_SIZE>>,
 		) -> DispatchResult {
 			let responder = ensure_signed(origin)?;
+			ensure!(Signers::<T>::contains_key(&responder), Error::<T>::NotAuthorizedSigner);
 
 			ensure!(request_ids.len() == signatures.len(), Error::<T>::InvalidInputLength);
 
@@ -410,12 +436,13 @@ pub mod pallet {
 
 		/// Report signature generation errors (batch support)
 		#[pallet::call_index(5)]
-		#[pallet::weight(<T as Config>::WeightInfo::respond_error())]
+		#[pallet::weight((<T as Config>::WeightInfo::respond_error(), Pays::No))]
 		pub fn respond_error(
 			origin: OriginFor<T>,
 			errors: BoundedVec<ErrorResponse, ConstU32<MAX_BATCH_SIZE>>,
 		) -> DispatchResult {
 			let responder = ensure_signed(origin)?;
+			ensure!(Signers::<T>::contains_key(&responder), Error::<T>::NotAuthorizedSigner);
 
 			for error in errors {
 				Self::deposit_event(Event::SignatureError {
@@ -430,7 +457,7 @@ pub mod pallet {
 
 		/// Provide a read response with signature
 		#[pallet::call_index(6)]
-		#[pallet::weight(<T as Config>::WeightInfo::respond_bidirectional())]
+		#[pallet::weight((<T as Config>::WeightInfo::respond_bidirectional(), Pays::No))]
 		pub fn respond_bidirectional(
 			origin: OriginFor<T>,
 			request_id: [u8; 32],
@@ -438,6 +465,7 @@ pub mod pallet {
 			signature: Signature,
 		) -> DispatchResult {
 			let responder = ensure_signed(origin)?;
+			ensure!(Signers::<T>::contains_key(&responder), Error::<T>::NotAuthorizedSigner);
 
 			Self::deposit_event(Event::RespondBidirectionalEvent {
 				request_id,
@@ -482,6 +510,37 @@ pub mod pallet {
 			});
 
 			Self::deposit_event(Event::Unpaused);
+			Ok(())
+		}
+
+		/// Authorize an account to submit signature responses.
+		#[pallet::call_index(9)]
+		#[pallet::weight(<T as Config>::WeightInfo::add_signer())]
+		pub fn add_signer(origin: OriginFor<T>, who: T::AccountId) -> DispatchResult {
+			T::UpdateOrigin::ensure_origin(origin)?;
+
+			ensure!(!Signers::<T>::contains_key(&who), Error::<T>::SignerAlreadyExists);
+			ensure!(SignerCount::<T>::get() < MAX_SIGNERS, Error::<T>::TooManySigners);
+
+			Signers::<T>::insert(&who, ());
+			SignerCount::<T>::mutate(|n| *n = n.saturating_add(1));
+
+			Self::deposit_event(Event::SignerAdded { who });
+			Ok(())
+		}
+
+		/// Remove an account from the signer allowlist.
+		#[pallet::call_index(10)]
+		#[pallet::weight(<T as Config>::WeightInfo::remove_signer())]
+		pub fn remove_signer(origin: OriginFor<T>, who: T::AccountId) -> DispatchResult {
+			T::UpdateOrigin::ensure_origin(origin)?;
+
+			ensure!(Signers::<T>::contains_key(&who), Error::<T>::SignerNotFound);
+
+			Signers::<T>::remove(&who);
+			SignerCount::<T>::mutate(|n| *n = n.saturating_sub(1));
+
+			Self::deposit_event(Event::SignerRemoved { who });
 			Ok(())
 		}
 	}

--- a/pallets/signet/src/tests/mod.rs
+++ b/pallets/signet/src/tests/mod.rs
@@ -1,3 +1,4 @@
+mod signer_allowlist;
 mod test_cases;
 pub mod utils;
 

--- a/pallets/signet/src/tests/signer_allowlist.rs
+++ b/pallets/signet/src/tests/signer_allowlist.rs
@@ -1,0 +1,270 @@
+use crate::{
+	tests::{
+		new_test_ext,
+		utils::{bounded_array, bounded_err, bounded_sig, bounded_u8, create_test_signature},
+		RuntimeCall, RuntimeOrigin, Signet, System, Test,
+	},
+	Error, ErrorResponse, Event, SignerCount, Signers, MAX_SIGNERS,
+};
+use frame_support::dispatch::{GetDispatchInfo, Pays};
+use frame_support::{assert_noop, assert_ok};
+use sp_runtime::DispatchError;
+
+const SIGNER: u64 = 1;
+const OUTSIDER: u64 = 2;
+
+// -----------------------------------------------------------------------------
+// add_signer / remove_signer
+// -----------------------------------------------------------------------------
+
+#[test]
+fn add_signer_should_authorize_account_when_called_by_update_origin() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Signet::add_signer(RuntimeOrigin::root(), SIGNER));
+
+		assert!(Signers::<Test>::contains_key(SIGNER));
+		assert_eq!(SignerCount::<Test>::get(), 1);
+		System::assert_last_event(Event::SignerAdded { who: SIGNER }.into());
+	});
+}
+
+#[test]
+fn add_signer_should_fail_when_origin_is_not_update_origin() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			Signet::add_signer(RuntimeOrigin::signed(OUTSIDER), SIGNER),
+			DispatchError::BadOrigin
+		);
+		assert!(!Signers::<Test>::contains_key(SIGNER));
+	});
+}
+
+#[test]
+fn add_signer_should_fail_when_account_already_authorized() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Signet::add_signer(RuntimeOrigin::root(), SIGNER));
+
+		assert_noop!(
+			Signet::add_signer(RuntimeOrigin::root(), SIGNER),
+			Error::<Test>::SignerAlreadyExists
+		);
+		assert_eq!(SignerCount::<Test>::get(), 1);
+	});
+}
+
+#[test]
+fn add_signer_should_fail_when_max_signers_reached() {
+	new_test_ext().execute_with(|| {
+		for i in 0..MAX_SIGNERS as u64 {
+			assert_ok!(Signet::add_signer(RuntimeOrigin::root(), 1000 + i));
+		}
+		assert_eq!(SignerCount::<Test>::get(), MAX_SIGNERS);
+
+		assert_noop!(
+			Signet::add_signer(RuntimeOrigin::root(), 9999),
+			Error::<Test>::TooManySigners
+		);
+		assert!(!Signers::<Test>::contains_key(9999u64));
+	});
+}
+
+#[test]
+fn remove_signer_should_deauthorize_account_when_authorized() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Signet::add_signer(RuntimeOrigin::root(), SIGNER));
+
+		assert_ok!(Signet::remove_signer(RuntimeOrigin::root(), SIGNER));
+
+		assert!(!Signers::<Test>::contains_key(SIGNER));
+		assert_eq!(SignerCount::<Test>::get(), 0);
+		System::assert_last_event(Event::SignerRemoved { who: SIGNER }.into());
+	});
+}
+
+#[test]
+fn remove_signer_should_fail_when_account_not_authorized() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			Signet::remove_signer(RuntimeOrigin::root(), SIGNER),
+			Error::<Test>::SignerNotFound
+		);
+	});
+}
+
+#[test]
+fn remove_signer_should_fail_when_origin_is_not_update_origin() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Signet::add_signer(RuntimeOrigin::root(), SIGNER));
+
+		assert_noop!(
+			Signet::remove_signer(RuntimeOrigin::signed(OUTSIDER), SIGNER),
+			DispatchError::BadOrigin
+		);
+		assert!(Signers::<Test>::contains_key(SIGNER));
+	});
+}
+
+#[test]
+fn signer_count_should_track_additions_and_removals() {
+	new_test_ext().execute_with(|| {
+		assert_eq!(SignerCount::<Test>::get(), 0);
+
+		assert_ok!(Signet::add_signer(RuntimeOrigin::root(), SIGNER));
+		assert_ok!(Signet::add_signer(RuntimeOrigin::root(), OUTSIDER));
+		assert_eq!(SignerCount::<Test>::get(), 2);
+
+		assert_ok!(Signet::remove_signer(RuntimeOrigin::root(), SIGNER));
+		assert_eq!(SignerCount::<Test>::get(), 1);
+	});
+}
+
+// -----------------------------------------------------------------------------
+// respond authorization
+// -----------------------------------------------------------------------------
+
+#[test]
+fn respond_should_succeed_when_caller_is_authorized_signer() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Signet::add_signer(RuntimeOrigin::root(), SIGNER));
+		let request_id = [7u8; 32];
+		let signature = create_test_signature();
+
+		assert_ok!(Signet::respond(
+			RuntimeOrigin::signed(SIGNER),
+			bounded_array::<100>(vec![request_id]),
+			bounded_sig::<100>(vec![signature.clone()])
+		));
+
+		System::assert_last_event(
+			Event::SignatureResponded {
+				request_id,
+				responder: SIGNER,
+				signature,
+			}
+			.into(),
+		);
+	});
+}
+
+#[test]
+fn respond_should_fail_when_caller_is_not_authorized() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			Signet::respond(
+				RuntimeOrigin::signed(OUTSIDER),
+				bounded_array::<100>(vec![[1u8; 32]]),
+				bounded_sig::<100>(vec![create_test_signature()])
+			),
+			Error::<Test>::NotAuthorizedSigner
+		);
+	});
+}
+
+#[test]
+fn respond_error_should_fail_when_caller_is_not_authorized() {
+	new_test_ext().execute_with(|| {
+		let error_response = ErrorResponse {
+			request_id: [1u8; 32],
+			error_message: bounded_u8::<1024>(b"boom".to_vec()),
+		};
+
+		assert_noop!(
+			Signet::respond_error(
+				RuntimeOrigin::signed(OUTSIDER),
+				bounded_err::<100>(vec![error_response])
+			),
+			Error::<Test>::NotAuthorizedSigner
+		);
+	});
+}
+
+#[test]
+fn respond_bidirectional_should_fail_when_caller_is_not_authorized() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			Signet::respond_bidirectional(
+				RuntimeOrigin::signed(OUTSIDER),
+				[1u8; 32],
+				bounded_u8::<65536>(b"out".to_vec()),
+				create_test_signature()
+			),
+			Error::<Test>::NotAuthorizedSigner
+		);
+	});
+}
+
+#[test]
+fn respond_should_fail_when_signer_is_removed() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Signet::add_signer(RuntimeOrigin::root(), SIGNER));
+
+		assert_ok!(Signet::respond(
+			RuntimeOrigin::signed(SIGNER),
+			bounded_array::<100>(vec![[1u8; 32]]),
+			bounded_sig::<100>(vec![create_test_signature()])
+		));
+
+		assert_ok!(Signet::remove_signer(RuntimeOrigin::root(), SIGNER));
+
+		assert_noop!(
+			Signet::respond(
+				RuntimeOrigin::signed(SIGNER),
+				bounded_array::<100>(vec![[2u8; 32]]),
+				bounded_sig::<100>(vec![create_test_signature()])
+			),
+			Error::<Test>::NotAuthorizedSigner
+		);
+	});
+}
+
+// -----------------------------------------------------------------------------
+// feeless (Pays::No) annotation
+// -----------------------------------------------------------------------------
+
+#[test]
+fn respond_should_be_feeless_when_called() {
+	new_test_ext().execute_with(|| {
+		let call = RuntimeCall::Signet(crate::Call::respond {
+			request_ids: bounded_array::<100>(vec![[1u8; 32]]),
+			signatures: bounded_sig::<100>(vec![create_test_signature()]),
+		});
+		assert_eq!(call.get_dispatch_info().pays_fee, Pays::No);
+	});
+}
+
+#[test]
+fn respond_error_should_be_feeless_when_called() {
+	new_test_ext().execute_with(|| {
+		let call = RuntimeCall::Signet(crate::Call::respond_error {
+			errors: bounded_err::<100>(vec![ErrorResponse {
+				request_id: [1u8; 32],
+				error_message: bounded_u8::<1024>(b"boom".to_vec()),
+			}]),
+		});
+		assert_eq!(call.get_dispatch_info().pays_fee, Pays::No);
+	});
+}
+
+#[test]
+fn respond_bidirectional_should_be_feeless_when_called() {
+	new_test_ext().execute_with(|| {
+		let call = RuntimeCall::Signet(crate::Call::respond_bidirectional {
+			request_id: [1u8; 32],
+			serialized_output: bounded_u8::<65536>(b"out".to_vec()),
+			signature: create_test_signature(),
+		});
+		assert_eq!(call.get_dispatch_info().pays_fee, Pays::No);
+	});
+}
+
+// -----------------------------------------------------------------------------
+// admin calls remain fee-paying
+// -----------------------------------------------------------------------------
+
+#[test]
+fn add_signer_should_pay_fee_when_called() {
+	new_test_ext().execute_with(|| {
+		let call = RuntimeCall::Signet(crate::Call::add_signer { who: SIGNER });
+		assert_eq!(call.get_dispatch_info().pays_fee, Pays::Yes);
+	});
+}

--- a/pallets/signet/src/tests/signer_allowlist.rs
+++ b/pallets/signet/src/tests/signer_allowlist.rs
@@ -218,42 +218,89 @@ fn respond_should_fail_when_signer_is_removed() {
 }
 
 // -----------------------------------------------------------------------------
-// feeless (Pays::No) annotation
+// fee: refunded on success, charged on failure
 // -----------------------------------------------------------------------------
 
 #[test]
-fn respond_should_be_feeless_when_called() {
+fn respond_should_refund_fee_when_successful() {
 	new_test_ext().execute_with(|| {
-		let call = RuntimeCall::Signet(crate::Call::respond {
-			request_ids: bounded_array::<100>(vec![[1u8; 32]]),
-			signatures: bounded_sig::<100>(vec![create_test_signature()]),
-		});
-		assert_eq!(call.get_dispatch_info().pays_fee, Pays::No);
+		assert_ok!(Signet::add_signer(RuntimeOrigin::root(), SIGNER));
+
+		let info = Signet::respond(
+			RuntimeOrigin::signed(SIGNER),
+			bounded_array::<100>(vec![[1u8; 32]]),
+			bounded_sig::<100>(vec![create_test_signature()]),
+		)
+		.expect("respond should succeed");
+
+		assert_eq!(info.pays_fee, Pays::No);
 	});
 }
 
 #[test]
-fn respond_error_should_be_feeless_when_called() {
+fn respond_error_should_refund_fee_when_successful() {
 	new_test_ext().execute_with(|| {
-		let call = RuntimeCall::Signet(crate::Call::respond_error {
-			errors: bounded_err::<100>(vec![ErrorResponse {
+		assert_ok!(Signet::add_signer(RuntimeOrigin::root(), SIGNER));
+
+		let info = Signet::respond_error(
+			RuntimeOrigin::signed(SIGNER),
+			bounded_err::<100>(vec![ErrorResponse {
 				request_id: [1u8; 32],
 				error_message: bounded_u8::<1024>(b"boom".to_vec()),
 			}]),
-		});
-		assert_eq!(call.get_dispatch_info().pays_fee, Pays::No);
+		)
+		.expect("respond_error should succeed");
+
+		assert_eq!(info.pays_fee, Pays::No);
 	});
 }
 
 #[test]
-fn respond_bidirectional_should_be_feeless_when_called() {
+fn respond_bidirectional_should_refund_fee_when_successful() {
 	new_test_ext().execute_with(|| {
-		let call = RuntimeCall::Signet(crate::Call::respond_bidirectional {
-			request_id: [1u8; 32],
-			serialized_output: bounded_u8::<65536>(b"out".to_vec()),
-			signature: create_test_signature(),
-		});
-		assert_eq!(call.get_dispatch_info().pays_fee, Pays::No);
+		assert_ok!(Signet::add_signer(RuntimeOrigin::root(), SIGNER));
+
+		let info = Signet::respond_bidirectional(
+			RuntimeOrigin::signed(SIGNER),
+			[1u8; 32],
+			bounded_u8::<65536>(b"out".to_vec()),
+			create_test_signature(),
+		)
+		.expect("respond_bidirectional should succeed");
+
+		assert_eq!(info.pays_fee, Pays::No);
+	});
+}
+
+#[test]
+fn respond_should_charge_fee_when_unauthorized() {
+	new_test_ext().execute_with(|| {
+		let err = Signet::respond(
+			RuntimeOrigin::signed(OUTSIDER),
+			bounded_array::<100>(vec![[1u8; 32]]),
+			bounded_sig::<100>(vec![create_test_signature()]),
+		)
+		.expect_err("respond should fail for an unauthorized caller");
+
+		assert_eq!(err.error, Error::<Test>::NotAuthorizedSigner.into());
+		assert_eq!(err.post_info.pays_fee, Pays::Yes);
+	});
+}
+
+#[test]
+fn respond_should_charge_fee_when_input_lengths_mismatch() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Signet::add_signer(RuntimeOrigin::root(), SIGNER));
+
+		let err = Signet::respond(
+			RuntimeOrigin::signed(SIGNER),
+			bounded_array::<100>(vec![[1u8; 32], [2u8; 32]]),
+			bounded_sig::<100>(vec![create_test_signature()]),
+		)
+		.expect_err("respond should fail on length mismatch");
+
+		assert_eq!(err.error, Error::<Test>::InvalidInputLength.into());
+		assert_eq!(err.post_info.pays_fee, Pays::Yes);
 	});
 }
 

--- a/pallets/signet/src/tests/test_cases.rs
+++ b/pallets/signet/src/tests/test_cases.rs
@@ -50,6 +50,11 @@ fn fund_signet_pallet(amount: u128) -> u64 {
 	pallet_account
 }
 
+/// Authorize an account as a responder (signer).
+fn authorize_signer(who: u64) {
+	assert_ok!(Signet::add_signer(RuntimeOrigin::root(), who));
+}
+
 // -----------------------------------------------------------------------------
 // set_config tests
 // -----------------------------------------------------------------------------
@@ -422,6 +427,7 @@ fn test_sign_bidirectional_empty_transaction_fails() {
 fn test_respond_single() {
 	new_test_ext().execute_with(|| {
 		let responder = REQUESTER;
+		authorize_signer(responder);
 		let request_id = [99u8; 32];
 		let signature = create_test_signature();
 
@@ -446,6 +452,7 @@ fn test_respond_single() {
 fn test_respond_batch() {
 	new_test_ext().execute_with(|| {
 		let responder = REQUESTER;
+		authorize_signer(responder);
 		let request_ids = vec![[1u8; 32], [2u8; 32], [3u8; 32]];
 		let signatures = vec![
 			create_test_signature(),
@@ -472,6 +479,7 @@ fn test_respond_batch() {
 fn test_respond_mismatched_arrays_fails() {
 	new_test_ext().execute_with(|| {
 		let responder = REQUESTER;
+		authorize_signer(responder);
 
 		assert_noop!(
 			Signet::respond(
@@ -492,6 +500,7 @@ fn test_respond_mismatched_arrays_fails() {
 fn test_respond_error_single() {
 	new_test_ext().execute_with(|| {
 		let responder = REQUESTER;
+		authorize_signer(responder);
 		let error_response = ErrorResponse {
 			request_id: [99u8; 32],
 			error_message: bounded_u8::<1024>(b"Signature generation failed".to_vec()),
@@ -517,6 +526,7 @@ fn test_respond_error_single() {
 fn test_respond_error_batch() {
 	new_test_ext().execute_with(|| {
 		let responder = REQUESTER;
+		authorize_signer(responder);
 		let errors = vec![
 			ErrorResponse {
 				request_id: [1u8; 32],
@@ -546,6 +556,7 @@ fn test_respond_error_batch() {
 fn test_respond_bidirectional() {
 	new_test_ext().execute_with(|| {
 		let responder = REQUESTER;
+		authorize_signer(responder);
 		let request_id = [99u8; 32];
 		let output = b"read_output_data".to_vec();
 		let signature = create_test_signature();

--- a/pallets/signet/src/types.rs
+++ b/pallets/signet/src/types.rs
@@ -8,6 +8,8 @@ pub trait WeightInfo {
 	fn respond() -> Weight;
 	fn respond_error() -> Weight;
 	fn respond_bidirectional() -> Weight;
+	fn add_signer() -> Weight;
+	fn remove_signer() -> Weight;
 	fn pause() -> Weight;
 	fn unpause() -> Weight;
 }

--- a/pallets/signet/src/weights.rs
+++ b/pallets/signet/src/weights.rs
@@ -62,16 +62,26 @@ impl<T: frame_system::Config> crate::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	fn respond() -> Weight {
-		Weight::from_parts(217_000_000, 0)
-			.saturating_add(Weight::from_parts(0, 0))
+		Weight::from_parts(217_000_000, 1517)
+			.saturating_add(T::DbWeight::get().reads(1))
 	}
 	fn respond_error() -> Weight {
-		Weight::from_parts(296_000_000, 0)
-			.saturating_add(Weight::from_parts(0, 0))
+		Weight::from_parts(296_000_000, 1517)
+			.saturating_add(T::DbWeight::get().reads(1))
 	}
 	fn respond_bidirectional() -> Weight {
-		Weight::from_parts(36_000_000, 0)
-			.saturating_add(Weight::from_parts(0, 0))
+		Weight::from_parts(36_000_000, 1517)
+			.saturating_add(T::DbWeight::get().reads(1))
+	}
+	fn add_signer() -> Weight {
+		Weight::from_parts(15_000_000, 1517)
+			.saturating_add(T::DbWeight::get().reads(2))
+			.saturating_add(T::DbWeight::get().writes(2))
+	}
+	fn remove_signer() -> Weight {
+		Weight::from_parts(15_000_000, 1517)
+			.saturating_add(T::DbWeight::get().reads(2))
+			.saturating_add(T::DbWeight::get().writes(2))
 	}
 	fn pause() -> Weight {
 		Weight::from_parts(9_000_000, 0)

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "428.0.0"
+version = "429.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "429.0.0"
+version = "430.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -129,7 +129,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("hydradx"),
 	impl_name: Cow::Borrowed("hydradx"),
 	authoring_version: 1,
-	spec_version: 429,
+	spec_version: 430,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -129,7 +129,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("hydradx"),
 	impl_name: Cow::Borrowed("hydradx"),
 	authoring_version: 1,
-	spec_version: 428,
+	spec_version: 429,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/hydradx/src/weights/pallet_signet.rs
+++ b/runtime/hydradx/src/weights/pallet_signet.rs
@@ -76,25 +76,26 @@ impl<T: frame_system::Config> pallet_signet::WeightInfo for HydraWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
 	fn respond() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 215_458_000 picoseconds.
-		Weight::from_parts(216_808_000, 0)
+		Weight::from_parts(216_808_000, 1517)
+			.saturating_add(T::DbWeight::get().reads(1_u64))
 	}
 	fn respond_error() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 321_457_000 picoseconds.
-		Weight::from_parts(323_288_000, 0)
+		Weight::from_parts(323_288_000, 1517)
+			.saturating_add(T::DbWeight::get().reads(1_u64))
 	}
 	fn respond_bidirectional() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 95_250_000 picoseconds.
-		Weight::from_parts(95_830_000, 0)
+		Weight::from_parts(95_830_000, 1517)
+			.saturating_add(T::DbWeight::get().reads(1_u64))
+	}
+	fn add_signer() -> Weight {
+		Weight::from_parts(15_000_000, 1517)
+			.saturating_add(T::DbWeight::get().reads(2_u64))
+			.saturating_add(T::DbWeight::get().writes(2_u64))
+	}
+	fn remove_signer() -> Weight {
+		Weight::from_parts(15_000_000, 1517)
+			.saturating_add(T::DbWeight::get().reads(2_u64))
+			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
 	fn pause() -> Weight {
 		Weight::from_parts(13_044_000, 1517)

--- a/scripts/dispenser-tests/.env.example
+++ b/scripts/dispenser-tests/.env.example
@@ -12,7 +12,7 @@ EVM_NETWORK=anvil
 
 # ---- Overrides (optional — presets in networks.ts used if omitted) ----
 # SUBSTRATE_WS_ENDPOINT=ws://localhost:8000
-# SUBSTRATE_CHAIN_ID=polkadot:e6b50b06e72a81194e9c96c488175ecd
+# SUBSTRATE_CHAIN_ID=polkadot:2034
 # SS58_PREFIX=63
 # EVM_RPC_URL=http://localhost:8545
 # EVM_CHAIN_ID=31337

--- a/scripts/dispenser-tests/dispenser.test.ts
+++ b/scripts/dispenser-tests/dispenser.test.ts
@@ -67,7 +67,7 @@ describe('ERC20 Vault Integration', () => {
       ENV.SUBSTRATE_CHAIN_ID,
     )
 
-    const derived = deriveEthAddress()
+    const derived = deriveEthAddress(DISPENSER_SIGNING_PATH, palletSS58Prefix0)
     derivedEthAddress = derived.derivedEthAddress
     derivedPubKey = derived.derivedPubKey
 

--- a/scripts/dispenser-tests/dispenser.test.ts
+++ b/scripts/dispenser-tests/dispenser.test.ts
@@ -139,7 +139,7 @@ describe('ERC20 Vault Integration', () => {
       palletSS58Prefix0,
       Array.from(ethers.getBytes(tx.unsignedSerialized)),
       {
-        caip2_id: `eip155:${ENV.EVM_CHAIN_ID}`,
+        caip2_id: 'eip155:1',
         keyVersion: 0,
         path: DISPENSER_SIGNING_PATH,
         algo: 'ecdsa',

--- a/scripts/dispenser-tests/env.ts
+++ b/scripts/dispenser-tests/env.ts
@@ -90,6 +90,9 @@ const GAS_LIMIT = envBigInt('GAS_LIMIT', 100_000n)
 const DEFAULT_MAX_FEE_PER_GAS = envBigInt('DEFAULT_MAX_FEE_PER_GAS', 30_000_000_000n)
 const DEFAULT_MAX_PRIORITY_FEE_PER_GAS = envBigInt('DEFAULT_MAX_PRIORITY_FEE_PER_GAS', 2_000_000_000n)
 
+const FAUCET_OWNER_KEY = env('FAUCET_OWNER_KEY')
+const EVM_FUNDER_KEY = env('EVM_FUNDER_KEY')
+
 // Validate critical values
 if (!ethers.isAddress(FAUCET_ADDRESS)) throw new Error(`Invalid FAUCET_ADDRESS: ${FAUCET_ADDRESS}`)
 if (!ethers.isAddress(TARGET_ADDRESS)) throw new Error(`Invalid TARGET_ADDRESS: ${TARGET_ADDRESS}`)
@@ -109,6 +112,8 @@ export const ENV = {
   EVM_CHAIN_ID,
   ROOT_PUBLIC_KEY,
   FAUCET_ADDRESS,
+  FAUCET_OWNER_KEY,
+  EVM_FUNDER_KEY,
 
   // Test params
   TARGET_ADDRESS,

--- a/scripts/dispenser-tests/key-derivation.ts
+++ b/scripts/dispenser-tests/key-derivation.ts
@@ -6,13 +6,15 @@ export class KeyDerivation {
 
   static derivePublicKey(
     rootPublicKey: string,
+    predecessorId: string,
+    path: string,
     chainId: string
   ): string {
     const ec = new EC("secp256k1");
 
     const uncompressedRoot = rootPublicKey.slice(4);
 
-    const derivationPath = `${this.EPSILON_PREFIX},${chainId}`;
+    const derivationPath = `${this.EPSILON_PREFIX},${chainId},${predecessorId},${path}`;
     const hash = ethers.keccak256(ethers.toUtf8Bytes(derivationPath));
     const scalarHex = hash.slice(2);
 

--- a/scripts/dispenser-tests/networks.ts
+++ b/scripts/dispenser-tests/networks.ts
@@ -24,19 +24,19 @@ export interface EvmPreset {
 export const SUBSTRATE_PRESETS: Record<SubstrateNetwork, SubstratePreset> = {
   chopsticks: {
     wsEndpoint: 'ws://localhost:8000',
-    // Chopsticks forks mainnet but tc-set-config.ts writes the lark chain ID
-    // by default. Override with SUBSTRATE_CHAIN_ID if needed.
-    chainId: 'polkadot:e6b50b06e72a81194e9c96c488175ecd',
+    // polkadot:2034 = MPC's canonical Hydration id; the mainnet derivation path
+    // is reused on every network (dev/testnet included), so all presets share it.
+    chainId: 'polkadot:2034',
     ss58Prefix: 63,
   },
   lark: {
     wsEndpoint: 'wss://1.lark.hydration.cloud',
-    chainId: 'polkadot:e6b50b06e72a81194e9c96c488175ecd',
+    chainId: 'polkadot:2034',
     ss58Prefix: 63,
   },
   mainnet: {
     wsEndpoint: 'wss://rpc.hydradx.cloud',
-    chainId: 'polkadot:afdc188f45c71dacbaa0b62e16a91f72',
+    chainId: 'polkadot:2034',
     ss58Prefix: 63,
   },
 }

--- a/scripts/dispenser-tests/utils.ts
+++ b/scripts/dispenser-tests/utils.ts
@@ -682,12 +682,17 @@ async function ensureAliceHasFaucetAsset(
   console.log(`Alice faucet asset (${faucetAsset}) balance after mint: ${afterBal}`)
 }
 
-export function deriveEthAddress(): {
+export function deriveEthAddress(
+  path: string,
+  palletSS58: string,
+): {
   derivedPubKey: string
   derivedEthAddress: string
 } {
   const derivedPubKey = KeyDerivation.derivePublicKey(
     ENV.ROOT_PUBLIC_KEY,
+    palletSS58,
+    path,
     ENV.SUBSTRATE_CHAIN_ID,
   )
 
@@ -716,11 +721,12 @@ export async function ensureDerivedEthHasGas(
 
   if (ethBalance >= estimatedGas) return
 
-  if (ENV.EVM_NETWORK === 'anvil') {
-    const ANVIL_DEFAULT_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
-    const funder = new ethers.Wallet(ANVIL_DEFAULT_KEY, provider)
+  const ANVIL_DEFAULT_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+  const funderKey = ENV.EVM_NETWORK === 'anvil' ? ANVIL_DEFAULT_KEY : ENV.EVM_FUNDER_KEY
+  if (funderKey) {
+    const funder = new ethers.Wallet(funderKey, provider)
     const fundAmount = estimatedGas * 10n
-    console.log(`Funding ${derivedEthAddress} with ${ethers.formatEther(fundAmount)} ETH from Anvil account...`)
+    console.log(`Funding ${derivedEthAddress} with ${ethers.formatEther(fundAmount)} ETH...`)
     const tx = await funder.sendTransaction({ to: derivedEthAddress, value: fundAmount })
     await tx.wait()
     console.log(`Funded. Tx: ${tx.hash}`)
@@ -731,7 +737,7 @@ export async function ensureDerivedEthHasGas(
     `Insufficient ETH at ${derivedEthAddress}\n` +
       `   Need: ${ethers.formatEther(estimatedGas)} ETH\n` +
       `   Have: ${ethers.formatEther(ethBalance)} ETH\n` +
-      `   Please fund this address with ETH for gas`,
+      `   Fund this address with ETH for gas, or set EVM_FUNDER_KEY to auto-fund`,
   )
 }
 
@@ -759,7 +765,15 @@ export async function ensureFaucetMpcAddress(
 
   console.log(`Setting faucet MPC to derived address ${derivedEthAddress}...`)
   // Use Anvil account 0 (deployer/owner) to call setMPC
-  const ownerKey = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+  const ANVIL_OWNER_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+  const ownerKey = ENV.EVM_NETWORK === 'anvil' ? ANVIL_OWNER_KEY : ENV.FAUCET_OWNER_KEY
+  if (!ownerKey) {
+    throw new Error(
+      `Faucet MPC is ${currentMpc} but derived address is ${derivedEthAddress}.\n` +
+        `   Set FAUCET_OWNER_KEY (owner of ${ENV.FAUCET_ADDRESS}) to auto-setMPC, ` +
+        `or call setMPC(${derivedEthAddress}) manually from the owner.`,
+    )
+  }
   const ownerWallet = new ethers.Wallet(ownerKey, provider)
   const contractWithSigner = faucetContract.connect(ownerWallet)
   const tx = await (contractWithSigner as any).setMPC(derivedEthAddress)
@@ -860,14 +874,15 @@ export async function executeAsRoot(
     return
   }
 
-  // Try TC path first — much faster than governance referendum
   const isTcMember = await isSignerTcMember(api, signer)
   if (isTcMember) {
-    await executeViaTechCommittee(api, signer, call, label)
-    return
+    const applied = await executeViaTechCommittee(api, signer, call, label)
+    if (applied) return
+    console.log(`${label}: TC motion did not apply the call (needs Root); falling back to referendum`)
+  } else {
+    console.log(`${label}: signer is not a TC member, using referendum`)
   }
 
-  console.log(`${label}: signer is not a TC member, falling back to referendum`)
   await executeAsRootViaReferendum(api, signer, call, label)
 }
 
@@ -953,7 +968,7 @@ async function executeViaTechCommittee(
   signer: any,
   call: SubmittableExtrinsic<'promise'>,
   label: string,
-) {
+): Promise<boolean> {
   const members = await (api.query as any).technicalCommittee.members()
   const memberList = members.toJSON() as string[]
   const memberCount = memberList.length
@@ -981,20 +996,26 @@ async function executeViaTechCommittee(
     }
   }
 
-  // Check if the call was executed (Executed event = threshold was 1 or auto-closed)
-  const executed = result.events.some(
-    (r: any) =>
-      r.event.section === 'technicalCommittee' &&
-      (r.event.method === 'Executed' || r.event.method === 'Closed'),
-  )
+  for (const { event } of result.events) {
+    if (event.section === 'technicalCommittee' && event.method === 'Executed') {
+      const res: any = (event.data as any).result ?? event.data[1]
+      if (res && res.isErr) {
+        console.warn(`${label}: TC motion executed but inner call failed: ${res.asErr.toString()}`)
+        return false
+      }
+      console.log(`${label}: TC proposal executed immediately`)
+      return true
+    }
+  }
 
-  if (executed) {
-    console.log(`${label}: TC proposal executed immediately`)
-  } else if (threshold > 1) {
+  if (threshold > 1) {
     console.log(`${label}: TC proposal needs ${threshold - 1} more Aye votes from other members`)
     // Poll for execution (other TC members may vote via separate process)
     await pollForTcExecution(api, result, label)
+    return true
   }
+
+  return false
 }
 
 /**

--- a/scripts/dispenser-tests/validate-mint.ts
+++ b/scripts/dispenser-tests/validate-mint.ts
@@ -1,0 +1,49 @@
+import { waitReady } from '@polkadot/wasm-crypto'
+import {
+  createApi,
+  createKeyringAndAccounts,
+  executeAsRoot,
+  getTokenFree,
+} from './utils'
+
+async function main() {
+  await waitReady()
+  const api = await createApi()
+
+  const faucetAsset = (api.consts.ethDispenser.faucetAsset as any).toNumber()
+  const { alice } = createKeyringAndAccounts()
+
+  const before = await getTokenFree(api, alice.address, faucetAsset)
+  console.log(`\n[validate] Alice = ${alice.address}`)
+  console.log(`[validate] asset ${faucetAsset} BEFORE = ${before.toString()}`)
+
+  const mintAmount = 1_000_000_000_000_000n // 0.001 WETH (18 decimals)
+  const mintCall = (api.tx as any).currencies.updateBalance(
+    alice.address,
+    faucetAsset,
+    mintAmount.toString(),
+  )
+
+  console.log(`[validate] minting ${mintAmount} via executeAsRoot (TC → referendum fallback)...`)
+  await executeAsRoot(api, alice, mintCall, 'VALIDATE mint faucet asset to Alice')
+
+  const after = await getTokenFree(api, alice.address, faucetAsset)
+  const delta = after - before
+  console.log(`[validate] asset ${faucetAsset} AFTER  = ${after.toString()}`)
+  console.log(`[validate] delta = ${delta.toString()}`)
+  console.log(
+    `[validate] RESULT = ${
+      delta > 0n
+        ? 'PASS ✅ balance increased — executeAsRoot applied the Root call'
+        : 'NO-CHANGE ❌ Root call did not apply within the poll window (see log above)'
+    }`,
+  )
+
+  await api.disconnect()
+  process.exit(delta > 0n ? 0 : 2)
+}
+
+main().catch((e) => {
+  console.error('[validate] FATAL', e)
+  process.exit(1)
+})

--- a/scripts/signet-feeless-test/.gitignore
+++ b/scripts/signet-feeless-test/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+yarn.lock
+package-lock.json

--- a/scripts/signet-feeless-test/README.md
+++ b/scripts/signet-feeless-test/README.md
@@ -1,8 +1,10 @@
 # signet-feeless-test
 
-Chopsticks e2e for the allowlist-gated, feeless `signet.respond` flow: an
-authorized signer holding only the existential deposit (1 HDX) can call
-`respond` without paying a fee, and a non-allowlisted account is rejected.
+Chopsticks e2e for the allowlist-gated `signet.respond` flow: the fee is locked
+upfront and refunded when the call succeeds, otherwise charged. An authorized
+signer's successful `respond` costs nothing (fee refunded), while a
+non-allowlisted account fails and is charged. The caller must hold enough HDX to
+lock the fee.
 
 Mirrors the pallet unit tests in `pallets/signet/src/tests/signer_allowlist.rs`.
 

--- a/scripts/signet-feeless-test/README.md
+++ b/scripts/signet-feeless-test/README.md
@@ -1,0 +1,25 @@
+# signet-feeless-test
+
+Chopsticks e2e for the allowlist-gated, feeless `signet.respond` flow: an
+authorized signer holding only the existential deposit (1 HDX) can call
+`respond` without paying a fee, and a non-allowlisted account is rejected.
+
+Mirrors the pallet unit tests in `pallets/signet/src/tests/signer_allowlist.rs`.
+
+## Run
+
+Build the runtime wasm and install deps:
+
+```sh
+cargo build --release -p hydradx-runtime
+cd scripts/signet-feeless-test && yarn install
+```
+
+Then run (launches a Chopsticks fork of hydradx, runs the tests, tears down):
+
+```sh
+./run.sh
+```
+
+`add_signer` is dispatched as Root via the scheduler on the fork; on a live
+chain it goes through governance (`UpdateOrigin = EnsureRoot | TechCommittee`).

--- a/scripts/signet-feeless-test/package.json
+++ b/scripts/signet-feeless-test/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "signet-feeless-test",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Chopsticks e2e test: allowlist-gated, feeless signet.respond",
+  "scripts": {
+    "test": "jest --runInBand --forceExit"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node",
+    "testMatch": ["**/*.test.ts"],
+    "testTimeout": 600000
+  },
+  "dependencies": {
+    "@polkadot/api": "latest",
+    "@polkadot/keyring": "latest",
+    "@polkadot/util": "latest",
+    "@polkadot/util-crypto": "latest"
+  },
+  "devDependencies": {
+    "@types/jest": "^30.0.0",
+    "@types/node": "^20.11.5",
+    "jest": "^30.1.3",
+    "ts-jest": "^29.4.4",
+    "typescript": "^5.3.3"
+  }
+}

--- a/scripts/signet-feeless-test/run.sh
+++ b/scripts/signet-feeless-test/run.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Launch a Chopsticks fork with the local runtime wasm, run the e2e suite, tear down.
+# Prereqs: build the wasm + `yarn install` (see README).
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+WASM="$ROOT/target/release/wbuild/hydradx-runtime/hydradx_runtime.compact.compressed.wasm"
+CHOPLOG="$(mktemp -t chopsticks-signet.XXXXXX.log)"
+PORT=8000
+
+if [ ! -f "$WASM" ]; then
+  echo "missing runtime wasm: $WASM"
+  echo "build it first: (cd $ROOT && cargo build --release -p hydradx-runtime)"
+  exit 1
+fi
+
+echo "[run] freeing port $PORT if held..."
+lsof -ti "tcp:$PORT" 2>/dev/null | xargs -r kill -9 2>/dev/null || true
+
+echo "[run] launching chopsticks (fork hydradx mainnet, wasm-override, db-less)..."
+( cd "$ROOT" && npx -y @acala-network/chopsticks@latest \
+    --endpoint=wss://rpc.hydradx.cloud \
+    --wasm-override "$WASM" \
+    --mock-signature-host \
+    --build-block-mode Manual \
+    --port "$PORT" ) > "$CHOPLOG" 2>&1 &
+CHOPID=$!
+trap 'kill $CHOPID 2>/dev/null; lsof -ti "tcp:'"$PORT"'" 2>/dev/null | xargs -r kill -9 2>/dev/null; wait $CHOPID 2>/dev/null' EXIT
+
+echo "[run] waiting for chopsticks to listen (log: $CHOPLOG)..."
+READY=0
+for i in $(seq 1 90); do
+  if grep -qi "listening" "$CHOPLOG" 2>/dev/null; then READY=1; break; fi
+  if ! kill -0 "$CHOPID" 2>/dev/null; then echo "[run] chopsticks exited early:"; tail -30 "$CHOPLOG"; exit 1; fi
+  sleep 2
+done
+[ "$READY" = "1" ] || { echo "[run] chopsticks not ready; log:"; tail -30 "$CHOPLOG"; exit 1; }
+echo "[run] chopsticks listening after ~$((i*2))s"
+
+echo "[run] running jest..."
+cd "$HERE"
+WS_URL="ws://localhost:$PORT" ./node_modules/.bin/jest --runInBand --forceExit --verbose

--- a/scripts/signet-feeless-test/signet-feeless.test.ts
+++ b/scripts/signet-feeless-test/signet-feeless.test.ts
@@ -20,7 +20,10 @@ const SIGNATURE = {
 	recoveryId: 0,
 };
 
-describe('signet feeless respond (allowlist-gated)', () => {
+// Existential deposit plus enough headroom to lock one respond fee.
+const FUND = ED + 10_000_000_000_000n;
+
+describe('signet respond (lock / refund-on-success)', () => {
 	let api: ApiPromise;
 	let provider: WsProvider;
 	let signer: KeyringPair;
@@ -34,9 +37,8 @@ describe('signet feeless respond (allowlist-gated)', () => {
 
 		await executeAsRootViaScheduler(api, provider, api.tx.signet.addSigner(signer.address));
 
-		// Fund both with exactly the existential deposit — no gas buffer.
-		await setNativeBalance(provider, signer.address, ED);
-		await setNativeBalance(provider, outsider.address, ED);
+		await setNativeBalance(provider, signer.address, FUND);
+		await setNativeBalance(provider, outsider.address, FUND);
 	}, 600000);
 
 	afterAll(async () => {
@@ -48,12 +50,12 @@ describe('signet feeless respond (allowlist-gated)', () => {
 		expect((entry as any).isSome).toBe(true);
 	});
 
-	it('respond should be annotated Pays::No (zero partial fee)', async () => {
+	it('respond should predict a non-zero fee (locked upfront)', async () => {
 		const info = await api.tx.signet.respond([REQUEST_ID], [SIGNATURE]).paymentInfo(signer.address);
-		expect((info as any).partialFee.toBigInt()).toBe(0n);
+		expect((info as any).partialFee.toBigInt()).toBeGreaterThan(0n);
 	});
 
-	it('respond should succeed for an ED-only signer and not charge a fee', async () => {
+	it('respond should refund the fee when successful', async () => {
 		const before = await freeBalance(api, signer.address);
 
 		const events = await submitAndMine(api, provider, api.tx.signet.respond([REQUEST_ID], [SIGNATURE]), signer);
@@ -63,10 +65,11 @@ describe('signet feeless respond (allowlist-gated)', () => {
 
 		const after = await freeBalance(api, signer.address);
 		expect(after).toBe(before);
-		expect(after).toBe(ED);
 	}, 300000);
 
-	it('respond should be rejected for a non-allowlisted account', async () => {
+	it('respond should charge the fee when the caller is not allowlisted', async () => {
+		const before = await freeBalance(api, outsider.address);
+
 		const events = await submitAndMine(api, provider, api.tx.signet.respond([REQUEST_ID], [SIGNATURE]), outsider);
 
 		const failed = findEvent(events, 'system', 'ExtrinsicFailed');
@@ -75,5 +78,8 @@ describe('signet feeless respond (allowlist-gated)', () => {
 		const err = moduleErrorName(api, failed);
 		expect(err.section).toBe('signet');
 		expect(err.name).toBe('NotAuthorizedSigner');
+
+		const after = await freeBalance(api, outsider.address);
+		expect(after).toBeLessThan(before);
 	}, 300000);
 });

--- a/scripts/signet-feeless-test/signet-feeless.test.ts
+++ b/scripts/signet-feeless-test/signet-feeless.test.ts
@@ -1,0 +1,79 @@
+import { ApiPromise, WsProvider } from '@polkadot/api';
+import { Keyring } from '@polkadot/keyring';
+import type { KeyringPair } from '@polkadot/keyring/types';
+import {
+	createApi,
+	ED,
+	executeAsRootViaScheduler,
+	findEvent,
+	freeBalance,
+	moduleErrorName,
+	setNativeBalance,
+	submitAndMine,
+} from './utils';
+
+// Arbitrary request id + dummy signature (not verified on-chain).
+const REQUEST_ID = '0x' + '11'.repeat(32);
+const SIGNATURE = {
+	bigR: { x: '0x' + '01'.repeat(32), y: '0x' + '02'.repeat(32) },
+	s: '0x' + '03'.repeat(32),
+	recoveryId: 0,
+};
+
+describe('signet feeless respond (allowlist-gated)', () => {
+	let api: ApiPromise;
+	let provider: WsProvider;
+	let signer: KeyringPair;
+	let outsider: KeyringPair;
+
+	beforeAll(async () => {
+		({ api, provider } = await createApi());
+		const keyring = new Keyring({ type: 'sr25519' });
+		signer = keyring.addFromUri('//signetSigner');
+		outsider = keyring.addFromUri('//signetOutsider');
+
+		await executeAsRootViaScheduler(api, provider, api.tx.signet.addSigner(signer.address));
+
+		// Fund both with exactly the existential deposit — no gas buffer.
+		await setNativeBalance(provider, signer.address, ED);
+		await setNativeBalance(provider, outsider.address, ED);
+	}, 600000);
+
+	afterAll(async () => {
+		await api?.disconnect();
+	});
+
+	it('add_signer should have authorized the signer', async () => {
+		const entry = await api.query.signet.signers(signer.address);
+		expect((entry as any).isSome).toBe(true);
+	});
+
+	it('respond should be annotated Pays::No (zero partial fee)', async () => {
+		const info = await api.tx.signet.respond([REQUEST_ID], [SIGNATURE]).paymentInfo(signer.address);
+		expect((info as any).partialFee.toBigInt()).toBe(0n);
+	});
+
+	it('respond should succeed for an ED-only signer and not charge a fee', async () => {
+		const before = await freeBalance(api, signer.address);
+
+		const events = await submitAndMine(api, provider, api.tx.signet.respond([REQUEST_ID], [SIGNATURE]), signer);
+
+		expect(findEvent(events, 'signet', 'SignatureResponded')).toBeDefined();
+		expect(findEvent(events, 'system', 'ExtrinsicFailed')).toBeUndefined();
+
+		const after = await freeBalance(api, signer.address);
+		expect(after).toBe(before);
+		expect(after).toBe(ED);
+	}, 300000);
+
+	it('respond should be rejected for a non-allowlisted account', async () => {
+		const events = await submitAndMine(api, provider, api.tx.signet.respond([REQUEST_ID], [SIGNATURE]), outsider);
+
+		const failed = findEvent(events, 'system', 'ExtrinsicFailed');
+		expect(failed).toBeDefined();
+
+		const err = moduleErrorName(api, failed);
+		expect(err.section).toBe('signet');
+		expect(err.name).toBe('NotAuthorizedSigner');
+	}, 300000);
+});

--- a/scripts/signet-feeless-test/tsconfig.json
+++ b/scripts/signet-feeless-test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["**/*.ts"]
+}

--- a/scripts/signet-feeless-test/utils.ts
+++ b/scripts/signet-feeless-test/utils.ts
@@ -1,0 +1,68 @@
+import { ApiPromise, WsProvider } from '@polkadot/api';
+
+export const ENDPOINT = process.env.WS_URL || 'ws://localhost:8000';
+
+// HDX existential deposit (1 HDX, 12 decimals).
+export const ED = 1_000_000_000_000n;
+
+export async function createApi(): Promise<{ api: ApiPromise; provider: WsProvider }> {
+	// Big request timeout: the first dev_newBlock on a fresh fork can exceed 60s.
+	const provider = new WsProvider(ENDPOINT, 2_500, {}, 600_000);
+	const api = await ApiPromise.create({ provider, throwOnConnect: false });
+	await api.isReady;
+	return { api, provider };
+}
+
+export async function newBlock(provider: WsProvider, count = 1): Promise<void> {
+	await provider.send('dev_newBlock', [{ count }]);
+}
+
+// Dispatch `call` as Root via the scheduler (chopsticks dev_setStorage).
+export async function executeAsRootViaScheduler(api: ApiPromise, provider: WsProvider, call: any): Promise<void> {
+	const header = await api.rpc.chain.getHeader();
+	const at = header.number.toNumber() + 1;
+	const callHex = call.method.toHex();
+
+	await provider.send('dev_setStorage', [
+		{
+			Scheduler: {
+				Agenda: [[[at], [{ call: { Inline: callHex }, origin: { system: 'Root' } }]]],
+			},
+		},
+	]);
+	await newBlock(provider);
+}
+
+// Make the account exist (providers = 1) with exactly `free` balance.
+export async function setNativeBalance(provider: WsProvider, address: string, free: bigint): Promise<void> {
+	await provider.send('dev_setStorage', [
+		{
+			System: {
+				Account: [[[address], { providers: 1, data: { free: free.toString() } }]],
+			},
+		},
+	]);
+}
+
+export async function freeBalance(api: ApiPromise, address: string): Promise<bigint> {
+	const acc = await api.query.system.account(address);
+	return (acc as any).data.free.toBigInt();
+}
+
+export async function submitAndMine(api: ApiPromise, provider: WsProvider, tx: any, signer: any): Promise<any[]> {
+	await tx.signAndSend(signer);
+	await newBlock(provider);
+	const blockHash = await api.rpc.chain.getBlockHash();
+	const events = await api.query.system.events.at(blockHash);
+	return (events as any).toArray();
+}
+
+export function findEvent(events: any[], section: string, method: string): any | undefined {
+	return events.find((r) => r.event.section === section && r.event.method === method);
+}
+
+export function moduleErrorName(api: ApiPromise, failedEvent: any): { section: string; name: string } {
+	const dispatchError = failedEvent.event.data[0];
+	const meta = api.registry.findMetaError(dispatchError.asModule);
+	return { section: meta.section, name: meta.name };
+}


### PR DESCRIPTION
Makes signet's `respond`/`respond_error`/`respond_bidirectional` feeless (`Pays::No`) and restricts them to a governance-managed signer allowlist (`add_signer`/`remove_signer`), so MPC nodes can respond from an account funded once with the existential deposit (~1 HDX) and never need gas top-ups.
Includes pallet unit tests and a Chopsticks e2e (`scripts/signet-feeless-test`).