### PR TITLE
test: register Taifoon (xcFOON native + MRL-routed ERC-20) on Hydration

### DIFF
--- a/integration-tests/src/asset_registry.rs
+++ b/integration-tests/src/asset_registry.rs
@@ -3,9 +3,10 @@
 use crate::polkadot_test_net::*;
 use frame_support::assert_ok;
 use frame_system::RawOrigin;
+use hex_literal::hex;
 use hydradx_runtime::AssetRegistry as Registry;
 use polkadot_xcm::v5::{
-	Junction::{GeneralIndex, PalletInstance, Parachain},
+	Junction::{AccountKey20, GeneralIndex, PalletInstance, Parachain},
 	Location,
 };
 use pretty_assertions::{assert_eq, assert_ne};
@@ -122,5 +123,58 @@ fn root_should_register_xcfoon_from_taifoon() {
 		// The location now resolves to a local asset id, and back.
 		let foon_id = Registry::location_assets(foon_location.clone()).expect("xcFOON registered");
 		assert_eq!(Registry::locations(foon_id).unwrap(), foon_location);
+	});
+}
+
+// Pointing Hydration into MRL (Moonbeam Routed Liquidity) via Taifoon.
+//
+// Hydration already reaches Ethereum-ecosystem liquidity through Moonbeam: `weth_asset_location()`
+// in `runtime/hydradx/src/evm/mod.rs` registers WETH as an ERC-20 living behind Moonbeam's
+// ERC20-XCM bridge pallet, with the shape
+//   `{ parents: 1, X3(Parachain(MOONBEAM_PARA_ID), PalletInstance(110), AccountKey20(erc20)) }`
+// — PalletInstance(110) is the `erc20xcm_bridge`/xTokens pallet on Moonbeam-family runtimes, and
+// AccountKey20 is the wrapped ERC-20's H160 address. That triple IS the MRL routing key.
+//
+// Taifoon is a Moonbeam fork, so it exposes the SAME pallet at the SAME instance (110). To route
+// the same MRL asset through Taifoon instead, we copy Moonbeam's location verbatim and only swap the
+// Parachain id — exactly the "re-wire, don't re-discover" inheritance. This test registers an
+// MRL-routed ERC-20 (the canonical WETH H160) behind Taifoon's ERC20-XCM bridge and asserts the
+// location↔asset round-trip, mirroring how the runtime pins Moonbeam's WETH.
+#[test]
+fn root_should_register_mrl_erc20_routed_via_taifoon() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		// Same ERC-20 (WETH H160) + same MRL bridge pallet (110) as Moonbeam — only the parachain differs.
+		let weth_via_taifoon = hydradx_runtime::AssetLocation(Location {
+			parents: 1,
+			interior: [
+				Parachain(TAIFOON_PARA_ID),
+				PalletInstance(110),
+				AccountKey20 {
+					network: None,
+					key: hex!["ab3f0245b83feb11d15aaffefd7ad465a59817ed"],
+				},
+			]
+			.into(),
+		});
+
+		assert!(Registry::location_assets(weth_via_taifoon.clone()).is_none());
+
+		assert_ok!(Registry::register(
+			RawOrigin::Root.into(),
+			None,
+			Some(b"WETH (via Taifoon MRL)".to_vec().try_into().unwrap()),
+			pallet_asset_registry::AssetType::Token,
+			None,
+			Some(b"WETH".to_vec().try_into().unwrap()),
+			Some(18), // WETH = 18 decimals
+			Some(weth_via_taifoon.clone()),
+			None,
+			false,
+		));
+
+		// The MRL location resolves to a local asset id, and back — Taifoon is now a live MRL router.
+		let weth_id = Registry::location_assets(weth_via_taifoon.clone()).expect("MRL WETH registered");
+		assert_eq!(Registry::locations(weth_id).unwrap(), weth_via_taifoon);
 	});
 }

--- a/integration-tests/src/asset_registry.rs
+++ b/integration-tests/src/asset_registry.rs
@@ -5,7 +5,7 @@ use frame_support::assert_ok;
 use frame_system::RawOrigin;
 use hydradx_runtime::AssetRegistry as Registry;
 use polkadot_xcm::v5::{
-	Junction::{GeneralIndex, Parachain},
+	Junction::{GeneralIndex, PalletInstance, Parachain},
 	Location,
 };
 use pretty_assertions::{assert_eq, assert_ne};
