### PR TITLE
test(asset-registry): register xcFOON from Taifoon

### DIFF
--- a/integration-tests/src/asset_registry.rs
+++ b/integration-tests/src/asset_registry.rs
@@ -5,7 +5,7 @@ use frame_support::assert_ok;
 use frame_system::RawOrigin;
 use hydradx_runtime::AssetRegistry as Registry;
 use polkadot_xcm::v5::{
-	Junction::{GeneralIndex, Parachain},
+	Junction::{GeneralIndex, PalletInstance, Parachain},
 	Location,
 };
 use pretty_assertions::{assert_eq, assert_ne};
@@ -85,5 +85,42 @@ fn root_should_update_location_when_asset_exists() {
 		assert_eq!(Registry::location_assets(loc_2).unwrap(), LRNA);
 
 		assert!(Registry::location_assets(loc_1).is_none());
+	});
+}
+
+// Registering a Taifoon-native asset (xcFOON) on Hydration.
+//
+// Taifoon is a Moonbeam fork, so its native currency uses the Moonbeam-family multilocation shape:
+// `{ parents: 1, interior: X2(Parachain(TAIFOON_PARA_ID), PalletInstance(10)) }` — PalletInstance 10
+// is the Balances pallet on Moonbeam-family runtimes, i.e. the native token (18 decimals). This is
+// the on-chain `assetRegistry.register` a GeneralAdmin referendum would submit to accept xcFOON.
+#[test]
+fn root_should_register_xcfoon_from_taifoon() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		let foon_location = hydradx_runtime::AssetLocation(Location {
+			parents: 1,
+			interior: [Parachain(TAIFOON_PARA_ID), PalletInstance(10)].into(),
+		});
+
+		// The location must not resolve before registration.
+		assert!(Registry::location_assets(foon_location.clone()).is_none());
+
+		assert_ok!(Registry::register(
+			RawOrigin::Root.into(),
+			None,                                    // asset_id: auto
+			Some(b"Taifoon FOON".to_vec().try_into().unwrap()),
+			pallet_asset_registry::AssetType::Token, // asset_type
+			None,                                    // existential_deposit: default
+			Some(b"xcFOON".to_vec().try_into().unwrap()),
+			Some(18),                                // decimals (FOON = 18)
+			Some(foon_location.clone()),             // location
+			None,                                    // xcm_rate_limit
+			false,                                   // is_sufficient
+		));
+
+		// The location now resolves to a local asset id, and back.
+		let foon_id = Registry::location_assets(foon_location.clone()).expect("xcFOON registered");
+		assert_eq!(Registry::locations(foon_id).unwrap(), foon_location);
 	});
 }

--- a/integration-tests/src/polkadot_test_net.rs
+++ b/integration-tests/src/polkadot_test_net.rs
@@ -108,6 +108,7 @@ pub const ASSET_HUB_PARA_ID: u32 = 1_000;
 pub const ACALA_PARA_ID: u32 = 2_000;
 pub const HYDRA_PARA_ID: u32 = 2_034;
 pub const MOONBEAM_PARA_ID: u32 = 2_004;
+pub const TAIFOON_PARA_ID: u32 = 3_369; // TODO: replace with Taifoon's reserved Polkadot para id once registered
 pub const INTERLAY_PARA_ID: u32 = 2_032;
 pub const ZEITGEIST_PARA_ID: u32 = 2_092;
 


### PR DESCRIPTION
## Summary

Adds an integration test for accepting **xcFOON** — the native currency of **Taifoon** (a Polkadot parachain, Moonbeam fork) — into Hydration's asset registry.

> **Draft.** Taifoon is not yet registered on Polkadot, so `TAIFOON_PARA_ID` is a placeholder (`3369`) pending its real reserved para id. In production the actual integration is **not** a code change — it's an on-chain `assetRegistry.register` submitted via a `GeneralAdmin` OpenGov referendum. This PR adds the test that mirrors that call so the round-trip is covered in CI.

## The multilocation (the load-bearing detail)

Taifoon is a Moonbeam fork, so xcFOON uses the **Moonbeam-family** shape — `PalletInstance(10)` (Balances/native, 18 decimals), **not** `GeneralIndex`:

```rust
AssetLocation(Location {
    parents: 1,
    interior: [Parachain(TAIFOON_PARA_ID), PalletInstance(10)].into(),
})
```

## Changes
- `integration-tests/src/polkadot_test_net.rs`: `TAIFOON_PARA_ID` const (placeholder).
- `integration-tests/src/asset_registry.rs`: `root_should_register_xcfoon_from_taifoon` — registers xcFOON via `AssetRegistry::register` (18 decimals, `AssetType::Token`) and asserts `location_assets` / `locations` round-trip. Mirrors the existing `root_should_update_location_when_asset_exists` pattern and the `AssetType` usage in `evm.rs`.

Also required for full integration (relay-chain governance, not this repo): bidirectional HRMP Taifoon↔Hydration via `hrmp.hrmpInitOpenChannel`/`hrmpAcceptOpenChannel`.