### PR TITLE
chore: Set AllowMultipleBlocksPerSlot to false

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "429.0.0"
+version = "430.0.0"
 dependencies = [
  "alloy-primitives 0.7.7",
  "alloy-sol-types 0.7.7",

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "429.0.0"
+version = "430.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -129,7 +129,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("hydradx"),
 	impl_name: Cow::Borrowed("hydradx"),
 	authoring_version: 1,
-	spec_version: 429,
+	spec_version: 430,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/hydradx/src/system.rs
+++ b/runtime/hydradx/src/system.rs
@@ -322,7 +322,7 @@ impl pallet_aura::Config for Runtime {
 	type AuthorityId = AuraId;
 	type MaxAuthorities = MaxAuthorities;
 	type DisabledValidators = ();
-	type AllowMultipleBlocksPerSlot = ConstBool<true>;
+	type AllowMultipleBlocksPerSlot = ConstBool<false>;
 	type SlotDuration = ConstU64<SLOT_DURATION>;
 }
 


### PR DESCRIPTION
This PR sets `AllowMultipleBlocksPerSlot` back to false

This was kept at `true` to allow for close-to-normal avg blocktime while nodes were having block production issues caused by forks.

Now that the collators have upgraded to `polkadot-stable2506` and the fork issues are mostly gone, this can be disabled again until the migration to 2s blocktime