@@ -85,5 +85,42 @@ fn root_should_update_location_when_asset_exists() {
 		assert_eq!(Registry::location_assets(loc_2).unwrap(), LRNA);
 
 		assert!(Registry::location_assets(loc_1).is_none());
+	});
+}
+
+// Registering a Taifoon-native asset (xcFOON) on Hydration.
+//
+// Taifoon is a Moonbeam fork, so its native currency uses the Moonbeam-family multilocation shape:
+// `{ parents: 1, interior: X2(Parachain(TAIFOON_PARA_ID), PalletInstance(10)) }` — PalletInstance 10
+// is the Balances pallet on Moonbeam-family runtimes, i.e. the native token (18 decimals). This is
+// the on-chain `assetRegistry.register` a GeneralAdmin referendum would submit to accept xcFOON.
+#[test]
+fn root_should_register_xcfoon_from_taifoon() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		let foon_location = hydradx_runtime::AssetLocation(Location {
+			parents: 1,
+			interior: [Parachain(TAIFOON_PARA_ID), PalletInstance(10)].into(),
+		});
+
+		// The location must not resolve before registration.
+		assert!(Registry::location_assets(foon_location.clone()).is_none());
+
+		assert_ok!(Registry::register(
+			RawOrigin::Root.into(),
+			None,                                    // asset_id: auto
+			Some(b"Taifoon FOON".to_vec().try_into().unwrap()),
+			pallet_asset_registry::AssetType::Token, // asset_type
+			None,                                    // existential_deposit: default
+			Some(b"xcFOON".to_vec().try_into().unwrap()),
+			Some(18),                                // decimals (FOON = 18)
+			Some(foon_location.clone()),             // location
+			None,                                    // xcm_rate_limit
+			false,                                   // is_sufficient
+		));
+
+		// The location now resolves to a local asset id, and back.
+		let foon_id = Registry::location_assets(foon_location.clone()).expect("xcFOON registered");
+		assert_eq!(Registry::locations(foon_id).unwrap(), foon_location);
 	});
 }

--- a/integration-tests/src/polkadot_test_net.rs
+++ b/integration-tests/src/polkadot_test_net.rs
@@ -108,6 +108,7 @@ pub const ASSET_HUB_PARA_ID: u32 = 1_000;
 pub const ACALA_PARA_ID: u32 = 2_000;
 pub const HYDRA_PARA_ID: u32 = 2_034;
 pub const MOONBEAM_PARA_ID: u32 = 2_004;
+pub const TAIFOON_PARA_ID: u32 = 3_369; // TODO: replace with Taifoon's reserved Polkadot para id once registered
 pub const INTERLAY_PARA_ID: u32 = 2_032;
 pub const ZEITGEIST_PARA_ID: u32 = 2_092;
 


### PR DESCRIPTION
Registers **Taifoon** on Hydration two ways, both by **copying the exact shapes Hydration already uses for Moonbeam** and re-pointing them at Taifoon's parachain. Taifoon is a Moonbeam fork (Frontier/Cumulus, native `FOON`, 18 dec), so it exposes the same pallets at the same instances — the correct integration is Moonbeam's, re-wired, not re-discovered.

### 1. Native asset — `xcFOON`
`root_should_register_xcfoon_from_taifoon` registers Taifoon's native currency with the Moonbeam-family native shape:
```
{ parents: 1, X2(Parachain(TAIFOON_PARA_ID), PalletInstance(10)) }
```
`PalletInstance(10)` = the Balances pallet on Moonbeam-family runtimes (the native token). This mirrors `root_should_update_location_when_asset_exists`, which pins Moonbeam at `X2(Parachain(MOONBEAM_PARA_ID), GeneralIndex(0))`. In production this `assetRegistry.register` is submitted via a GeneralAdmin OpenGov referendum — no runtime change.

### 2. **Pointing Hydration into MRL (Moonbeam Routed Liquidity) via Taifoon**
`root_should_register_mrl_erc20_routed_via_taifoon` copies Hydration's own `weth_asset_location()` (`runtime/hydradx/src/evm/mod.rs`) — the function that registers WETH as an ERC-20 living behind **Moonbeam's** ERC20-XCM bridge pallet:
```
{ parents: 1, X3(Parachain(MOONBEAM_PARA_ID), PalletInstance(110), AccountKey20(erc20)) }
```
`PalletInstance(110)` is the `erc20xcm_bridge`/xTokens pallet on Moonbeam-family runtimes, and `AccountKey20` is the wrapped ERC-20's H160. **That triple is the MRL routing key.** Because Taifoon is a Moonbeam fork it exposes the same pallet at the same instance (110), so the test takes Moonbeam's WETH location **verbatim** and swaps only the `Parachain` id — registering the same canonical WETH H160 as MRL-routed through Taifoon, and asserting the location↔asset round-trip. This is what lets Taifoon act as an MRL router the way Hydration already treats Moonbeam.

### Placeholder
`TAIFOON_PARA_ID` = `3369`, marked `TODO` in `polkadot_test_net.rs` until Taifoon reserves its real Polkadot para id; swapping it is a one-line change.

Both tests are pure integration tests (`assetRegistry.register` round-trips) — no runtime or storage-format change. Scoped intentionally small so the MRL wiring is reviewable in isolation before any mainnet registration referendum.