### PR TITLE
feat: add evidence-backed runtime interaction graph

### DIFF
--- a/.github/workflows/runtime-interaction-graph.yml
+++ b/.github/workflows/runtime-interaction-graph.yml
@@ -1,0 +1,106 @@
+name: Runtime interaction graph
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  graph-diff:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: current
+          persist-credentials: false
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+          persist-credentials: false
+      - name: Select coverage policy
+        id: coverage-policy
+        run: |
+          policy=base/scripts/runtime-interaction-graph/coverage-thresholds-deployment.json
+          if [ ! -f "$policy" ]; then
+            policy=current/scripts/runtime-interaction-graph/coverage-thresholds-deployment.json
+          fi
+          echo "path=$policy" >> "$GITHUB_OUTPUT"
+      - name: Select contract fixtures
+        id: contract-fixtures
+        run: |
+          before=base/scripts/runtime-interaction-graph/fixtures/ci-contracts.json
+          if [ ! -f "$before" ]; then
+            before=current/scripts/runtime-interaction-graph/fixtures/ci-contracts.json
+          fi
+          echo "before=$before" >> "$GITHUB_OUTPUT"
+          echo "after=current/scripts/runtime-interaction-graph/fixtures/ci-contracts.json" >> "$GITHUB_OUTPUT"
+      - name: Test graph tooling
+        run: |
+          python3 -m unittest discover -s current/scripts/runtime-interaction-graph -p 'test_*.py'
+          node --test current/scripts/runtime-interaction-graph/collect_runtime_contracts.test.mjs
+      - name: Generate graphs
+        run: |
+          python3 current/scripts/runtime-interaction-graph/runtime_interaction_graph.py \
+            --root base --output output/before \
+            --contracts-manifest "${{ steps.contract-fixtures.outputs.before }}"
+          python3 current/scripts/runtime-interaction-graph/runtime_interaction_graph.py \
+            --root current --output output/after \
+            --contracts-manifest "${{ steps.contract-fixtures.outputs.after }}"
+      - name: Compare graphs and coverage
+        run: |
+          python3 current/scripts/runtime-interaction-graph/diff_graphs.py \
+            output/before/interaction-graph.json output/after/interaction-graph.json \
+            --before-coverage output/before/coverage.json \
+            --after-coverage output/after/coverage.json \
+            --coverage-thresholds "${{ steps.coverage-policy.outputs.path }}" \
+            --output output/graph-diff.json --markdown output/graph-diff.md
+      - name: Add graph summary
+        if: always()
+        run: |
+          if [ -f output/graph-diff.md ]; then
+            cat output/graph-diff.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: runtime-interaction-graph
+          path: output
+
+  full-semantic-graph:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    env:
+      CARGO_INCREMENTAL: "0"
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+      CARGO_PROFILE_DEV_DEBUG: "0"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install pinned nightly
+        run: rustup toolchain install nightly-2025-12-06 --profile minimal
+      - name: Test graph tooling
+        run: |
+          python3 -m unittest discover -s scripts/runtime-interaction-graph -p 'test_*.py'
+          node --test scripts/runtime-interaction-graph/collect_runtime_contracts.test.mjs
+      - name: Collect workspace MIR
+        run: |
+          python3 scripts/runtime-interaction-graph/collect_mir.py \
+            --all --output output/full/mir
+      - name: Generate compiler-enriched graph
+        run: |
+          python3 scripts/runtime-interaction-graph/runtime_interaction_graph.py \
+            --rustc-mir-manifest output/full/mir/manifest.json \
+            --contracts-manifest scripts/runtime-interaction-graph/fixtures/ci-contracts.json \
+            --output output/full/graph \
+            --coverage-thresholds scripts/runtime-interaction-graph/coverage-thresholds-full.json
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: runtime-interaction-graph-full
+          path: output/full

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,38 @@ available Codex equivalent:
 Available shared skills:
 - `hydration_cl0wdit` - security audit workflow for Substrate runtime and pallet
   code.
+
+## runtime interaction graph
+
+For runtime dependency and interaction questions, use the bounded AI-facing
+query interface documented in `scripts/runtime-interaction-graph/README.md`.
+Prefer `query_graph.py` over loading `interaction-graph.json` or the interactive
+HTML into model context. Use the generated `graph-scale.svg` for a compact visual
+overview of graph size, activity, domains, edge kinds, and evidence provenance.
+
+## User working preferences
+
+- Do not run `git commit` or stage changes unless the user explicitly authorizes
+  that specific commit. Leave completed changes unstaged by default.
+- When authorized to commit, stay on the current branch unless the user asks for
+  a new branch.
+- Use a single short commit subject with no body or trailers. Do not add AI
+  attribution. Follow wording supplied by the user; otherwise use the repository
+  convention where applicable.
+- Prefer lowercase prose in responses, summaries, headings, and proposed commit
+  messages. Preserve the canonical capitalization of code identifiers and names.
+- Default to no new explanatory comments. Add comments only for non-obvious
+  runtime invariants or constraints, never to narrate a diff.
+- Run `cargo fmt` after Rust changes.
+- Prefer Makefile targets for builds and tests. For direct cargo commands, export
+  the Makefile's required `RUSTFLAGS` and `CXXFLAGS` separately before running
+  cargo; do not use inline environment prefixes.
+- After version changes, run an appropriate cargo check so `Cargo.lock` remains
+  synchronized. Version every changed crate: use a minor bump for source changes
+  and a patch bump for test-only changes, and keep the runtime crate version and
+  `spec_version` aligned.
+- For comparison tests, use the reference implementation in its original
+  language and toolchain instead of translating it.
+- When the user needs to copy generated data such as an encoded call or a long
+  hex value, write it to a suitable untracked project file so it is available in
+  the IDE changes view.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ Available shared skills:
 - `scripts/mint-limit/README.md` — generate TC proposals to set XCM mint limits and lift circuit breaker lockdowns
 - `scripts/dca-monitor/README.md` — verify DCA fixes on a Chopsticks fork before deploying a runtime upgrade
 - `scripts/onchain-routes/README.md` — generate TC proposals to register/update on-chain router routes
+- `scripts/runtime-interaction-graph/README.md` — generate, query, and visualize the runtime interaction graph
 - `integration-tests/README.md` — debug prod issues via scraper snapshots + integration tests
 
 ## Project overview

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,29 @@ Available shared skills:
 - `scripts/runtime-interaction-graph/README.md` — generate, query, and visualize the runtime interaction graph
 - `integration-tests/README.md` — debug prod issues via scraper snapshots + integration tests
 
+## Runtime interaction graph (live query API)
+
+A deployed instance of the runtime interaction graph (FRAME pallets, runtime config, EVM
+subsystem, precompiles, storage, callbacks — evidence-backed nodes/edges) is queryable at:
+
+`https://runtime-graph.lark.hydration.cloud`
+
+Use it to answer "what calls what / what reaches what" questions about the runtime without
+grepping or loading the graph into context. `POST /api/v1/query` with JSON:
+
+- `{"operation":"summary"}` — graph totals and identity
+- `{"operation":"search","text":"pallet:omnipool"}` — ranked node/edge matches
+- `{"operation":"node","id":"pallet:omnipool"}` — one node with evidence
+- `{"operation":"neighbors","id":"pallet:omnipool","depth":2}` — bounded ego subgraph
+- `{"operation":"paths","source":"pallet:route-executor","target":"boundary:evm-execution","view":"components"}` — bounded reachability
+- `{"operation":"packs","section":"component_cycles"}` — precomputed audit queries (cycles, ordering, origin, token flows, entrypoints)
+
+Responses are deterministic, token-budgeted (defaults: 250 records / 16k tokens; lower with
+`max_records`/`max_tokens`), and carry the graph SHA-256 fingerprint — check it if build
+identity matters. `GET /api/v1` lists operations and limits; `/readyz` shows the loaded graph
+identity. The interactive dashboard for humans is at `/`. See
+`scripts/runtime-interaction-graph/README.md` for regenerating or querying local graphs.
+
 ## Project overview
 
 Substrate-based parachain (Polkadot ecosystem) implementing DeFi protocols — DEX (Omnipool, Stableswap, XYK, LBP), DCA, OTC, bonds, staking, governance, and EVM compatibility.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5726,7 +5726,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-adapters"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -5762,7 +5762,7 @@ dependencies = [
  "pallet-referrals",
  "pallet-route-executor",
  "pallet-stableswap",
- "pallet-staking 5.1.0",
+ "pallet-staking 5.2.0",
  "pallet-timestamp",
  "pallet-transaction-multi-payment",
  "pallet-uniques",
@@ -5885,7 +5885,7 @@ dependencies = [
  "pallet-omnipool-liquidity-mining",
  "pallet-otc",
  "pallet-otc-settlements",
- "pallet-parameters 1.2.0",
+ "pallet-parameters 1.3.0",
  "pallet-preimage",
  "pallet-proxy",
  "pallet-referenda",
@@ -5896,7 +5896,7 @@ dependencies = [
  "pallet-session",
  "pallet-signet",
  "pallet-stableswap",
- "pallet-staking 5.1.0",
+ "pallet-staking 5.2.0",
  "pallet-state-trie-migration",
  "pallet-timestamp",
  "pallet-tips",
@@ -8919,7 +8919,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-broadcast"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -9343,7 +9343,7 @@ dependencies = [
  "pallet-balances",
  "pallet-currencies",
  "pallet-evm",
- "pallet-parameters 1.2.0",
+ "pallet-parameters 1.3.0",
  "pallet-transaction-payment",
  "parity-scale-codec",
  "primitives",
@@ -9506,7 +9506,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-accounts"
-version = "1.6.1"
+version = "1.7.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10062,7 +10062,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-nft"
-version = "7.3.0"
+version = "7.4.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10309,7 +10309,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-parameters"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10674,7 +10674,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -13984,7 +13984,7 @@ dependencies = [
  "pallet-scheduler",
  "pallet-session",
  "pallet-stableswap",
- "pallet-staking 5.1.0",
+ "pallet-staking 5.2.0",
  "pallet-timestamp",
  "pallet-transaction-multi-payment",
  "pallet-transaction-pause",
@@ -14050,7 +14050,7 @@ dependencies = [
  "pallet-asset-registry",
  "pallet-omnipool",
  "pallet-stableswap",
- "pallet-staking 5.1.0",
+ "pallet-staking 5.2.0",
  "primitives",
  "scraper",
  "serde",

--- a/pallets/broadcast/Cargo.toml
+++ b/pallets/broadcast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-broadcast"
-version = "1.7.0"
+version = "1.8.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"
@@ -42,6 +42,7 @@ std = [
     "sp-core/std",
     "sp-io/std",
     "primitives/std",
+    "hydradx-traits/std",
     "frame-support-procedural/std",
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/pallets/evm-accounts/Cargo.toml
+++ b/pallets/evm-accounts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-evm-accounts"
-version = "1.6.1"
+version = "1.7.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache-2.0"
@@ -59,6 +59,7 @@ std = [
     "orml-tokens/std",
     "orml-traits/std",
     "frame-benchmarking/std",
+    "hydradx-traits/std",
 ]
 runtime-benchmarks = [
     "frame-benchmarking/runtime-benchmarks",

--- a/pallets/nft/Cargo.toml
+++ b/pallets/nft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-nft"
-version = "7.3.0"
+version = "7.4.0"
 description = "A generic NFT pallet for managing non-fungible tokens"
 authors = ["GalacticCoucil"]
 edition = "2021"
@@ -46,6 +46,7 @@ std = [
     "pallet-uniques/std",
     "pallet-balances/std",
     "scale-info/std",
+    "hydradx-traits/std",
 ]
 runtime-benchmarks = [
     "frame-benchmarking",

--- a/pallets/parameters/Cargo.toml
+++ b/pallets/parameters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-parameters"
-version = "1.2.0"
+version = "1.3.0"
 authors = ['GalacticCouncil']
 edition = "2021"
 license = "Apache-2.0"
@@ -35,6 +35,8 @@ std = [
     'sp-core/std',
     'sp-io/std',
     'sp-std/std',
+    'frame-support/std',
+    'frame-system/std',
 ]
 
 try-runtime = ["frame-support/try-runtime"]

--- a/pallets/staking/Cargo.toml
+++ b/pallets/staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-staking"
-version = "5.1.0"
+version = "5.2.0"
 authors = ['GalacticCouncil']
 edition = "2021"
 license = "Apache-2.0"
@@ -61,6 +61,8 @@ std = [
 	"pallet-conviction-voting/std",
 	"pallet-referenda/std",
 	"pallet-democracy/std",
+	"orml-traits/std",
+	"hydra-dx-math/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/runtime/adapters/Cargo.toml
+++ b/runtime/adapters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-adapters"
-version = "1.13.2"
+version = "1.14.0"
 description = "Structs and other generic types for building runtimes."
 authors = ["GalacticCouncil"]
 edition = "2021"
@@ -125,4 +125,6 @@ std = [
     "pallet-bonds/std",
     "pallet-timestamp/std",
     "pallet-fee-processor/std",
+    "orml-vesting/std",
+    "pallet-staking/std",
 ]

--- a/scripts/runtime-interaction-graph/AUDIT_WORKFLOW.md
+++ b/scripts/runtime-interaction-graph/AUDIT_WORKFLOW.md
@@ -1,0 +1,22 @@
+# Runtime interaction graph audit workflow
+
+1. Generate the source graph and compiler manifests.
+2. Review `coverage.json` and failed semantic-analysis packages before relying on absence of edges.
+3. Use `interaction-graph.html` to filter by component, boundary, storage, origin, selector, or provenance.
+4. Review `projections-active/` for cycles and cross-domain paths, then inspect callback, state, asset,
+	authorization, configuration, EVM-interface, and deployment projections independently. Use `projections/`
+	when auditing inventory-only evidence. Configuration or deployment relationships never create execution cycles.
+5. Pin EVM and Substrate observations to the same block number, enforce the descriptor's Substrate genesis hash
+   and runtime spec name, and review `evm-build-provenance.json` for chain identities, block hashes, sibling
+   commits, input hashes, and explicitly supplied semantic manifests.
+6. Compare graph and contract snapshots before and after a runtime or deployment change.
+7. Convert important expected paths into regression fixtures in `historical-interactions.json`.
+8. Review `integration-test-coverage.md` for graph-only components and entrypoints, then inspect tests before
+   deciding whether a missing link represents a real coverage gap.
+9. Review `completeness.md`, `resolution-coverage.md`, MIR source-function coverage, path-search truncation
+	metadata, and `prioritized-test-gaps.md`; full semantic runs enforce 46/46 MIR packages, zero unresolved
+	runtime targets, and explicit reasons for inventory-only traits and migrations.
+
+The graph records evidence and ambiguity. A missing edge is meaningful only when the relevant package and
+resolution coverage are complete. Cycles, ordering matches, and cross-domain paths are review targets, not
+standalone vulnerability findings.

--- a/scripts/runtime-interaction-graph/Dockerfile
+++ b/scripts/runtime-interaction-graph/Dockerfile
@@ -1,0 +1,57 @@
+# syntax=docker/dockerfile:1.7
+
+ARG PYTHON_IMAGE=python:3.14-alpine@sha256:26730869004e2b9c4b9ad09cab8625e81d256d1ce97e72df5520e806b1709f92
+FROM ${PYTHON_IMAGE}
+
+ARG PYTHON_IMAGE
+ARG BUILD_DATE=unknown
+ARG VCS_REF=unknown
+ARG VERSION=dev
+ARG GRAPH_SHA256=unknown
+ARG RUNTIME_SPEC_VERSION=unknown
+
+LABEL org.opencontainers.image.title="Hydration runtime interaction graph" \
+	org.opencontainers.image.description="Static graph dashboard and deterministic query API" \
+	org.opencontainers.image.created="${BUILD_DATE}" \
+	org.opencontainers.image.revision="${VCS_REF}" \
+	org.opencontainers.image.version="${VERSION}" \
+	org.opencontainers.image.source="https://github.com/galacticcouncil/hydration-node" \
+	org.opencontainers.image.licenses="Apache-2.0" \
+	org.opencontainers.image.base.name="${PYTHON_IMAGE}" \
+	io.hydration.graph.sha256="${GRAPH_SHA256}" \
+	io.hydration.runtime.spec-version="${RUNTIME_SPEC_VERSION}"
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+	PYTHONUNBUFFERED=1
+
+RUN addgroup -S -g 10001 graph \
+	&& adduser -S -D -H -u 10001 -G graph graph
+
+WORKDIR /app
+
+COPY --chown=10001:10001 scripts/runtime-interaction-graph/query_graph.py \
+	scripts/runtime-interaction-graph/serve_graph.py \
+	scripts/runtime-interaction-graph/query-response.schema.json \
+	/app/
+
+COPY --from=graph --chown=10001:10001 \
+	interaction-graph.json \
+	interaction-graph.html \
+	graph-scale.svg \
+	component-graph.json \
+	query-packs.json \
+	coverage.json \
+	completeness.json \
+	/srv/graph/
+
+RUN python -c 'import gzip,pathlib; root=pathlib.Path("/srv/graph"); [path.with_name(path.name + ".gz").write_bytes(gzip.compress(path.read_bytes(), compresslevel=9, mtime=0)) for path in sorted(root.iterdir()) if path.is_file() and path.suffix in {".html", ".json", ".svg"} and path.stat().st_size >= 65536]'
+
+USER 10001:10001
+
+EXPOSE 8080
+STOPSIGNAL SIGTERM
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+	CMD ["python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/healthz', timeout=2).read()"]
+
+CMD ["python", "/app/serve_graph.py", "--root", "/srv/graph", "--host", "0.0.0.0", "--port", "8080"]

--- a/scripts/runtime-interaction-graph/README.md
+++ b/scripts/runtime-interaction-graph/README.md
@@ -33,7 +33,8 @@ Outputs are written to `target/runtime-interaction-graph/` and are not committed
 - `coverage.json` — CI metrics checked against `coverage-thresholds.json`
 - `integration-test-coverage.{json,md}` — graph components, entrypoints, and interactions linked from integration tests
 - `query-packs.json` — reusable cycles, paths, ordering, origin, lifecycle, token, contract, and entrypoint queries
-- `interaction-graph.html` — dependency-free interactive edge browser with evidence filtering
+- `interaction-graph.html` — dependency-free clickable canvas explorer with projection, domain, edge-kind, search,
+  pan/zoom, neighbor highlighting, evidence samples, deep links, and bounded API drill-down
 - `completeness.{json,md}` — source-component, entrypoint-class, MIR, state, asset, and contract inventory
 - `prioritized-test-gaps.md` — uncovered static targets ranked by privilege, asset impact, and domain crossings
 - `focused/state-invariants.svg` — storage, ledgers, pool state, guards, and source-validated invariants
@@ -139,7 +140,7 @@ curl --fail --request POST http://127.0.0.1:8080/api/v1/query \
 
 The service exposes:
 
-- `/` — redirect to the static interaction dashboard
+- `/` — redirect to the clickable interaction explorer
 - `/healthz` — container health check
 - `/readyz` — loaded graph identity, counts, and companion fingerprints
 - `/api/v1` — graph metadata, fingerprints, operations, and server limits

--- a/scripts/runtime-interaction-graph/README.md
+++ b/scripts/runtime-interaction-graph/README.md
@@ -1,0 +1,341 @@
+# Runtime interaction graph
+
+Generates an evidence-backed interaction graph of Hydration's FRAME pallets, runtime configuration,
+EVM subsystem, precompiles, token backends, storage, lifecycle functions, and dynamic callbacks.
+
+```sh
+python3 scripts/runtime-interaction-graph/runtime_interaction_graph.py
+```
+
+Outputs are written to `target/runtime-interaction-graph/` and are not committed:
+
+- `interaction-graph.json` — machine-readable evidence graph
+- `interaction-graph.dot` — Graphviz input
+- `component-graph.json` — execution-only component edges, cycles, bounded paths, and truncation metadata
+- `projections/*.json` — raw-inventory execution, callback, configuration, state, asset, authorization,
+  EVM-interface, and deployment graphs
+- `projections-active/*.json` — the operational projections, excluding explicit and inherited inactive nodes
+  while retaining unclassified evidence
+- `audit-candidates.md` — functions combining state access and external execution
+- `interaction-cycles.md` — cross-component cycles, with EVM/precompile cycles prioritized
+- `execution-boundaries.md` — native↔EVM and precompile→FRAME dispatch sites
+- `execution-paths.md` — bounded multi-component paths ending at EVM or FRAME boundaries
+- `audit-overview.dot` — audit-focused component, callback, boundary, and asset view
+- `audit-overview.svg` — deterministic dependency-free rendered audit overview
+- `graph-scale.svg` — bounded executive dashboard of raw/operational totals, tri-state activity, top distributions,
+  and evidence provenance
+- `dangerous-interactions.md` — cross-domain and state/call-order rule matches
+- `focused/*.svg` — cycle/path views plus component, execution-boundary, router, and token-flow layers
+- `semantic-coverage.md` — per-package RAPx callgraph, MIR, and dataflow status
+- `mir-coverage.md` — functions and relevant operations imported from genuine rustc MIR
+- `graph-coverage.md` — node, edge, component, and unresolved-target coverage totals
+- `resolution-coverage.md` — unresolved and inventory-only targets grouped by evidence-backed reason
+- `coverage.json` — CI metrics checked against `coverage-thresholds.json`
+- `integration-test-coverage.{json,md}` — graph components, entrypoints, and interactions linked from integration tests
+- `query-packs.json` — reusable cycles, paths, ordering, origin, lifecycle, token, contract, and entrypoint queries
+- `interaction-graph.html` — dependency-free interactive edge browser with evidence filtering
+- `completeness.{json,md}` — source-component, entrypoint-class, MIR, state, asset, and contract inventory
+- `prioritized-test-gaps.md` — uncovered static targets ranked by privilege, asset impact, and domain crossings
+- `focused/state-invariants.svg` — storage, ledgers, pool state, guards, and source-validated invariants
+- `evm-build-provenance.json` — hashes and tool, repository, chain, block, and optional semantic-input provenance
+
+Edges are evidence-bearing and conservative. Associated types resolve by canonical Rust trait path,
+runtime instance, import alias, and declared supertraits. Qualified `<T as Trait>::Type` calls, grouped
+`use` imports, aliased crates, and generic associated-type assignments retain their exact identity; the
+graph does not infer targets from a same-named associated type in another trait or pallet instance.
+
+Associated types configured by `impl pallet_*::Config for Runtime` resolve to either a mapped
+component or an exact runtime-binding node with `resolution: runtime-config`. Trait-bound `Get`
+and weight providers are classified as configuration reads, not callbacks. Compiler-derived RAPx
+and rustc MIR extend this source evidence without replacing it. MIR receivers retain their exact source module,
+Config trait, and pallet instance. Source-only pallets, unimplemented nested
+`Config` traits, and unconfigured migrations remain in the raw inventory with `runtime_active: false` and
+an evidence-backed reason. They remain visible under `projections/`, but are excluded from
+`projections-active/`, operational query packs, component/path/cycle graphs, integration-test coverage, and
+focused token/state visualizations. Coverage requires zero unresolved runtime targets, enforces operational projection
+floors separately from raw inventory totals, and reports inventory-only targets separately.
+
+The scale dashboard uses three activity states: `active` requires explicit `runtime_active: true`, `inactive`
+includes explicit `false` and owner/source-function inheritance, and missing affirmative metadata remains
+`unclassified`. Dashboard totals label only the `active` + `unclassified` union as `operational`.
+
+## ai-facing graph queries
+
+`query_graph.py` provides deterministic, dependency-free JSON responses without loading the full graph into an
+agent context. It auto-loads sibling `coverage.json`, `completeness.json`, `component-graph.json`, and
+`query-packs.json` files when present:
+
+```sh
+GRAPH=target/runtime-interaction-graph/interaction-graph.json
+python3 scripts/runtime-interaction-graph/query_graph.py --graph "$GRAPH" summary
+python3 scripts/runtime-interaction-graph/query_graph.py --graph "$GRAPH" search pallet:omnipool --scope all
+python3 scripts/runtime-interaction-graph/query_graph.py --graph "$GRAPH" node pallet:omnipool
+python3 scripts/runtime-interaction-graph/query_graph.py --graph "$GRAPH" neighbors pallet:omnipool --depth 2
+python3 scripts/runtime-interaction-graph/query_graph.py --graph "$GRAPH" paths pallet:route-executor boundary:evm-execution --view components --max-depth 5
+python3 scripts/runtime-interaction-graph/query_graph.py --graph "$GRAPH" packs --section component_cycles
+```
+
+Search ranks an exact node ID first, followed by ID prefixes/substrings, exact metadata, matching edge endpoints,
+and general JSON evidence. Neighbor retrieval is a bounded ego subgraph (`--depth` is capped at 6); path search is
+bounded by depth, path count, and expansion count. Use `paths --view components` for collapsed runtime-component
+reachability and the default `raw` view for exact node/edge evidence. Raw neighbors and searches keep parallel
+evidence edges separate. Component paths group parallel variants per hop and retain their count, fingerprints,
+edge kinds, traversals, representative edge, and bounded variant records, producing one record per unique node path.
+
+Every response uses the stable envelope documented by `query-response.schema.json`. It includes the input graph's
+SHA-256, SHA-256 identities for every loaded companion, query parameters, matched/returned counts, deterministic
+truncation reasons, companion-coverage warnings, and an approximate token budget. `result.total_is_exact` states
+whether `matched` is an exact total; bounded traversal results use `false` and `omitted: null` when the search stops
+before the total can be known. `--max-records` and `--max-tokens` are hard output bounds. The main and component
+graphs must use schema version 2, and the component graph must be the execution projection. Missing
+`runtime_active` metadata is reported as `unclassified`: default queries exclude explicit `false` values and nodes
+that inherit `false` from their owner or source function, while retaining unclassified records. Pass
+`--include-inactive` to search or traverse raw inventory.
+
+For multiple agent queries, `batch` reads JSON objects from stdin and emits one compact response per line. Per-query
+budgets may reduce, but cannot exceed, the process-level limits:
+
+```sh
+printf '%s\n' \
+  '{"operation":"search","text":"pallet:omnipool","max_records":10}' \
+  '{"operation":"neighbors","id":"pallet:omnipool","depth":2,"max_tokens":2000}' |
+  python3 scripts/runtime-interaction-graph/query_graph.py \
+    --graph "$GRAPH" --max-records 50 --max-tokens 4000 batch
+```
+
+## containerized dashboard and api
+
+Build one image containing the static dashboard and `/api/v1/query`. Generated files are supplied through a
+BuildKit named context because `target/` remains excluded from the repository build context:
+
+```sh
+GRAPH=target/runtime-interaction-graph/complete-ai-interface-v3
+BUILD_DATE=2026-07-16T00:00:00Z
+VCS_REF=local
+VERSION=local
+GRAPH_SHA256=$(sha256sum "$GRAPH/interaction-graph.json" | awk '{print $1}')
+RUNTIME_SPEC_VERSION=432
+docker buildx build --load \
+  --build-context graph="$GRAPH" \
+  --build-arg BUILD_DATE --build-arg VCS_REF --build-arg VERSION \
+  --build-arg GRAPH_SHA256 --build-arg RUNTIME_SPEC_VERSION \
+  -f scripts/runtime-interaction-graph/Dockerfile \
+  -t hydration-runtime-graph:local .
+```
+
+The default Python Alpine base is digest-pinned and can be replaced with `--build-arg PYTHON_IMAGE=...`. Large
+HTML, JSON, and SVG files are deterministically gzip-compressed during the build; the uncompressed files remain
+available for clients without gzip support. The runtime uses UID/GID `10001`, writes no application state, and
+works with a read-only root filesystem:
+
+```sh
+docker run --rm --read-only --cap-drop=ALL --security-opt=no-new-privileges \
+  -p 8080:8080 hydration-runtime-graph:local
+curl --fail http://127.0.0.1:8080/healthz
+curl --fail --request POST http://127.0.0.1:8080/api/v1/query \
+  --header 'Content-Type: application/json' \
+  --data '{"operation":"summary"}'
+```
+
+The service exposes:
+
+- `/` — redirect to the static interaction dashboard
+- `/healthz` — container health check
+- `/readyz` — loaded graph identity, counts, and companion fingerprints
+- `/api/v1` — graph metadata, fingerprints, operations, and server limits
+- `/api/v1/query` — deterministic JSON query endpoint (`POST`)
+
+Published images can be retrieved with `docker pull <namespace>/hydration-runtime-graph:<tag>`. Docker Hub stores
+and distributes the image; it does not run or host the dashboard/API service. Start the pulled image with
+`docker run` as above, or deploy it through a container orchestrator.
+
+RAPx call graphs can be merged as compiler-derived evidence:
+
+```sh
+export RAPX_CLEAN=false
+export CXXFLAGS="-include cstdint"
+cargo +nightly-2025-12-06 rapx --timeout 180 analyze callgraph -- -p pallet-hsm --lib \
+  > target/runtime-interaction-graph/rapx-hsm.txt 2>&1
+python3 scripts/runtime-interaction-graph/runtime_interaction_graph.py \
+  --rapx-output target/runtime-interaction-graph/rapx-hsm.txt --rapx-owner pallet:hsm
+```
+
+RAPx requires its pinned nightly and should run without `-D warnings`, because newer-nightly
+style lints are unrelated to semantic analysis. The imported graph keeps `semantic_source:
+rapx` provenance on every accepted edge.
+
+Collect every custom pallet, precompile, and runtime package into a normalized manifest:
+
+```sh
+python3 scripts/runtime-interaction-graph/collect_rapx.py --analysis callgraph
+python3 scripts/runtime-interaction-graph/runtime_interaction_graph.py \
+  --rapx-manifest target/runtime-interaction-graph/rapx/manifest.json
+```
+
+Additional `--analysis mir --analysis dataflow` flags request deeper compiler evidence.
+The collector hashes the runtime source tree, collector, command inputs, and every artifact. It validates
+the expected output marker and records `invalid-output` when RAPx
+replays callgraph output for another analysis. Package status and artifact paths are written
+incrementally, so a failed, invalid, or timed-out crate does not hide successful results.
+
+RAPx currently may replay cached callgraph output for MIR and dataflow requests. Such output
+is marked `invalid-output` and is never treated as MIR evidence. Collect genuine rustc MIR for
+the high-risk routing and AMM components instead:
+
+```sh
+python3 scripts/runtime-interaction-graph/collect_mir.py
+python3 scripts/runtime-interaction-graph/runtime_interaction_graph.py \
+  --rapx-manifest target/runtime-interaction-graph/rapx/manifest.json \
+  --rustc-mir-manifest target/runtime-interaction-graph/mir/manifest.json
+```
+
+The default MIR set is Router, HSM, Omnipool, and Stableswap. Repeat `--package` to select a
+different set, or pass `--all` to collect every runtime pallet and precompile package. Successful
+manifest entries are reused only when source, collector, command, and artifact hashes still match;
+`--force` rebuilds selected packages. MIR instances retain monomorphized symbol identity, ordinary
+calls, and separate normal/unwind successors. Basic-block control flow establishes whether a storage write can execute
+before or after a conservative external call; lexical source ordering remains a separate
+triage signal.
+
+Workspace collection records package failures without discarding successful MIR. Local `std` feature
+propagation is kept complete so all runtime packages currently produce MIR on the pinned nightly, and
+the optional zero-failure CI budget is enforced whenever a MIR manifest is supplied. Unwind successors
+are retained as conservative control-flow evidence; a reachable unwind edge does not by itself prove rollback.
+
+The graph also models inbound/outbound XCM execution, Polkadot SDK/ORML/Frontier runtime dependencies,
+the configured asset transactor, and every static or dynamic precompile route as
+separate components. Function nodes receive first-class entrypoint nodes for pallet extrinsics,
+runtime hooks, runtime-resolved callbacks, precompile selectors and dispatchers, EVM adapters,
+and inbound XCM execution. Runtime-pallet instances retain their alias, instance parameter, index,
+and excluded parts.
+
+`semantic-inventory.json` adds source-hashed token and liquidity semantics that syntax alone cannot
+name reliably: Balances/ORML/ERC-20 currency routing, StableSwap reserves and issued shares, XYK
+`TotalLiquidity` and routed share issuance, Omnipool positions/protocol shares/hub backing, and the
+issuance-increase circuit breaker. Enforcement labels distinguish runtime checks, transactional checks,
+coupled updates, calculations, configuration, observation, and try-runtime validation.
+
+Deployment artifacts from the sibling Aave, Hollar, and WHM repositories can be normalized and
+merged into the graph:
+
+```sh
+python3 scripts/runtime-interaction-graph/collect_contracts.py \
+  --descriptor scripts/runtime-interaction-graph/deployment-sources.json \
+  --output target/runtime-interaction-graph/contracts.json
+python3 scripts/runtime-interaction-graph/runtime_interaction_graph.py \
+  --contracts-manifest target/runtime-interaction-graph/contracts.json
+```
+
+`deployment-sources.json` is the reviewed schema-v2 input inventory. It explicitly selects the mainnet-relevant
+`hydration` and `gigahdx` Aave/Hollar directories and the production WHM descriptors. Missing sources,
+empty selections, and malformed artifacts fail collection. Every record retains its artifact SHA-256;
+the manifest records the descriptor hash, aggregate input hashes, sibling repository commits and dirty
+state, and collector version. Each chain pins its EVM chain ID, Substrate genesis hash, and runtime spec name.
+Nested tuple ABI inputs are recursively canonicalized and emitted with their canonical four-byte EVM selectors.
+WHM deployment-step outputs are split into explicit implementation/proxy/contract aliases and typed address
+references such as assets, oracles, handlers, bridge endpoints, and authorization accounts. References are
+retained as deployment-step relationships but are not submitted to RPC enrichment or classified as deployed code.
+
+Pin and enrich deployment records with live EVM bytecode, EIP-1967 implementations, and runtime
+storage configuration:
+
+```sh
+python3 scripts/runtime-interaction-graph/enrich_contracts_rpc.py \
+  --input target/runtime-interaction-graph/contracts.json \
+  --output target/runtime-interaction-graph/contracts-onchain.json \
+  --rpc https://hdx.tarn.hydration.cloud \
+  --block 0xc8d433 \
+  --expected-chain-id 222222 \
+  --network hydration \
+  --network gigahdx
+node scripts/runtime-interaction-graph/collect_runtime_contracts.mjs \
+  --input target/runtime-interaction-graph/contracts-onchain.json \
+  --output target/runtime-interaction-graph/contracts-runtime.json \
+  --rpc wss://rpc.hydradx.cloud \
+  --block-number 13161523 \
+  --expected-genesis-hash 0xafdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d \
+  --expected-spec-name hydradx
+python3 scripts/runtime-interaction-graph/runtime_interaction_graph.py \
+  --contracts-manifest target/runtime-interaction-graph/contracts-runtime.json
+```
+
+All paths, RPCs, chains, networks, and blocks are explicit. The EVM collector verifies the RPC chain ID
+and records the EVM block, parent, and state-root identity. The runtime collector rejects legacy input,
+requires declared collection/enrichment provenance, and enforces the same block number, expected Substrate
+genesis hash, and expected runtime
+spec name, and records the Substrate genesis/block/header and runtime-version identity plus its input and tool
+hashes. All five Hydration storage query APIs must be present, per-query calls and record counts are retained,
+and the chain descriptor enforces minimum GigaHDX, HSM, Liquidation, total, and Asset Registry ERC-20
+configuration counts. WHM Base,
+Ethereum, and other external deployments
+require separate descriptors and runs against their own RPCs. EVM observations include code presence,
+SHA-256, code size, EIP-1967 implementation, canonical `eip155:<chain-id>:<address>` identity, and embedded
+known addresses. Runtime storage covers GigaHDX, HSM, Liquidation, and Asset Registry assets whose type is
+`Erc20` and whose `AssetLocations` value is exactly an `X1(AccountKey20)` location.
+Compare two pinned snapshots with
+`diff_snapshots.py before.json after.json`; changes include code, implementation, and embedded
+contract relationships. The focused `deployed-contracts.svg` view connects runtime components,
+EVM adapters, contracts, implementations, deployment steps, and typed external-address references.
+
+Run the complete Hydration EVM pipeline with:
+
+```sh
+python3 scripts/runtime-interaction-graph/build_evm_graph.py \
+  --descriptor scripts/runtime-interaction-graph/deployment-sources.json \
+  --chain hydration-mainnet \
+  --evm-rpc https://hdx.tarn.hydration.cloud \
+  --substrate-rpc wss://rpc.hydradx.cloud \
+  --block 0xc8d433 \
+  --output target/runtime-interaction-graph/evm-hydration-pinned
+```
+
+It normalizes deployment artifacts, selects an EVM block, reads runtime configuration at the same
+block number, enriches proxy and bytecode relationships, and renders the graph. `--block` accepts only
+a pinned decimal or `0x`-prefixed block number. The output path must be new or empty so stale optional
+artifacts cannot be attributed to the current build. RAPx and rustc-MIR manifests are never discovered from
+the output directory; pass `--rapx-manifest` or `--rustc-mir-manifest` explicitly to include a validated,
+hashed semantic input whose source fingerprint matches the current runtime tree. Rust selector enums
+are connected to matching deployed-contract ABI functions. `diff_graphs.py` compares any two
+`interaction-graph.json` files. Pull requests run the source graph for the base and head revisions
+and upload both graphs plus `graph-diff.json` as a CI artifact.
+The composite `evm-build-provenance.json` hashes every transitive graph-generator input, the active coverage
+policy, source tree, compiler manifests and artifacts, chain identity, deployment inputs, and every generated
+output except the provenance file itself. Supplying a rustc-MIR manifest selects the full zero-failure MIR
+coverage policy.
+
+Integration-test comparison is conservative: direct source references link tests to graph components and
+entrypoints, while interaction linkage requires both edge endpoints to occur in the same test. Tests are
+split into reference, assertion, and direct-dispatch-assertion confidence tiers. None of these static tiers
+equates source mention or co-occurrence with observed behavioral coverage.
+
+`coverage-thresholds.json` protects minimum graph, operational projection, and operational integration-test linkage
+counts, requires zero unresolved runtime targets, and pins the reviewed inventory-only target IDs and reason
+counts exactly. Raw-inventory counts remain available as compatibility and completeness metrics. Pull-request graphs add
+`fixtures/ci-contracts.json` and apply
+`coverage-thresholds-deployment.json`, which requires deployed contracts, deployment edges, and runtime EVM
+configuration bindings without accessing RPC endpoints or sibling deployment repositories.
+`coverage-thresholds-full.json` additionally requires all 46 requested MIR packages to succeed and enforces
+aggregate matched-function, monomorphized-instance, and imported-operation floors so a nonempty but
+unparsable MIR corpus cannot pass. Pull-request diffs apply the trusted base policy and explicit per-field
+regression budgets.
+
+## Security model
+
+Execution domains are represented separately: FRAME pallets, runtime adapters, EVM,
+precompiles, and runtime configuration bindings. Currency calls remain polymorphic so
+future enrichment can branch them into Balances, ORML Tokens, real ERC-20, mapped ERC-20,
+XCM, pool-share, and protocol-minted asset behavior.
+Asset-kind edges are grounded in `pallet_asset_registry::AssetType`. `Token` remains
+polymorphic because the runtime adapter may route it through native Balances, ORML
+Tokens, a protocol-controlled implementation, or the mapped ERC-20 facade.
+
+State/external-call candidates use storage writes, not reads. The report records whether
+writes occur before or after the first conservative external boundary. This ordering is a
+triage signal; Rust source order alone does not establish reentrancy or rollback behavior.
+
+Run the extractor regression tests with:
+
+```sh
+python3 -m unittest discover -s scripts/runtime-interaction-graph -p 'test_*.py'
+node --test scripts/runtime-interaction-graph/collect_runtime_contracts.test.mjs
+```

--- a/scripts/runtime-interaction-graph/analysis_provenance.py
+++ b/scripts/runtime-interaction-graph/analysis_provenance.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+SOURCE_ROOTS = ("pallets", "precompiles", "runtime", "traits", "primitives", "math", "integration-tests")
+ROOT_INPUTS = ("Cargo.toml", "Cargo.lock", "rust-toolchain", "rust-toolchain.toml", ".cargo/config.toml")
+
+
+def file_sha256(path: Path) -> str:
+	digest = hashlib.sha256()
+	with path.open("rb") as stream:
+		for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+			digest.update(chunk)
+	return digest.hexdigest()
+
+
+def source_inputs(root: Path) -> list[Path]:
+	paths = [root / relative for relative in ROOT_INPUTS if (root / relative).is_file()]
+	for directory in SOURCE_ROOTS:
+		base = root / directory
+		if not base.is_dir():
+			continue
+		paths.extend(path for path in base.rglob("*.rs") if path.is_file())
+		paths.extend(path for path in base.rglob("Cargo.toml") if path.is_file())
+	return sorted(set(paths), key=lambda path: path.relative_to(root).as_posix())
+
+
+def tree_fingerprint(root: Path) -> dict:
+	digest = hashlib.sha256()
+	paths = source_inputs(root)
+	for path in paths:
+		relative = path.relative_to(root).as_posix().encode()
+		digest.update(len(relative).to_bytes(4, "big"))
+		digest.update(relative)
+		with path.open("rb") as stream:
+			for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+				digest.update(chunk)
+	return {"sha256": digest.hexdigest(), "file_count": len(paths)}
+
+
+def git_commit(root: Path) -> str | None:
+	result = subprocess.run(
+		["git", "rev-parse", "HEAD"],
+		cwd=root,
+		text=True,
+		capture_output=True,
+	)
+	return result.stdout.strip() if result.returncode == 0 else None
+
+
+def tool_input_fingerprint(paths: list[Path]) -> dict:
+	files = {}
+	for path in sorted({path.resolve() for path in paths}, key=lambda item: item.name):
+		name = path.name
+		if name in files:
+			raise ValueError(f"duplicate tool input name: {name}")
+		files[name] = file_sha256(path)
+	return {"sha256": tool_input_digest(files), "files": files}
+
+
+def tool_input_digest(files: dict[str, str]) -> str:
+	digest = hashlib.sha256()
+	for name, checksum in sorted(files.items()):
+		if not isinstance(name, str) or not name or "/" in name or "\\" in name:
+			raise ValueError(f"invalid tool input name: {name!r}")
+		if not isinstance(checksum, str) or not re.fullmatch(r"[0-9a-f]{64}", checksum):
+			raise ValueError(f"invalid tool input checksum: {name}")
+		digest.update(len(name.encode()).to_bytes(4, "big"))
+		digest.update(name.encode())
+		digest.update(bytes.fromhex(checksum))
+	return digest.hexdigest()
+
+
+def valid_tool_input_fingerprint(value: object) -> bool:
+	if not isinstance(value, dict) or not isinstance(value.get("files"), dict):
+		return False
+	try:
+		return value.get("sha256") == tool_input_digest(value["files"])
+	except ValueError:
+		return False
+
+
+def collector_provenance(root: Path, collector: Path, toolchain: str,
+	tool_inputs: list[Path] | None = None) -> dict:
+	inputs = [collector, *(tool_inputs or [])]
+	return {
+		"git_commit": git_commit(root),
+		"source_inputs": tree_fingerprint(root),
+		"collector_sha256": file_sha256(collector),
+		"tool_inputs": tool_input_fingerprint(inputs),
+		"toolchain": toolchain,
+	}
+
+
+def command_fingerprint(provenance: dict, package: dict, command: list[str]) -> str:
+	payload = {
+		"provenance": provenance,
+		"package": package,
+		"command": command,
+	}
+	encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+	return hashlib.sha256(encoded).hexdigest()
+
+
+def reusable_artifact(entry: dict | None, fingerprint: str, artifact: Path) -> bool:
+	return bool(
+		entry
+		and entry.get("status") == "ok"
+		and entry.get("input_fingerprint") == fingerprint
+		and artifact.is_file()
+		and artifact.stat().st_size
+		and entry.get("artifact_sha256") == file_sha256(artifact)
+	)

--- a/scripts/runtime-interaction-graph/build_evm_graph.py
+++ b/scripts/runtime-interaction-graph/build_evm_graph.py
@@ -20,6 +20,8 @@ PINNED_BLOCK = re.compile(r"^(?:0x[0-9a-fA-F]+|[0-9]+)$")
 HASH_256 = re.compile(r"^0x[0-9a-fA-F]{64}$")
 GRAPH_GENERATOR_INPUTS = (
 	"runtime_interaction_graph.py",
+	"graph_explorer.js",
+	"graph_explorer.css",
 	"mir_parser.py",
 	"runtime_inventory.py",
 	"semantic_inventory.py",

--- a/scripts/runtime-interaction-graph/build_evm_graph.py
+++ b/scripts/runtime-interaction-graph/build_evm_graph.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+
+import argparse
+import hashlib
+import json
+import platform
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import runtime_interaction_graph as runtime_graph
+
+
+BUILD_VERSION = 4
+PINNED_BLOCK = re.compile(r"^(?:0x[0-9a-fA-F]+|[0-9]+)$")
+HASH_256 = re.compile(r"^0x[0-9a-fA-F]{64}$")
+GRAPH_GENERATOR_INPUTS = (
+	"runtime_interaction_graph.py",
+	"mir_parser.py",
+	"runtime_inventory.py",
+	"semantic_inventory.py",
+	"semantic-inventory.json",
+	"analysis_provenance.py",
+	"collect_contracts.py",
+	"collect_mir.py",
+	"collect_rapx.py",
+	"historical-interactions.json",
+)
+REQUIRED_RUNTIME_BINDINGS = {
+	"gigaHdx.gigaHdxPoolContract": "pallet:gigahdx",
+	"hsm.flashMinter": "pallet:hsm",
+	"liquidation.borrowingContract": "pallet:liquidation",
+}
+
+
+def sha256_file(path: Path) -> str:
+	return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def source_fingerprint(root: Path) -> dict:
+	return runtime_graph.analysis_provenance.tree_fingerprint(root)
+
+
+def load_chain(descriptor: Path, chain_id: str) -> dict:
+	payload = json.loads(descriptor.read_text())
+	if payload.get("schema_version") != 2:
+		raise ValueError("deployment descriptor must use schema_version 2")
+	matches = [chain for chain in payload.get("chains", []) if chain.get("id") == chain_id]
+	if len(matches) != 1:
+		raise ValueError(f"deployment descriptor has no unique chain named {chain_id}")
+	chain = matches[0]
+	minimums = chain.get("runtime_configuration_minimums")
+	binding_minimums = minimums.get("required_bindings") if isinstance(minimums, dict) else None
+	if (not isinstance(chain.get("evm_chain_id"), int) or isinstance(chain.get("evm_chain_id"), bool) or
+		chain["evm_chain_id"] < 1 or not chain.get("deployment_networks") or
+		not isinstance(chain.get("substrate_genesis_hash"), str) or
+		not HASH_256.fullmatch(chain["substrate_genesis_hash"]) or
+		not isinstance(chain.get("substrate_spec_name"), str) or not chain["substrate_spec_name"] or
+		not isinstance(minimums, dict) or set(minimums) != {"total", "asset_registry_erc20", "required_bindings"} or
+		any(not isinstance(minimums.get(field), int) or isinstance(minimums.get(field), bool)
+			or minimums[field] < 1 for field in ("total", "asset_registry_erc20")) or
+		not isinstance(binding_minimums, dict) or set(binding_minimums) != set(REQUIRED_RUNTIME_BINDINGS) or
+		any(not isinstance(value, int) or isinstance(value, bool) or value < 1
+			for value in binding_minimums.values())):
+		raise ValueError(f"invalid chain descriptor: {chain!r}")
+	return chain
+
+
+def validate_runtime_configuration_coverage(payload: dict, minimums: dict) -> dict:
+	configurations = payload.get("runtime_configurations")
+	query_coverage = payload.get("runtime_collection_provenance", {}).get("query_coverage", {})
+	if not isinstance(configurations, list) or query_coverage.get("required_query_count") != 5 \
+		or query_coverage.get("available_query_count") != query_coverage.get("required_query_count"):
+		raise ValueError("runtime contract collection has incomplete required-query coverage")
+	registry_erc20 = sum(configuration.get("component") == "pallet:asset-registry"
+		and configuration.get("storage") == "assetRegistry.assetLocations"
+		and configuration.get("asset_type") == "erc20" for configuration in configurations)
+	bindings = {storage: sum(configuration.get("component") == component
+		and configuration.get("storage") == storage for configuration in configurations)
+		for storage, component in REQUIRED_RUNTIME_BINDINGS.items()}
+	coverage = {"total": len(configurations), "asset_registry_erc20": registry_erc20,
+		"required_bindings": bindings, "required_queries": query_coverage["required_query_count"]}
+	for field in ("total", "asset_registry_erc20"):
+		if coverage[field] < minimums[field]:
+			raise ValueError(
+				f"runtime configuration coverage {field}={coverage[field]} is below minimum {minimums[field]}"
+			)
+	for storage, minimum in minimums["required_bindings"].items():
+		if bindings[storage] < minimum:
+			raise ValueError(
+				f"runtime configuration coverage {storage}={bindings[storage]} is below minimum {minimum}"
+			)
+	return coverage
+
+
+def logical_path(path: Path, root: Path | None = None) -> str:
+	if root is not None:
+		try:
+			return path.resolve().relative_to(root.resolve()).as_posix()
+		except ValueError:
+			pass
+	return path.name
+
+
+def validate_semantic_manifest(path: Path, expected_tool: str, expected_source_inputs: dict | None = None,
+	root: Path | None = None) -> dict:
+	if not path.is_file():
+		raise FileNotFoundError(f"semantic manifest does not exist: {path}")
+	payload = json.loads(path.read_text())
+	runtime_graph.validate_semantic_manifest(payload, path, expected_tool, root)
+	provenance = payload.get("provenance", {})
+	if expected_source_inputs is not None and provenance["source_inputs"] != expected_source_inputs:
+		raise ValueError(f"semantic manifest was produced from stale or different source inputs: {path}")
+	artifacts = []
+	if expected_tool == "rustc-mir":
+		artifacts = [(entry.get("artifact"), entry.get("artifact_sha256"))
+			for entry in payload.get("packages", []) if entry.get("status") == "ok"]
+	else:
+		artifacts = [(analysis.get("path"), analysis.get("artifact_sha256"))
+			for entry in payload.get("packages", []) for analysis in entry.get("analyses", {}).values()
+			if analysis.get("status") == "ok"]
+	return {"path": logical_path(path, root), "sha256": sha256_file(path), "tool": expected_tool,
+		"toolchain": payload.get("toolchain"), "source_inputs": provenance["source_inputs"],
+		"collector_sha256": provenance["collector_sha256"], "tool_inputs": provenance.get("tool_inputs"),
+		"artifacts": [{"path": artifact, "sha256": expected_sha256}
+			for artifact, expected_sha256 in artifacts], "packages": len(payload.get("packages", [])),
+		"validated": True}
+
+
+def git_state(root: Path) -> dict:
+	commit = subprocess.run(["git", "-C", root, "rev-parse", "HEAD"], capture_output=True, text=True, check=True)
+	status = subprocess.run(["git", "-C", root, "status", "--porcelain"], capture_output=True, text=True, check=True)
+	return {"commit": commit.stdout.strip(), "dirty": bool(status.stdout.strip())}
+
+
+def graph_command(scripts: Path, runtime: Path, output: Path, rapx_manifest: Path | None,
+	rustc_mir_manifest: Path | None) -> list[object]:
+	thresholds = scripts / ("coverage-thresholds-full.json" if rustc_mir_manifest else "coverage-thresholds.json")
+	command: list[object] = ["python3", scripts / "runtime_interaction_graph.py", "--contracts-manifest", runtime,
+		"--output", output, "--coverage-thresholds", thresholds]
+	if rapx_manifest:
+		command.extend(["--rapx-manifest", rapx_manifest])
+	if rustc_mir_manifest:
+		command.extend(["--rustc-mir-manifest", rustc_mir_manifest])
+	return command
+
+
+def run(command: list[object], root: Path) -> None:
+	subprocess.run([str(value) for value in command], cwd=root, check=True)
+
+
+def output_hashes(output: Path) -> dict[str, str]:
+	return {path.relative_to(output).as_posix(): sha256_file(path)
+		for path in sorted(output.rglob("*"))
+		if path.is_file() and path.name != "evm-build-provenance.json"}
+
+
+def graph_generator_fingerprint(scripts: Path, rustc_mir_manifest: Path | None) -> dict:
+	thresholds = "coverage-thresholds-full.json" if rustc_mir_manifest else "coverage-thresholds.json"
+	paths = [scripts / relative for relative in (*GRAPH_GENERATOR_INPUTS, thresholds)]
+	return runtime_graph.analysis_provenance.tool_input_fingerprint(paths)
+
+
+def prepare_output(output: Path) -> None:
+	if output.exists() and (not output.is_dir() or any(output.iterdir())):
+		raise ValueError(f"output directory must be empty: {output}")
+	output.mkdir(parents=True, exist_ok=True)
+
+
+def main() -> None:
+	parser = argparse.ArgumentParser()
+	parser.add_argument("--descriptor", type=Path, required=True)
+	parser.add_argument("--chain", required=True)
+	parser.add_argument("--evm-rpc", required=True)
+	parser.add_argument("--substrate-rpc", required=True)
+	parser.add_argument("--block", required=True, help="Pinned EVM block number in decimal or 0x-prefixed form")
+	parser.add_argument("--output", type=Path, required=True)
+	parser.add_argument("--rapx-manifest", type=Path)
+	parser.add_argument("--rustc-mir-manifest", type=Path)
+	args = parser.parse_args()
+	if not PINNED_BLOCK.fullmatch(args.block):
+		parser.error("--block must be a pinned decimal or 0x-prefixed block number")
+	root = Path(__file__).resolve().parents[2]
+	scripts = Path(__file__).parent
+	descriptor = args.descriptor.resolve()
+	chain = load_chain(descriptor, args.chain)
+	output = args.output.resolve()
+	prepare_output(output)
+	contracts = output / "contracts.json"
+	onchain = output / "contracts-onchain.json"
+	runtime = output / "contracts-runtime.json"
+	run(["python3", scripts / "collect_contracts.py", "--descriptor", descriptor, "--output", contracts], root)
+	enrich_command: list[object] = ["python3", scripts / "enrich_contracts_rpc.py", "--input", contracts,
+		"--output", onchain, "--rpc", args.evm_rpc, "--block", args.block,
+		"--expected-chain-id", chain["evm_chain_id"]]
+	for network in chain["deployment_networks"]:
+		enrich_command.extend(["--network", network])
+	run(enrich_command, root)
+	onchain_payload = json.loads(onchain.read_text())
+	block_number = onchain_payload["rpc_snapshot"]["block_number"]
+	run(["node", scripts / "collect_runtime_contracts.mjs", "--input", onchain, "--output", runtime,
+		"--rpc", args.substrate_rpc, "--block-number", block_number,
+		"--expected-genesis-hash", chain["substrate_genesis_hash"],
+		"--expected-spec-name", chain["substrate_spec_name"]], root)
+	runtime_payload = json.loads(runtime.read_text())
+	chain_context = runtime_payload.get("chain_context", {})
+	if chain_context.get("block_number") != block_number:
+		raise RuntimeError("runtime collection did not preserve the pinned block number")
+	if chain_context.get("substrate_genesis_hash", "").lower() != chain["substrate_genesis_hash"].lower():
+		raise RuntimeError("runtime collection did not preserve the expected Substrate genesis hash")
+	if chain_context.get("substrate_spec_name") != chain["substrate_spec_name"]:
+		raise RuntimeError("runtime collection did not preserve the expected Substrate spec name")
+	runtime_configuration_coverage = validate_runtime_configuration_coverage(
+		runtime_payload, chain["runtime_configuration_minimums"])
+	semantic_inputs = []
+	current_source_inputs = source_fingerprint(root)
+	if args.rapx_manifest:
+		semantic_inputs.append(validate_semantic_manifest(args.rapx_manifest, "rapx", current_source_inputs, root))
+	if args.rustc_mir_manifest:
+		semantic_inputs.append(validate_semantic_manifest(
+			args.rustc_mir_manifest, "rustc-mir", current_source_inputs, root))
+	run(graph_command(scripts, runtime, output, args.rapx_manifest, args.rustc_mir_manifest), root)
+	provenance = {
+		"schema_version": 2,
+		"tool": "build_evm_graph",
+		"tool_version": BUILD_VERSION,
+		"python_version": platform.python_version(),
+		"collector_sha256": sha256_file(Path(__file__)),
+		"node_version": subprocess.run(["node", "--version"], capture_output=True, text=True, check=True).stdout.strip(),
+		"repository": git_state(root),
+		"source_inputs": current_source_inputs,
+		"descriptor": {"path": descriptor.name, "sha256": sha256_file(descriptor), "chain": args.chain},
+		"graph_generator": graph_generator_fingerprint(scripts, args.rustc_mir_manifest),
+		"semantic_inputs": semantic_inputs,
+		"snapshot": runtime_payload["chain_context"],
+		"runtime_configuration_coverage": runtime_configuration_coverage,
+		"outputs": output_hashes(output),
+	}
+	(output / "evm-build-provenance.json").write_text(json.dumps(provenance, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+	main()

--- a/scripts/runtime-interaction-graph/collect_contracts.py
+++ b/scripts/runtime-interaction-graph/collect_contracts.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+
+import argparse
+import hashlib
+import json
+import platform
+import re
+import subprocess
+from pathlib import Path
+
+
+ADDRESS = re.compile(r"^0x[0-9a-fA-F]{40}$")
+HASH_256 = re.compile(r"^0x[0-9a-fA-F]{64}$")
+COLLECTOR_VERSION = 3
+REQUIRED_RUNTIME_BINDINGS = {
+	"gigaHdx.gigaHdxPoolContract",
+	"hsm.flashMinter",
+	"liquidation.borrowingContract",
+}
+MASK_64 = (1 << 64) - 1
+KECCAK_ROTATIONS = (
+	(0, 36, 3, 41, 18),
+	(1, 44, 10, 45, 2),
+	(62, 6, 43, 15, 61),
+	(28, 55, 25, 21, 56),
+	(27, 20, 39, 8, 14),
+)
+KECCAK_ROUND_CONSTANTS = (
+	0x0000000000000001, 0x0000000000008082, 0x800000000000808A, 0x8000000080008000,
+	0x000000000000808B, 0x0000000080000001, 0x8000000080008081, 0x8000000000008009,
+	0x000000000000008A, 0x0000000000000088, 0x0000000080008009, 0x000000008000000A,
+	0x000000008000808B, 0x800000000000008B, 0x8000000000008089, 0x8000000000008003,
+	0x8000000000008002, 0x8000000000000080, 0x000000000000800A, 0x800000008000000A,
+	0x8000000080008081, 0x8000000000008080, 0x0000000080000001, 0x8000000080008008,
+)
+
+
+def sha256_bytes(value: bytes) -> str:
+	return hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+	return sha256_bytes(path.read_bytes())
+
+
+def rotate_left(value: int, shift: int) -> int:
+	if not shift:
+		return value
+	return ((value << shift) | (value >> (64 - shift))) & MASK_64
+
+
+def keccak_f1600(state: list[int]) -> None:
+	for constant in KECCAK_ROUND_CONSTANTS:
+		columns = [state[x] ^ state[x + 5] ^ state[x + 10] ^ state[x + 15] ^ state[x + 20]
+			for x in range(5)]
+		delta = [columns[(x - 1) % 5] ^ rotate_left(columns[(x + 1) % 5], 1) for x in range(5)]
+		for y in range(5):
+			for x in range(5):
+				state[x + 5 * y] ^= delta[x]
+		rotated = [0] * 25
+		for y in range(5):
+			for x in range(5):
+				rotated[y + 5 * ((2 * x + 3 * y) % 5)] = rotate_left(
+					state[x + 5 * y], KECCAK_ROTATIONS[x][y])
+		for y in range(5):
+			for x in range(5):
+				state[x + 5 * y] = rotated[x + 5 * y] ^ (
+					(~rotated[(x + 1) % 5 + 5 * y]) & rotated[(x + 2) % 5 + 5 * y])
+		state[0] ^= constant
+
+
+def keccak256(value: bytes) -> bytes:
+	rate = 136
+	padded = bytearray(value)
+	padded.append(0x01)
+	padded.extend(b"\x00" * ((rate - len(padded) % rate) % rate))
+	padded[-1] ^= 0x80
+	state = [0] * 25
+	for offset in range(0, len(padded), rate):
+		block = padded[offset:offset + rate]
+		for lane in range(rate // 8):
+			state[lane] ^= int.from_bytes(block[lane * 8:(lane + 1) * 8], "little")
+		keccak_f1600(state)
+	return b"".join(lane.to_bytes(8, "little") for lane in state)[:32]
+
+
+def canonical_abi_type(parameter: dict) -> str:
+	type_name = parameter.get("type")
+	if not isinstance(type_name, str) or not type_name:
+		raise ValueError(f"ABI parameter has no type: {parameter!r}")
+	if not type_name.startswith("tuple"):
+		match = re.fullmatch(r"(uint|int)((?:\[[0-9]*\])*)", type_name)
+		return f"{match.group(1)}256{match.group(2)}" if match else type_name
+	components = parameter.get("components")
+	if not isinstance(components, list):
+		raise ValueError(f"tuple ABI parameter has no components: {parameter!r}")
+	canonical = ",".join(canonical_abi_type(component) for component in components)
+	return f"({canonical}){type_name[len('tuple'):]}"
+
+
+def abi_functions(abi: list[dict]) -> list[dict]:
+	functions = {}
+	for item in abi:
+		if item.get("type") != "function" or not item.get("name"):
+			continue
+		signature = f"{item['name']}({','.join(canonical_abi_type(value) for value in item.get('inputs', []))})"
+		functions[signature] = {"signature": signature, "selector": f"0x{keccak256(signature.encode())[:4].hex()}"}
+	return [functions[signature] for signature in sorted(functions)]
+
+
+def abi_signatures(abi: list[dict]) -> list[str]:
+	return [item["signature"] for item in abi_functions(abi)]
+
+
+def git_repository(path: Path) -> Path | None:
+	current = path.resolve()
+	for candidate in (current, *current.parents):
+		if (candidate / ".git").exists():
+			return candidate
+	return None
+
+
+def git_output(repository: Path, *args: str) -> str | None:
+	result = subprocess.run(["git", "-C", repository, *args], capture_output=True, text=True, check=False)
+	return result.stdout.strip() if result.returncode == 0 else None
+
+
+def artifact_name(path: Path, repository: Path | None) -> str:
+	if repository:
+		try:
+			return path.resolve().relative_to(repository).as_posix()
+		except ValueError:
+			pass
+	return path.name
+
+
+def aggregate_inputs(paths: list[Path], repository: Path | None) -> str:
+	digest = hashlib.sha256()
+	for path in sorted(paths):
+		digest.update(artifact_name(path, repository).encode())
+		digest.update(b"\0")
+		digest.update(bytes.fromhex(sha256_file(path)))
+	return digest.hexdigest()
+
+
+def hardhat_deployments(project: str, root: Path, networks: set[str]) -> tuple[list[dict], list[Path]]:
+	contracts = []
+	paths = []
+	for path in sorted(root.glob("*/*.json")):
+		if path.parent.name not in networks or path.name.startswith((".", "_")):
+			continue
+		paths.append(path)
+		try:
+			data = json.loads(path.read_text())
+		except json.JSONDecodeError as error:
+			raise ValueError(f"invalid deployment JSON: {path}") from error
+		address = data.get("address")
+		if not isinstance(address, str) or not ADDRESS.fullmatch(address):
+			continue
+		receipt = data.get("receipt") or {}
+		functions = abi_functions(data.get("abi", []))
+		contracts.append({"project": project, "network": path.parent.name, "name": path.stem,
+			"address": address.lower(), "artifact_path": path, "artifact_sha256": sha256_file(path),
+			"transaction_hash": data.get("transactionHash") or receipt.get("transactionHash"),
+			"block_number": receipt.get("blockNumber"), "abi_functions": functions,
+			"abi_signatures": [item["signature"] for item in functions]})
+	return contracts, paths
+
+
+def address_values(value: object, prefix: str = "") -> list[tuple[str, str]]:
+	result = []
+	if isinstance(value, dict):
+		for key, child in value.items():
+			result.extend(address_values(child, f"{prefix}.{key}" if prefix else key))
+	elif isinstance(value, list):
+		for index, child in enumerate(value):
+			result.extend(address_values(child, f"{prefix}.{index}" if prefix else str(index)))
+	elif isinstance(value, str) and ADDRESS.fullmatch(value):
+		result.append((prefix, value.lower()))
+	return result
+
+
+def whm_field_name(field: str) -> str:
+	return field.rsplit(".", 1)[-1].replace("_", "").lower()
+
+
+def whm_deployment_role(step: str, field: str) -> str | None:
+	if not re.search(r"(?:^|[-_])deploy(?:$|[-_])", step.lower()):
+		return None
+	return {
+		"address": "contract",
+		"contract": "contract",
+		"contractaddress": "contract",
+		"implementation": "implementation",
+		"implementationaddress": "implementation",
+		"impladdress": "implementation",
+		"proxy": "proxy",
+		"proxyaddress": "proxy",
+	}.get(whm_field_name(field))
+
+
+def whm_reference_role(field: str, address: str) -> str:
+	name = whm_field_name(field)
+	if address == "0x" + "0" * 40:
+		return "null-address"
+	if name in {"asset", "sourceasset", "destasset", "wrappednative"}:
+		return "asset"
+	if "oracle" in name:
+		return "oracle"
+	if "handler" in name:
+		return "handler"
+	if name in {"bridge", "bridgeaddress", "mdah160"}:
+		return "bridge"
+	if "transactor" in name:
+		return "transactor"
+	if "receiver" in name:
+		return "receiver"
+	if any(value in name for value in ("owner", "operator", "relayer")):
+		return "authorization-account"
+	if name in {"contract", "contractaddress", "implementation", "implementationaddress", "impladdress",
+		"proxy", "proxyaddress"}:
+		return "contract-reference"
+	return "address-reference"
+
+
+def whm_deployments(project: str, root: Path,
+	networks: set[str]) -> tuple[list[dict], list[dict], list[Path]]:
+	contracts = []
+	references = []
+	paths = []
+	for path in sorted(root.glob("*.json")):
+		if path.stem not in networks:
+			continue
+		paths.append(path)
+		try:
+			data = json.loads(path.read_text())
+		except json.JSONDecodeError as error:
+			raise ValueError(f"invalid deployment JSON: {path}") from error
+		for step in data.get("steps", []):
+			if step.get("status") != "completed":
+				continue
+			for field, address in address_values(step.get("output", {})):
+				role = whm_deployment_role(step["name"], field)
+				entry = {"project": project, "network": path.stem, "address": address,
+					"artifact_path": path, "artifact_sha256": sha256_file(path),
+					"migration_step": step["name"], "field": field}
+				if role:
+					contracts.append({**entry, "name": f"{step['name']}:{field}", "deployment_role": role,
+						"abi_functions": [], "abi_signatures": []})
+				else:
+					references.append({**entry, "role": whm_reference_role(field, address)})
+	return contracts, references, paths
+
+
+def load_descriptor(path: Path) -> dict:
+	try:
+		payload = json.loads(path.read_text())
+	except json.JSONDecodeError as error:
+		raise ValueError(f"invalid deployment descriptor JSON: {path}") from error
+	if payload.get("schema_version") != 2 or not isinstance(payload.get("sources"), list):
+		raise ValueError("deployment descriptor must use schema_version 2 and define sources")
+	projects = set()
+	for source in payload["sources"]:
+		required = {"project", "kind", "root", "networks"}
+		if not isinstance(source, dict) or not required <= source.keys() or source["kind"] not in {"hardhat", "whm"}:
+			raise ValueError(f"invalid deployment source descriptor: {source!r}")
+		if (not isinstance(source["project"], str) or not source["project"] or
+			not isinstance(source["root"], str) or not source["root"] or
+			not isinstance(source["networks"], list) or not source["networks"] or
+			any(not isinstance(network, str) or not network for network in source["networks"]) or
+			len(source["networks"]) != len(set(source["networks"])) or source["project"] in projects):
+			raise ValueError(f"duplicate project or empty network set: {source['project']}")
+		projects.add(source["project"])
+	if not isinstance(payload.get("chains"), list) or not payload["chains"]:
+		raise ValueError("deployment descriptor must define at least one chain")
+	chain_ids = set()
+	for chain in payload["chains"]:
+		minimums = chain.get("runtime_configuration_minimums") if isinstance(chain, dict) else None
+		binding_minimums = minimums.get("required_bindings") if isinstance(minimums, dict) else None
+		if (not isinstance(chain, dict) or not isinstance(chain.get("id"), str) or not chain["id"] or
+			not isinstance(chain.get("evm_chain_id"), int) or isinstance(chain["evm_chain_id"], bool) or
+			chain["evm_chain_id"] < 1 or not isinstance(chain.get("substrate_genesis_hash"), str) or
+			not HASH_256.fullmatch(chain["substrate_genesis_hash"]) or
+			not isinstance(chain.get("substrate_spec_name"), str) or not chain["substrate_spec_name"] or
+			not isinstance(minimums, dict) or set(minimums) != {"total", "asset_registry_erc20", "required_bindings"} or
+			any(not isinstance(minimums.get(field), int) or isinstance(minimums.get(field), bool)
+				or minimums[field] < 1 for field in ("total", "asset_registry_erc20")) or
+			not isinstance(binding_minimums, dict) or set(binding_minimums) != REQUIRED_RUNTIME_BINDINGS or
+			any(not isinstance(value, int) or isinstance(value, bool) or value < 1
+				for value in binding_minimums.values()) or
+			not isinstance(chain.get("deployment_networks"), list) or
+			not chain["deployment_networks"] or any(not isinstance(network, str) or not network
+				for network in chain["deployment_networks"]) or
+			len(chain["deployment_networks"]) != len(set(chain["deployment_networks"])) or chain["id"] in chain_ids):
+			raise ValueError(f"invalid or duplicate deployment chain descriptor: {chain!r}")
+		chain_ids.add(chain["id"])
+	return payload
+
+
+def collect(descriptor_path: Path) -> dict:
+	descriptor = load_descriptor(descriptor_path)
+	contracts = []
+	references = []
+	sources = []
+	for source in descriptor["sources"]:
+		root = (descriptor_path.parent / source["root"]).resolve()
+		if not root.is_dir():
+			raise FileNotFoundError(f"required deployment source is missing: {root}")
+		networks = set(source["networks"])
+		if source["kind"] == "hardhat":
+			items, inputs = hardhat_deployments(source["project"], root, networks)
+			source_references = []
+		else:
+			items, source_references, inputs = whm_deployments(source["project"], root, networks)
+		if not inputs or not items:
+			raise ValueError(f"required deployment source produced no contracts: {source['project']}")
+		repository = git_repository(root)
+		for item in items:
+			item["artifact"] = artifact_name(item.pop("artifact_path"), repository)
+		for reference in source_references:
+			reference["artifact"] = artifact_name(reference.pop("artifact_path"), repository)
+		contracts.extend(items)
+		references.extend(source_references)
+		sources.append({"project": source["project"], "kind": source["kind"],
+			"configured_root": source["root"], "networks": sorted(networks),
+			"git_commit": git_output(repository, "rev-parse", "HEAD") if repository else None,
+			"git_dirty": bool(git_output(repository, "status", "--porcelain")) if repository else None,
+			"input_count": len(inputs), "input_sha256": aggregate_inputs(inputs, repository),
+			"contract_count": len(items), "address_reference_count": len(source_references)})
+	return {"schema_version": 2,
+		"collection_provenance": {"tool": "collect_contracts", "tool_version": COLLECTOR_VERSION,
+			"python_version": platform.python_version(), "collector_sha256": sha256_file(Path(__file__)),
+			"descriptor": descriptor_path.name,
+			"descriptor_sha256": sha256_file(descriptor_path), "sources": sources},
+		"chains": descriptor["chains"], "contracts": sorted(contracts,
+			key=lambda item: (item["project"], item["network"], item["address"], item["name"])),
+		"address_references": sorted(references, key=lambda item: (
+			item["project"], item["network"], item["address"], item["migration_step"], item["field"]))}
+
+
+def main() -> None:
+	parser = argparse.ArgumentParser()
+	parser.add_argument("--descriptor", type=Path, required=True)
+	parser.add_argument("--output", type=Path, required=True)
+	args = parser.parse_args()
+	payload = collect(args.descriptor.resolve())
+	args.output.parent.mkdir(parents=True, exist_ok=True)
+	args.output.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+	main()

--- a/scripts/runtime-interaction-graph/collect_mir.py
+++ b/scripts/runtime-interaction-graph/collect_mir.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import subprocess
+from pathlib import Path
+
+from analysis_provenance import collector_provenance, command_fingerprint, file_sha256, reusable_artifact
+from collect_rapx import workspace_packages
+
+
+DEFAULT_PACKAGES = {"pallet-hsm", "pallet-omnipool", "pallet-route-executor", "pallet-stableswap"}
+TOOLCHAIN = "nightly-2025-12-06"
+
+
+def mir_command(package: dict) -> list[str]:
+	return ["cargo", f"+{TOOLCHAIN}", "rustc", "-p", package["package"], "--lib",
+		"--features", "std", "--locked", "--", "-Zunpretty=mir"]
+
+
+def failure_reason(log: Path) -> str:
+	text = log.read_text(errors="replace")
+	if any(marker in text for marker in ("to_substrate_wasm_fn_return_value", "cumulus-primitives-proof-size-hostfunction",
+		"could not compile `staging-xcm`", "could not compile `pallet-democracy`")):
+		return "pinned-nightly-dependency-incompatibility"
+	if "could not compile" in text:
+		return "compile-error"
+	return "unknown"
+
+
+def run(root: Path, output: Path, packages: set[str], timeout: int, force: bool = False) -> dict:
+	output.mkdir(parents=True, exist_ok=True)
+	environment = os.environ.copy()
+	environment["CXXFLAGS"] = "-include cstdint"
+	environment.pop("RUSTFLAGS", None)
+	manifest_path = output / "manifest.json"
+	previous = json.loads(manifest_path.read_text()) if manifest_path.exists() else {}
+	provenance = collector_provenance(root, Path(__file__), TOOLCHAIN, [
+		Path(__file__).with_name("analysis_provenance.py"),
+		Path(__file__).with_name("collect_rapx.py"),
+	])
+	selected = {package["package"]: package for package in workspace_packages(root)
+		if package["package"] in packages}
+	existing = {package["package"]: package for package in previous.get("packages", [])
+		if package["package"] in selected}
+	for entry in existing.values():
+		if entry.get("status") == "failed" and entry.get("log"):
+			log = output / entry["log"]
+			if log.exists():
+				entry["failure_reason"] = failure_reason(log)
+	manifest = {
+		"schema_version": 2,
+		"tool": "rustc-mir",
+		"toolchain": TOOLCHAIN,
+		"provenance": provenance,
+		"requested_packages": sorted(selected),
+		"timeout_seconds": timeout,
+		"packages": [],
+	}
+	workspace = sorted(selected.values(), key=lambda item: (item["owner"] == "runtime:hydradx", item["package"]))
+	for package in workspace:
+		artifact = output / f"{package['package']}.mir"
+		log = output / f"{package['package']}.log"
+		command = mir_command(package)
+		fingerprint = command_fingerprint(provenance, package, command)
+		if not force and reusable_artifact(existing.get(package["package"]), fingerprint, artifact):
+			continue
+		entry = dict(package)
+		try:
+			with artifact.open("w") as stdout, log.open("w") as stderr:
+				completed = subprocess.run(command, cwd=root, env=environment, text=True, stdout=stdout,
+					stderr=stderr, timeout=timeout)
+			entry.update({"status": "ok" if completed.returncode == 0 and artifact.stat().st_size else "failed",
+				"returncode": completed.returncode, "artifact": artifact.name, "log": log.name,
+				"command": command, "input_fingerprint": fingerprint})
+			if artifact.is_file() and artifact.stat().st_size:
+				entry["artifact_sha256"] = file_sha256(artifact)
+			if entry["status"] == "failed":
+				entry["failure_reason"] = failure_reason(log)
+		except subprocess.TimeoutExpired:
+			entry.update({"status": "timeout", "artifact": artifact.name, "log": log.name,
+				"command": command, "input_fingerprint": fingerprint})
+		existing[package["package"]] = entry
+		manifest["packages"] = sorted(existing.values(), key=lambda item: item["package"])
+		manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+	manifest["packages"] = sorted(existing.values(), key=lambda item: item["package"])
+	manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+	return manifest
+
+
+def main() -> None:
+	parser = argparse.ArgumentParser()
+	parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[2])
+	parser.add_argument("--output", type=Path, default=Path("target/runtime-interaction-graph/mir"))
+	parser.add_argument("--package", action="append", default=[])
+	parser.add_argument("--all", action="store_true")
+	parser.add_argument("--force", action="store_true")
+	parser.add_argument("--timeout", type=int, default=900)
+	args = parser.parse_args()
+	available = {package["package"] for package in workspace_packages(args.root.resolve())}
+	packages = available if args.all else (set(args.package) or DEFAULT_PACKAGES)
+	run(args.root.resolve(), args.output.resolve(), packages, args.timeout, args.force)
+
+
+if __name__ == "__main__":
+	main()

--- a/scripts/runtime-interaction-graph/collect_rapx.py
+++ b/scripts/runtime-interaction-graph/collect_rapx.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import subprocess
+from pathlib import Path
+
+from analysis_provenance import collector_provenance, command_fingerprint, file_sha256, reusable_artifact
+
+
+ANALYSIS_MARKERS = {"callgraph": "CallGraph:", "mir": "MIR:", "dataflow": "DataFlow:"}
+TOOLCHAIN = "nightly-2025-12-06"
+
+
+def analysis_command(package: dict, analysis: str, timeout: int) -> list[str]:
+	return ["cargo", f"+{TOOLCHAIN}", "rapx", "--timeout", str(timeout),
+		"analyze", analysis, "--", "-p", package["package"], "--lib", "--features", "std", "--locked"]
+
+
+def workspace_packages(root: Path) -> list[dict]:
+	result = subprocess.run(
+		["cargo", "metadata", "--no-deps", "--format-version", "1", "--locked"],
+		cwd=root,
+		check=True,
+		text=True,
+		capture_output=True,
+	)
+	packages = []
+	for package in json.loads(result.stdout)["packages"]:
+		manifest = Path(package["manifest_path"])
+		relative = manifest.relative_to(root).as_posix()
+		if not relative.startswith(("pallets/", "precompiles/", "runtime/hydradx/")):
+			continue
+		parts = relative.split("/")
+		if parts[0] in {"pallets", "precompiles"} and len(parts) != 3:
+			continue
+		if parts[0] == "runtime" and relative != "runtime/hydradx/Cargo.toml":
+			continue
+		if parts[0] == "pallets":
+			owner = f"pallet:{parts[1]}"
+		elif parts[0] == "precompiles":
+			owner = f"precompile:{parts[1]}"
+		else:
+			owner = "runtime:hydradx"
+		packages.append({"package": package["name"], "owner": owner, "manifest": relative})
+	return sorted(packages, key=lambda item: item["package"])
+
+
+def run(root: Path, output: Path, analyses: list[str], timeout: int, package_filter: set[str]) -> dict:
+	output.mkdir(parents=True, exist_ok=True)
+	environment = os.environ.copy()
+	environment["RAPX_CLEAN"] = "false"
+	environment["CXXFLAGS"] = "-include cstdint"
+	environment.pop("RUSTFLAGS", None)
+	manifest_path = output / "manifest.json"
+	previous = json.loads(manifest_path.read_text()) if manifest_path.exists() else {}
+	provenance = collector_provenance(root, Path(__file__), TOOLCHAIN,
+		[Path(__file__).with_name("analysis_provenance.py")])
+	selected = {package["package"]: package for package in workspace_packages(root)
+		if not package_filter or package["package"] in package_filter}
+	existing = {package["package"]: package for package in previous.get("packages", [])
+		if package["package"] in selected}
+	manifest = {
+		"schema_version": 2,
+		"tool": "rapx",
+		"toolchain": TOOLCHAIN,
+		"provenance": provenance,
+		"requested_packages": sorted(selected),
+		"requested_analyses": sorted(analyses),
+		"timeout_seconds": timeout,
+		"packages": [],
+	}
+	for package in selected.values():
+		entry = existing.get(package["package"], dict(package))
+		entry.setdefault("analyses", {})
+		entry["analyses"] = {name: value for name, value in entry["analyses"].items() if name in analyses}
+		for analysis in analyses:
+			path = output / f"{package['package']}.{analysis}.txt"
+			command = analysis_command(package, analysis, timeout)
+			fingerprint = command_fingerprint(provenance, {**package, "analysis": analysis}, command)
+			previous_analysis = entry["analyses"].get(analysis)
+			cache_entry = ({"status": previous_analysis.get("status"),
+				"input_fingerprint": previous_analysis.get("input_fingerprint"),
+				"artifact_sha256": previous_analysis.get("artifact_sha256")}
+				if previous_analysis else None)
+			if reusable_artifact(cache_entry, fingerprint, path):
+				continue
+			try:
+				with path.open("w") as stream:
+					completed = subprocess.run(command, cwd=root, env=environment, text=True,
+						stdout=stream, stderr=subprocess.STDOUT, timeout=timeout + 30)
+				status = "ok" if completed.returncode == 0 else "failed"
+				if status == "ok" and ANALYSIS_MARKERS[analysis] not in path.read_text(errors="replace"):
+					status = "invalid-output"
+				result = {"path": path.relative_to(output).as_posix(), "status": status,
+					"returncode": completed.returncode, "command": command, "input_fingerprint": fingerprint}
+				if path.is_file() and path.stat().st_size:
+					result["artifact_sha256"] = file_sha256(path)
+				entry["analyses"][analysis] = result
+			except subprocess.TimeoutExpired:
+				entry["analyses"][analysis] = {"path": path.relative_to(output).as_posix(),
+					"status": "timeout", "command": command, "input_fingerprint": fingerprint}
+		existing[package["package"]] = entry
+		manifest["packages"] = sorted(existing.values(), key=lambda item: item["package"])
+		manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+	manifest["packages"] = sorted(existing.values(), key=lambda item: item["package"])
+	manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+	return manifest
+
+
+def main() -> None:
+	parser = argparse.ArgumentParser()
+	parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[2])
+	parser.add_argument("--output", type=Path, default=Path("target/runtime-interaction-graph/rapx"))
+	parser.add_argument("--analysis", action="append", choices=["callgraph", "mir", "dataflow"], default=[])
+	parser.add_argument("--package", action="append", default=[])
+	parser.add_argument("--timeout", type=int, default=300)
+	args = parser.parse_args()
+	analyses = args.analysis or ["callgraph"]
+	run(args.root.resolve(), args.output.resolve(), analyses, args.timeout, set(args.package))
+
+
+if __name__ == "__main__":
+	main()

--- a/scripts/runtime-interaction-graph/collect_runtime_contracts.mjs
+++ b/scripts/runtime-interaction-graph/collect_runtime_contracts.mjs
@@ -1,0 +1,305 @@
+#!/usr/bin/env node
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+
+const ADDRESS = /^0x[0-9a-fA-F]{40}$/;
+const HASH_256 = /^0x[0-9a-fA-F]{64}$/;
+const COLLECTOR_VERSION = 4;
+const CONTRACT_QUERIES = [
+	["gigaHdx", "gigaHdxPoolContract", "pallet:gigahdx"],
+	["hsm", "flashMinter", "pallet:hsm"],
+	["liquidation", "borrowingContract", "pallet:liquidation"],
+];
+const ASSET_QUERIES = [
+	["assetRegistry", "assets"],
+	["assetRegistry", "assetLocations"],
+];
+
+
+export function options(argv) {
+	const result = new Map();
+	for (let index = 0; index < argv.length; index += 2) {
+		const flag = argv[index];
+		const value = argv[index + 1];
+		if (!flag?.startsWith("--") || value === undefined || value.startsWith("--")) {
+			throw new Error(`expected --flag value, received ${flag ?? "end of arguments"}`);
+		}
+		if (result.has(flag)) throw new Error(`duplicate option: ${flag}`);
+		result.set(flag, value);
+	}
+	return result;
+}
+
+
+export function requiredOption(parsed, flag) {
+	const value = parsed.get(flag);
+	if (!value) throw new Error(`missing required option: ${flag}`);
+	return value;
+}
+
+
+export function addressValues(value) {
+	if (typeof value === "string") return ADDRESS.test(value) ? [value.toLowerCase()] : [];
+	if (Array.isArray(value)) return value.flatMap(addressValues);
+	if (value && typeof value === "object") return Object.values(value).flatMap(addressValues);
+	return [];
+}
+
+
+function namedValue(value, name) {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	const normalized = name.replaceAll("_", "").toLowerCase();
+	const entry = Object.entries(value).find(([key]) => key.replaceAll("_", "").toLowerCase() === normalized);
+	return entry?.[1];
+}
+
+
+export function isErc20Asset(details) {
+	const assetType = namedValue(details, "assetType");
+	if (typeof assetType === "string") return assetType.toLowerCase() === "erc20";
+	return assetType && typeof assetType === "object" && namedValue(assetType, "erc20") !== undefined;
+}
+
+
+export function accountKey20Address(assetLocation) {
+	let location = assetLocation;
+	if (Array.isArray(location) && location.length === 1) [location] = location;
+	const interior = namedValue(location, "interior");
+	const x1 = namedValue(interior, "x1");
+	const junctions = Array.isArray(x1) ? x1 : (x1 ? [x1] : []);
+	if (junctions.length !== 1) return null;
+	const accountKey20 = namedValue(junctions[0], "accountKey20");
+	const key = namedValue(accountKey20, "key");
+	return typeof key === "string" && ADDRESS.test(key) ? key.toLowerCase() : null;
+}
+
+
+export function erc20AssetAddress(details, assetLocation) {
+	return isErc20Asset(details) ? accountKey20Address(assetLocation) : null;
+}
+
+
+export function validateSubstrateIdentity(snapshot, expectedGenesisHash, expectedSpecName) {
+	if (!HASH_256.test(expectedGenesisHash)) throw new Error(`invalid expected Substrate genesis hash: ${expectedGenesisHash}`);
+	if (!expectedSpecName) throw new Error("expected Substrate spec name must not be empty");
+	if (snapshot.genesis_hash.toLowerCase() !== expectedGenesisHash.toLowerCase()) {
+		throw new Error(
+			`Substrate genesis ${snapshot.genesis_hash} does not match expected genesis ${expectedGenesisHash}`
+		);
+	}
+	if (snapshot.spec_name !== expectedSpecName) {
+		throw new Error(`Substrate spec ${snapshot.spec_name} does not match expected spec ${expectedSpecName}`);
+	}
+}
+
+
+export function validateInputPayload(payload, requestedBlockNumber = null) {
+	if (payload.schema_version !== 2) throw new Error("contract snapshot must use schema_version 2");
+	if (!payload.collection_provenance?.descriptor_sha256 || !payload.enrichment_provenance?.input_sha256) {
+		throw new Error("contract snapshot has no verified collection and EVM enrichment provenance");
+	}
+	const snapshot = payload.rpc_snapshot;
+	if (!snapshot?.chain_id || !snapshot.block_hash || !Number.isInteger(snapshot.block_number)) {
+		throw new Error("contract snapshot has no canonical EVM chain and block identity");
+	}
+	if (!Array.isArray(payload.observations) || !payload.observations.length || payload.observations.some(
+		(observation) => observation.chain_id !== snapshot.chain_id ||
+			observation.chain_address_id !== `eip155:${snapshot.chain_id}:${observation.address}`
+	)) {
+		throw new Error("contract snapshot has missing or mixed-chain observations");
+	}
+	if (requestedBlockNumber !== null && snapshot.block_number !== requestedBlockNumber) {
+		throw new Error(
+			`requested Substrate block ${requestedBlockNumber} does not match EVM block ${snapshot.block_number}`
+		);
+	}
+}
+
+
+export function deduplicateConfigurations(configurations) {
+	const unique = new Map();
+	for (const configuration of configurations) unique.set(JSON.stringify(configuration), configuration);
+	return [...unique.values()].sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+}
+
+
+export function runtimeConfiguration(payload, component, storage, address, extra = {}) {
+	return {
+		component,
+		storage,
+		...extra,
+		chain_id: payload.rpc_snapshot.chain_id,
+		address,
+		chain_address_id: `eip155:${payload.rpc_snapshot.chain_id}:${address}`,
+	};
+}
+
+
+function requiredQuery(at, section, method) {
+	const query = at?.query?.[section]?.[method];
+	if (typeof query !== "function") {
+		throw new Error(`required runtime query API is missing: at.query.${section}.${method}`);
+	}
+	return query;
+}
+
+
+export function requiredRuntimeQueries(at) {
+	const queries = Object.fromEntries([...CONTRACT_QUERIES, ...ASSET_QUERIES].map(([section, method]) => [
+		`${section}.${method}`,
+		requiredQuery(at, section, method),
+	]));
+	if (typeof queries["assetRegistry.assets"].entries !== "function") {
+		throw new Error("required runtime query API does not expose entries(): at.query.assetRegistry.assets");
+	}
+	return queries;
+}
+
+
+export async function collectRuntimeConfigurations(payload, at) {
+	const queries = requiredRuntimeQueries(at);
+	const configurations = [];
+	const queryResults = Object.fromEntries(Object.keys(queries).map((storage) => [storage, {
+		available: true,
+		calls: 0,
+		records: 0,
+		configurations: 0,
+	}]));
+	for (const [section, method, component] of CONTRACT_QUERIES) {
+		const storage = `${section}.${method}`;
+		const addresses = addressValues((await queries[storage]()).toJSON());
+		queryResults[storage].calls = 1;
+		queryResults[storage].records = addresses.length;
+		queryResults[storage].configurations = addresses.length;
+		for (const address of addresses) {
+			configurations.push(runtimeConfiguration(payload, component, storage, address));
+		}
+	}
+	const entries = await queries["assetRegistry.assets"].entries();
+	queryResults["assetRegistry.assets"].calls = 1;
+	queryResults["assetRegistry.assets"].records = entries.length;
+	queryResults["assetRegistry.assets"].erc20_assets = 0;
+	for (const [key, codec] of entries) {
+		const assetId = key.args[0];
+		const details = codec.toJSON();
+		if (!isErc20Asset(details)) continue;
+		queryResults["assetRegistry.assets"].erc20_assets += 1;
+		const location = (await queries["assetRegistry.assetLocations"](assetId)).toJSON();
+		queryResults["assetRegistry.assetLocations"].calls += 1;
+		const address = erc20AssetAddress(details, location);
+		if (!address) continue;
+		queryResults["assetRegistry.assetLocations"].records += 1;
+		queryResults["assetRegistry.assetLocations"].configurations += 1;
+		configurations.push(runtimeConfiguration(payload, "pallet:asset-registry",
+			"assetRegistry.assetLocations", address, { asset_id: assetId.toString(), asset_type: "erc20" }));
+	}
+	return {
+		configurations,
+		queryCoverage: {
+			required_query_count: Object.keys(queries).length,
+			available_query_count: Object.keys(queries).length,
+			collected_configuration_count: configurations.length,
+			unique_configuration_count: deduplicateConfigurations(configurations).length,
+			queries: queryResults,
+		},
+	};
+}
+
+
+export function outputPayload(payload, configurations, snapshot, inputSha256, versions, queryCoverage) {
+	return {
+		...payload,
+		substrate_snapshot: snapshot,
+		chain_context: {
+			evm_chain_id: payload.rpc_snapshot.chain_id,
+			evm_block_hash: payload.rpc_snapshot.block_hash,
+			substrate_genesis_hash: snapshot.genesis_hash,
+			substrate_block_hash: snapshot.block_hash,
+			substrate_spec_name: snapshot.spec_name,
+			block_number: snapshot.block_number,
+		},
+		runtime_collection_provenance: {
+			tool: "collect_runtime_contracts",
+			tool_version: COLLECTOR_VERSION,
+			node_version: versions.node,
+			polkadot_api_version: versions.polkadotApi,
+			collector_sha256: versions.collectorSha256,
+			input_sha256: inputSha256,
+			query_coverage: queryCoverage,
+		},
+		runtime_configurations: deduplicateConfigurations(configurations),
+	};
+}
+
+
+export async function main(argv = process.argv.slice(2)) {
+	const parsed = options(argv);
+	const input = requiredOption(parsed, "--input");
+	const output = requiredOption(parsed, "--output");
+	const rpc = requiredOption(parsed, "--rpc");
+	const expectedGenesisHash = requiredOption(parsed, "--expected-genesis-hash");
+	const expectedSpecName = requiredOption(parsed, "--expected-spec-name");
+	const requestedBlock = parsed.get("--block") ?? null;
+	const requestedNumberValue = parsed.get("--block-number") ?? null;
+	if ((requestedBlock === null) === (requestedNumberValue === null)) {
+		throw new Error("exactly one of --block or --block-number is required");
+	}
+	const requestedNumber = requestedNumberValue === null ? null : Number(requestedNumberValue);
+	if (requestedNumberValue !== null && (!Number.isSafeInteger(requestedNumber) || requestedNumber < 0)) {
+		throw new Error(`invalid block number: ${requestedNumberValue}`);
+	}
+	const inputBytes = fs.readFileSync(input);
+	const payload = JSON.parse(inputBytes.toString("utf8"));
+	validateInputPayload(payload, requestedNumber);
+	const { ApiPromise, WsProvider } = await import(
+		"../../launch-configs/fork/node_modules/@polkadot/api/index.js"
+	);
+	const provider = new WsProvider(rpc);
+	const api = await ApiPromise.create({ provider, noInitWarn: true });
+	try {
+		const hash = requestedBlock || (await api.rpc.chain.getBlockHash(requestedNumber)).toHex();
+		const header = await api.rpc.chain.getHeader(hash);
+		const blockNumber = header.number.toNumber();
+		if (blockNumber !== payload.rpc_snapshot.block_number) {
+			throw new Error(`Substrate block ${blockNumber} does not match EVM block ${payload.rpc_snapshot.block_number}`);
+		}
+		const genesisHash = (await api.rpc.chain.getBlockHash(0)).toHex();
+		const chain = (await api.rpc.system.chain()).toString();
+		const runtimeVersion = await api.rpc.state.getRuntimeVersion(hash);
+		const snapshot = {
+			rpc,
+			chain,
+			genesis_hash: genesisHash,
+			block_hash: hash,
+			block_number: blockNumber,
+			parent_hash: header.parentHash.toHex(),
+			state_root: header.stateRoot.toHex(),
+			extrinsics_root: header.extrinsicsRoot.toHex(),
+			spec_name: runtimeVersion.specName.toString(),
+			spec_version: runtimeVersion.specVersion.toNumber(),
+		};
+		validateSubstrateIdentity(snapshot, expectedGenesisHash, expectedSpecName);
+		const at = await api.at(hash);
+		const { configurations, queryCoverage } = await collectRuntimeConfigurations(payload, at);
+		const packagePath = new URL(
+			"../../launch-configs/fork/node_modules/@polkadot/api/package.json", import.meta.url
+		);
+		const polkadotApi = JSON.parse(fs.readFileSync(packagePath, "utf8")).version;
+		const result = outputPayload(payload, configurations, snapshot,
+			crypto.createHash("sha256").update(inputBytes).digest("hex"),
+			{ node: process.version, polkadotApi,
+				collectorSha256: crypto.createHash("sha256").update(fs.readFileSync(new URL(import.meta.url))).digest("hex") },
+			queryCoverage);
+		fs.mkdirSync(path.dirname(path.resolve(output)), { recursive: true });
+		fs.writeFileSync(output, `${JSON.stringify(result, null, 2)}\n`);
+	} finally {
+		await api.disconnect();
+	}
+}
+
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) await main();

--- a/scripts/runtime-interaction-graph/collect_runtime_contracts.test.mjs
+++ b/scripts/runtime-interaction-graph/collect_runtime_contracts.test.mjs
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+import {
+	accountKey20Address,
+	addressValues,
+	collectRuntimeConfigurations,
+	deduplicateConfigurations,
+	erc20AssetAddress,
+	isErc20Asset,
+	options,
+	outputPayload,
+	requiredOption,
+	requiredRuntimeQueries,
+	runtimeConfiguration,
+	validateInputPayload,
+	validateSubstrateIdentity,
+} from "./collect_runtime_contracts.mjs";
+
+
+const GENESIS = `0x${"11".repeat(32)}`;
+const ADDRESS = "0x1111111111111111111111111111111111111111";
+
+
+function codec(value) {
+	return { toJSON: () => value };
+}
+
+
+function runtimeQueries(overrides = {}) {
+	const gigaHdxPoolContract = async () => codec(ADDRESS);
+	const flashMinter = async () => codec(null);
+	const borrowingContract = async () => codec({ value: ADDRESS });
+	const assets = async () => codec(null);
+	assets.entries = async () => [
+		[{ args: [{ toString: () => "7" }] }, codec({ assetType: "Erc20" })],
+		[{ args: [{ toString: () => "8" }] }, codec({ assetType: "Token" })],
+		[{ args: [{ toString: () => "9" }] }, codec({ assetType: "Erc20" })],
+	];
+	const assetLocations = async (assetId) => codec(assetId.toString() === "7" ? {
+		parents: 0,
+		interior: { x1: [{ accountKey20: { network: null, key: ADDRESS } }] },
+	} : null);
+	return {
+		query: {
+			gigaHdx: { gigaHdxPoolContract },
+			hsm: { flashMinter },
+			liquidation: { borrowingContract },
+			assetRegistry: { assets, assetLocations },
+			...overrides,
+		},
+	};
+}
+
+
+test("runtime collector requires explicit unique options", () => {
+	const parsed = options(["--input", "in.json", "--output", "out.json"]);
+	assert.equal(requiredOption(parsed, "--input"), "in.json");
+	assert.throws(() => requiredOption(parsed, "--rpc"), /missing required option/);
+	assert.throws(() => options(["--input", "a", "--input", "b"]), /duplicate option/);
+});
+
+
+test("runtime collector extracts exact nested addresses only", () => {
+	assert.deepEqual(addressValues({ values: [
+		"0x1111111111111111111111111111111111111111",
+		"prefix0x2222222222222222222222222222222222222222",
+	] }), ["0x1111111111111111111111111111111111111111"]);
+});
+
+
+test("runtime query validation should fail when required API is missing", () => {
+	const at = runtimeQueries({ hsm: {} });
+	assert.throws(() => requiredRuntimeQueries(at), /at\.query\.hsm\.flashMinter/);
+});
+
+
+test("runtime collector should report complete query coverage", async () => {
+	const payload = { rpc_snapshot: { chain_id: 42 } };
+	const { configurations, queryCoverage } = await collectRuntimeConfigurations(payload, runtimeQueries());
+	assert.equal(queryCoverage.required_query_count, 5);
+	assert.equal(queryCoverage.available_query_count, 5);
+	assert.equal(queryCoverage.collected_configuration_count, 3);
+	assert.equal(queryCoverage.unique_configuration_count, 3);
+	assert.deepEqual(queryCoverage.queries["hsm.flashMinter"], {
+		available: true,
+		calls: 1,
+		records: 0,
+		configurations: 0,
+	});
+	assert.deepEqual(queryCoverage.queries["assetRegistry.assets"], {
+		available: true,
+		calls: 1,
+		records: 3,
+		configurations: 0,
+		erc20_assets: 2,
+	});
+	assert.equal(queryCoverage.queries["assetRegistry.assetLocations"].calls, 2);
+	assert.equal(queryCoverage.queries["assetRegistry.assetLocations"].configurations, 1);
+	assert.equal(configurations.length, 3);
+});
+
+
+test("asset registry collector should extract only Erc20 AccountKey20 locations", () => {
+	const address = ADDRESS;
+	const asciiName = "0x44414920284163616c6120576f726d686f6c6529";
+	const location = { parents: 0, interior: { x1: [{ accountKey20: { network: null, key: address } }] } };
+	assert.equal(isErc20Asset({ assetType: "Erc20", name: asciiName }), true);
+	assert.equal(accountKey20Address(location), address);
+	assert.equal(erc20AssetAddress({ assetType: "Erc20", name: asciiName }, location), address);
+	assert.equal(erc20AssetAddress({ assetType: "Token", name: asciiName }, location), null);
+	assert.equal(erc20AssetAddress({ assetType: "Erc20", name: asciiName }, {
+		parents: 0, interior: { x1: [{ generalKey: { data: asciiName } }] },
+	}), null);
+	assert.equal(erc20AssetAddress({ assetType: "Erc20", name: asciiName }, {
+		parents: 0, interior: { x2: [{ accountKey20: { key: address } }] },
+	}), null);
+});
+
+
+test("runtime collector should enforce expected Substrate identity", () => {
+	const snapshot = { genesis_hash: GENESIS, spec_name: "hydradx" };
+	assert.doesNotThrow(() => validateSubstrateIdentity(snapshot, GENESIS.toUpperCase().replace("0X", "0x"),
+		"hydradx"));
+	assert.throws(() => validateSubstrateIdentity(snapshot, `0x${"22".repeat(32)}`, "hydradx"),
+		/does not match expected genesis/);
+	assert.throws(() => validateSubstrateIdentity(snapshot, GENESIS, "other"), /does not match expected spec/);
+});
+
+
+test("runtime collector rejects legacy and mismatched snapshots", () => {
+	assert.throws(() => validateInputPayload({ schema_version: 1 }), /schema_version 2/);
+	const payload = {
+		schema_version: 2,
+		collection_provenance: { descriptor_sha256: "hash" },
+		enrichment_provenance: { input_sha256: "hash" },
+		rpc_snapshot: { chain_id: 42, block_hash: "0xabc", block_number: 10 },
+		observations: [{ chain_id: 42, address: "0x1111111111111111111111111111111111111111",
+			chain_address_id: "eip155:42:0x1111111111111111111111111111111111111111" }],
+	};
+	assert.doesNotThrow(() => validateInputPayload(payload, 10));
+	assert.throws(() => validateInputPayload(payload, 11), /does not match EVM block/);
+});
+
+
+test("CI contract fixture should satisfy pinned snapshot validation", () => {
+	const payload = JSON.parse(fs.readFileSync(new URL("./fixtures/ci-contracts.json", import.meta.url)));
+	assert.doesNotThrow(() => validateInputPayload(payload, 13161523));
+	assert.doesNotThrow(() => validateSubstrateIdentity(payload.substrate_snapshot,
+		payload.chain_context.substrate_genesis_hash, payload.chain_context.substrate_spec_name));
+	assert.equal(payload.runtime_collection_provenance.query_coverage.required_query_count, 5);
+	assert.equal(payload.runtime_collection_provenance.query_coverage.available_query_count, 5);
+});
+
+
+test("runtime output preserves canonical chain identity and deduplicates configuration", () => {
+	const payload = { rpc_snapshot: { chain_id: 42, block_hash: "0xevm" } };
+	const snapshot = { genesis_hash: GENESIS, block_hash: "0xsubstrate", block_number: 10,
+		spec_name: "hydradx" };
+	const configuration = runtimeConfiguration(payload, "pallet:hsm", "hsm.flashMinter",
+		"0x1111111111111111111111111111111111111111");
+	assert.equal(configuration.chain_address_id,
+		"eip155:42:0x1111111111111111111111111111111111111111");
+	assert.equal(deduplicateConfigurations([configuration, configuration]).length, 1);
+	const queryCoverage = { required_query_count: 5, available_query_count: 5, queries: {} };
+	const result = outputPayload(payload, [configuration, configuration], snapshot, "input-hash",
+		{ node: "v1", polkadotApi: "2", collectorSha256: "collector" }, queryCoverage);
+	assert.deepEqual(result.chain_context, {
+		evm_chain_id: 42,
+		evm_block_hash: "0xevm",
+		substrate_genesis_hash: GENESIS,
+		substrate_block_hash: "0xsubstrate",
+		substrate_spec_name: "hydradx",
+		block_number: 10,
+	});
+	assert.equal(result.runtime_collection_provenance.input_sha256, "input-hash");
+	assert.equal(result.runtime_collection_provenance.collector_sha256, "collector");
+	assert.equal(result.runtime_collection_provenance.query_coverage, queryCoverage);
+	assert.equal(result.runtime_configurations.length, 1);
+});

--- a/scripts/runtime-interaction-graph/coverage-thresholds-deployment.json
+++ b/scripts/runtime-interaction-graph/coverage-thresholds-deployment.json
@@ -1,0 +1,93 @@
+{
+  "minimum": {
+    "nodes": 7900,
+    "edges": 27000,
+    "components": 220,
+    "entrypoints": 450,
+    "entrypoint_kinds": 12,
+    "state_invariants": 7,
+    "asset_operations": 9,
+    "inventory_only_targets": 6,
+    "deployed_contracts": 6,
+    "runtime_contract_configurations": 4,
+    "runtime_registry_erc20_configurations": 1,
+    "integration_tests_linked": 800,
+    "integration_components_linked": 45,
+    "integration_entrypoints_linked": 180,
+    "active_integration_tests_linked": 800,
+    "active_integration_components_linked": 45,
+    "active_integration_entrypoints_linked": 180,
+    "asset_projection_edges": 300,
+    "authorization_projection_edges": 600,
+    "callback_projection_edges": 4100,
+    "configuration_projection_edges": 3930,
+    "deployment_projection_edges": 20,
+    "execution_projection_edges": 3650,
+    "state_projection_edges": 1300,
+    "active_asset_projection_edges": 300,
+    "active_authorization_projection_edges": 640,
+    "active_callback_projection_edges": 4100,
+    "active_configuration_projection_edges": 3800,
+    "active_deployment_projection_edges": 20,
+    "active_execution_projection_edges": 3650,
+    "active_state_projection_edges": 1200
+  },
+  "maximum": {
+    "unresolved_targets": 0,
+    "inventory_only_targets": 6
+  },
+  "regression": {
+    "maximum_drop": {
+      "nodes": 50,
+      "edges": 100,
+      "components": 2,
+      "entrypoints": 2,
+      "entrypoint_kinds": 0,
+      "state_invariants": 0,
+      "asset_operations": 0,
+      "inventory_only_targets": 0,
+      "deployed_contracts": 0,
+      "runtime_contract_configurations": 0,
+      "runtime_registry_erc20_configurations": 0,
+      "integration_tests_linked": 5,
+      "integration_components_linked": 0,
+      "integration_entrypoints_linked": 2,
+      "active_integration_tests_linked": 5,
+      "active_integration_components_linked": 0,
+      "active_integration_entrypoints_linked": 2,
+      "asset_projection_edges": 5,
+      "authorization_projection_edges": 5,
+      "callback_projection_edges": 20,
+      "configuration_projection_edges": 20,
+      "deployment_projection_edges": 0,
+      "execution_projection_edges": 20,
+      "state_projection_edges": 5,
+      "active_asset_projection_edges": 5,
+      "active_authorization_projection_edges": 5,
+      "active_callback_projection_edges": 20,
+      "active_configuration_projection_edges": 20,
+      "active_deployment_projection_edges": 0,
+      "active_execution_projection_edges": 20,
+      "active_state_projection_edges": 5
+    },
+    "maximum_increase": {
+      "unresolved_targets": 0,
+      "inventory_only_targets": 0
+    }
+  },
+  "exact": {
+    "inventory_only_target_ids": [
+      "associated:pallet:aura:PalletPrefix",
+      "associated:pallet:cumulus-pallet-xcmp-queue:ChannelList",
+      "associated:pallet:nft:Permissions",
+      "associated:pallet:session:historical:FullIdentificationOf",
+      "associated:pallet:xcm-rate-limiter:CurrencyIdConvert",
+      "associated:pallet:xcm-rate-limiter:RelayBlockNumberProvider"
+    ],
+    "inventory_only_targets_by_reason": {
+      "component-not-instantiated": 3,
+      "config-trait-not-implemented": 1,
+      "migration-not-configured": 2
+    }
+  }
+}

--- a/scripts/runtime-interaction-graph/coverage-thresholds-full.json
+++ b/scripts/runtime-interaction-graph/coverage-thresholds-full.json
@@ -1,0 +1,61 @@
+{
+  "minimum": {
+    "nodes": 7900,
+    "edges": 27000,
+    "components": 220,
+    "entrypoints": 450,
+    "entrypoint_kinds": 12,
+    "state_invariants": 7,
+    "asset_operations": 9,
+    "inventory_only_targets": 6,
+    "deployed_contracts": 6,
+    "runtime_contract_configurations": 4,
+    "runtime_registry_erc20_configurations": 1,
+    "integration_tests_linked": 800,
+    "integration_components_linked": 45,
+    "integration_entrypoints_linked": 180,
+    "active_integration_tests_linked": 800,
+    "active_integration_components_linked": 45,
+    "active_integration_entrypoints_linked": 180,
+    "asset_projection_edges": 300,
+    "authorization_projection_edges": 600,
+    "callback_projection_edges": 4100,
+    "configuration_projection_edges": 3930,
+    "deployment_projection_edges": 20,
+    "execution_projection_edges": 3650,
+    "state_projection_edges": 1300,
+    "active_asset_projection_edges": 300,
+    "active_authorization_projection_edges": 640,
+    "active_callback_projection_edges": 4100,
+    "active_configuration_projection_edges": 3800,
+    "active_deployment_projection_edges": 20,
+    "active_execution_projection_edges": 3650,
+    "active_state_projection_edges": 1200,
+    "mir_packages_success": 46,
+    "mir_packages_total": 46,
+    "mir_functions_matched": 1000,
+    "mir_instances_matched": 2500,
+    "mir_operation_count": 3000
+  },
+  "maximum": {
+    "unresolved_targets": 0,
+    "inventory_only_targets": 6,
+    "mir_packages_total": 46,
+    "mir_packages_failed": 0
+  },
+  "exact": {
+    "inventory_only_target_ids": [
+      "associated:pallet:aura:PalletPrefix",
+      "associated:pallet:cumulus-pallet-xcmp-queue:ChannelList",
+      "associated:pallet:nft:Permissions",
+      "associated:pallet:session:historical:FullIdentificationOf",
+      "associated:pallet:xcm-rate-limiter:CurrencyIdConvert",
+      "associated:pallet:xcm-rate-limiter:RelayBlockNumberProvider"
+    ],
+    "inventory_only_targets_by_reason": {
+      "component-not-instantiated": 3,
+      "config-trait-not-implemented": 1,
+      "migration-not-configured": 2
+    }
+  }
+}

--- a/scripts/runtime-interaction-graph/coverage-thresholds.json
+++ b/scripts/runtime-interaction-graph/coverage-thresholds.json
@@ -1,0 +1,83 @@
+{
+  "minimum": {
+    "nodes": 7900,
+    "edges": 27000,
+    "components": 220,
+    "entrypoints": 450,
+    "entrypoint_kinds": 12,
+    "state_invariants": 7,
+    "asset_operations": 9,
+    "inventory_only_targets": 6,
+    "integration_tests_linked": 800,
+    "integration_components_linked": 45,
+    "integration_entrypoints_linked": 180,
+    "active_integration_tests_linked": 800,
+    "active_integration_components_linked": 45,
+    "active_integration_entrypoints_linked": 180,
+    "asset_projection_edges": 300,
+    "authorization_projection_edges": 600,
+    "callback_projection_edges": 4100,
+    "configuration_projection_edges": 3930,
+    "execution_projection_edges": 3650,
+    "state_projection_edges": 1300,
+    "active_asset_projection_edges": 300,
+    "active_authorization_projection_edges": 640,
+    "active_callback_projection_edges": 4100,
+    "active_configuration_projection_edges": 3800,
+    "active_execution_projection_edges": 3650,
+    "active_state_projection_edges": 1200
+  },
+  "maximum": {
+    "unresolved_targets": 0,
+    "inventory_only_targets": 6
+  },
+  "regression": {
+    "maximum_drop": {
+      "nodes": 50,
+      "edges": 100,
+      "components": 2,
+      "entrypoints": 2,
+      "entrypoint_kinds": 0,
+      "state_invariants": 0,
+      "asset_operations": 0,
+      "inventory_only_targets": 0,
+      "integration_tests_linked": 5,
+      "integration_components_linked": 0,
+      "integration_entrypoints_linked": 2,
+      "active_integration_tests_linked": 5,
+      "active_integration_components_linked": 0,
+      "active_integration_entrypoints_linked": 2,
+      "asset_projection_edges": 5,
+      "authorization_projection_edges": 5,
+      "callback_projection_edges": 20,
+      "configuration_projection_edges": 20,
+      "execution_projection_edges": 20,
+      "state_projection_edges": 5,
+      "active_asset_projection_edges": 5,
+      "active_authorization_projection_edges": 5,
+      "active_callback_projection_edges": 20,
+      "active_configuration_projection_edges": 20,
+      "active_execution_projection_edges": 20,
+      "active_state_projection_edges": 5
+    },
+    "maximum_increase": {
+      "unresolved_targets": 0,
+      "inventory_only_targets": 0
+    }
+  },
+  "exact": {
+    "inventory_only_target_ids": [
+      "associated:pallet:aura:PalletPrefix",
+      "associated:pallet:cumulus-pallet-xcmp-queue:ChannelList",
+      "associated:pallet:nft:Permissions",
+      "associated:pallet:session:historical:FullIdentificationOf",
+      "associated:pallet:xcm-rate-limiter:CurrencyIdConvert",
+      "associated:pallet:xcm-rate-limiter:RelayBlockNumberProvider"
+    ],
+    "inventory_only_targets_by_reason": {
+      "component-not-instantiated": 3,
+      "config-trait-not-implemented": 1,
+      "migration-not-configured": 2
+    }
+  }
+}

--- a/scripts/runtime-interaction-graph/deployment-sources.json
+++ b/scripts/runtime-interaction-graph/deployment-sources.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "deployment-sources.schema.json",
+  "schema_version": 2,
+  "chains": [
+    {
+      "id": "hydration-mainnet",
+      "evm_chain_id": 222222,
+      "substrate_genesis_hash": "0xafdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
+      "substrate_spec_name": "hydradx",
+      "runtime_configuration_minimums": {
+        "total": 4,
+        "asset_registry_erc20": 1,
+        "required_bindings": {
+          "gigaHdx.gigaHdxPoolContract": 1,
+          "hsm.flashMinter": 1,
+          "liquidation.borrowingContract": 1
+        }
+      },
+      "deployment_networks": [
+        "gigahdx",
+        "hydration"
+      ]
+    }
+  ],
+  "sources": [
+    {
+      "project": "aave-v3-deploy",
+      "kind": "hardhat",
+      "root": "../../../aave-v3-deploy/deployments",
+      "networks": [
+        "gigahdx",
+        "hydration"
+      ]
+    },
+    {
+      "project": "hollar",
+      "kind": "hardhat",
+      "root": "../../../hollar/deployments",
+      "networks": [
+        "gigahdx",
+        "hydration"
+      ]
+    },
+    {
+      "project": "whm",
+      "kind": "whm",
+      "root": "../../../whm/deployments/prod",
+      "networks": [
+        "basejump-base",
+        "nintent-ethereum-alpha",
+        "oracle-relay-solana"
+      ]
+    }
+  ]
+}

--- a/scripts/runtime-interaction-graph/deployment-sources.schema.json
+++ b/scripts/runtime-interaction-graph/deployment-sources.schema.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hydration.net/schemas/runtime-interaction-graph/deployment-sources.schema.json",
+  "title": "Runtime interaction graph deployment sources",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "chains",
+    "sources"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "schema_version": {
+      "const": 2
+    },
+    "chains": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "evm_chain_id",
+          "substrate_genesis_hash",
+          "substrate_spec_name",
+          "runtime_configuration_minimums",
+          "deployment_networks"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "evm_chain_id": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "substrate_genesis_hash": {
+            "type": "string",
+            "pattern": "^0x[0-9a-fA-F]{64}$"
+          },
+          "substrate_spec_name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "runtime_configuration_minimums": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "total",
+              "asset_registry_erc20",
+              "required_bindings"
+            ],
+            "properties": {
+              "total": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "asset_registry_erc20": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "required_bindings": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "gigaHdx.gigaHdxPoolContract",
+                  "hsm.flashMinter",
+                  "liquidation.borrowingContract"
+                ],
+                "properties": {
+                  "gigaHdx.gigaHdxPoolContract": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "hsm.flashMinter": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "liquidation.borrowingContract": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
+            }
+          },
+          "deployment_networks": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "uniqueItems": true
+          }
+        }
+      }
+    },
+    "sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "project",
+          "kind",
+          "root",
+          "networks"
+        ],
+        "properties": {
+          "project": {
+            "type": "string",
+            "minLength": 1
+          },
+          "kind": {
+            "enum": [
+              "hardhat",
+              "whm"
+            ]
+          },
+          "root": {
+            "type": "string",
+            "minLength": 1
+          },
+          "networks": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "uniqueItems": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/runtime-interaction-graph/diff_graphs.py
+++ b/scripts/runtime-interaction-graph/diff_graphs.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+from pathlib import Path
+
+
+VOLATILE_FIELDS = frozenset({
+	"artifact",
+	"binding_file",
+	"configured_by",
+	"declaration_file",
+	"file",
+	"first_external_line",
+	"impl_line",
+	"line",
+	"manifest",
+	"mir_source",
+	"path",
+	"rapx_output",
+	"source_file",
+})
+RISKY_KINDS = frozenset({
+	"affects-invariant",
+	"asset-operation",
+	"authorizes-entry",
+	"burns",
+	"dispatches-frame",
+	"dynamic-call",
+	"enforces",
+	"enters-evm",
+	"external-execution",
+	"guards",
+	"locks",
+	"mints",
+	"mir-dispatches-frame",
+	"mir-dynamic-call",
+	"mir-enters-evm",
+	"mir-external-call",
+	"must-equal",
+	"nested-dispatch",
+	"proxy-implementation",
+	"runtime-configures-contract",
+	"transfers-from",
+	"transfers-to",
+})
+RISKY_ENDPOINT_PREFIXES = ("boundary:", "guard:", "invariant:", "operation:", "origin:", "precompile:")
+SEMANTIC_DETAIL_FIELDS = ("operation", "value", "enforcement", "resolution")
+
+
+def identity(edge: dict) -> tuple:
+	return edge["source"], edge["target"], edge["kind"], edge.get("method")
+
+
+def identity_key(value: tuple) -> tuple:
+	return tuple((item is None, "" if item is None else str(item)) for item in value)
+
+
+def canonical(value):
+	if isinstance(value, dict):
+		return {key: canonical(item) for key, item in sorted(value.items()) if key not in VOLATILE_FIELDS}
+	if isinstance(value, list):
+		return [canonical(item) for item in value]
+	return value
+
+
+def fingerprint(value: dict) -> str:
+	return json.dumps(canonical(value), sort_keys=True, separators=(",", ":"), default=str)
+
+
+def display(value: dict) -> dict:
+	result = canonical(value)
+	location = {key: value[key] for key in sorted(VOLATILE_FIELDS & value.keys()) if value[key] is not None}
+	if location:
+		result["location"] = location
+	return result
+
+
+def edge_index(edges: list[dict]) -> dict[tuple, dict[str, dict]]:
+	result = {}
+	for edge in sorted(edges, key=lambda item: (
+		identity_key(identity(item)),
+		item.get("line") is None,
+		item.get("line") or 0,
+		item.get("file") or "",
+	)):
+		result.setdefault(identity(edge), {}).setdefault(fingerprint(edge), edge)
+	return result
+
+
+def review_priority(edge: dict) -> bool:
+	return edge["kind"] in RISKY_KINDS or edge["source"].startswith(RISKY_ENDPOINT_PREFIXES) \
+		or edge["target"].startswith(RISKY_ENDPOINT_PREFIXES)
+
+
+def semantic_details(edge: dict) -> str:
+	return ", ".join(f"{field}={edge[field]}" for field in SEMANTIC_DETAIL_FIELDS
+		if edge.get(field) is not None)
+
+
+def variant_details(edges: list[dict]) -> str:
+	details = [semantic_details(edge) or "semantic variant" for edge in edges]
+	return " | ".join(details)
+
+
+def diff(before: dict, after: dict) -> dict:
+	left_nodes = {node["id"]: node for node in before["nodes"]}
+	right_nodes = {node["id"]: node for node in after["nodes"]}
+	nodes_changed = []
+	for ident in sorted(left_nodes.keys() & right_nodes.keys()):
+		if fingerprint(left_nodes[ident]) == fingerprint(right_nodes[ident]):
+			continue
+		before_node = canonical(left_nodes[ident])
+		after_node = canonical(right_nodes[ident])
+		before_node.pop("id", None)
+		after_node.pop("id", None)
+		nodes_changed.append({"id": ident, "before": before_node, "after": after_node})
+
+	left_edges = edge_index(before["edges"])
+	right_edges = edge_index(after["edges"])
+	added = []
+	removed = []
+	edges_changed = []
+	for ident in sorted(left_edges.keys() | right_edges.keys(), key=identity_key):
+		left_variants = left_edges.get(ident, {})
+		right_variants = right_edges.get(ident, {})
+		left_only = sorted(left_variants.keys() - right_variants.keys())
+		right_only = sorted(right_variants.keys() - left_variants.keys())
+		if left_only and right_only:
+			edges_changed.append({
+				"source": ident[0],
+				"target": ident[1],
+				"kind": ident[2],
+				"method": ident[3],
+				"before": [display(left_variants[key]) for key in left_only],
+				"after": [display(right_variants[key]) for key in right_only],
+			})
+		elif left_only:
+			removed.extend(display(left_variants[key]) for key in left_only)
+		elif right_only:
+			added.extend(display(right_variants[key]) for key in right_only)
+	return {
+		"nodes_added": sorted(right_nodes.keys() - left_nodes.keys()),
+		"nodes_removed": sorted(left_nodes.keys() - right_nodes.keys()),
+		"nodes_changed": nodes_changed,
+		"edges_added": added,
+		"edges_removed": removed,
+		"edges_changed": edges_changed,
+		"review_edges_added": [edge for edge in added if review_priority(edge)],
+		"review_edges_removed": [edge for edge in removed if review_priority(edge)],
+		"review_edges_changed": [edge for edge in edges_changed if review_priority(edge)],
+	}
+
+
+def compare_coverage(before: dict, after: dict, thresholds: dict) -> dict:
+	changes = {field: after[field] - before[field] for field in sorted(before.keys() & after.keys())
+		if isinstance(before[field], (int, float)) and isinstance(after[field], (int, float))}
+	regressions = []
+	for field, minimum in thresholds.get("minimum", {}).items():
+		if after.get(field) is None or after[field] < minimum:
+			regressions.append(f"{field}={after.get(field)} is below minimum {minimum}")
+	for field, maximum in thresholds.get("maximum", {}).items():
+		if after.get(field) is None or after[field] > maximum:
+			regressions.append(f"{field}={after.get(field)} is above maximum {maximum}")
+	for field, expected in thresholds.get("exact", {}).items():
+		if after.get(field) != expected:
+			regressions.append(f"{field}={after.get(field)!r} does not equal {expected!r}")
+	for field, maximum_drop in thresholds.get("regression", {}).get("maximum_drop", {}).items():
+		if before.get(field) is None or after.get(field) is None:
+			regressions.append(f"{field} is unavailable for regression comparison")
+		elif before[field] - after[field] > maximum_drop:
+			regressions.append(f"{field} dropped by {before[field] - after[field]}, maximum is {maximum_drop}")
+	for field, maximum_increase in thresholds.get("regression", {}).get("maximum_increase", {}).items():
+		if before.get(field) is None or after.get(field) is None:
+			regressions.append(f"{field} is unavailable for regression comparison")
+		elif after[field] - before[field] > maximum_increase:
+			regressions.append(f"{field} increased by {after[field] - before[field]}, maximum is {maximum_increase}")
+	return {"before": before, "after": after, "changes": changes, "regressions": regressions}
+
+
+def markdown(result: dict) -> str:
+	lines = ["# Runtime interaction graph diff", "",
+		f"- Nodes: +{len(result['nodes_added'])} / -{len(result['nodes_removed'])} / "
+		f"~{len(result['nodes_changed'])}",
+		f"- Edges: +{len(result['edges_added'])} / -{len(result['edges_removed'])} / "
+		f"~{len(result['edges_changed'])}",
+		f"- Review-priority edges: +{len(result['review_edges_added'])} / "
+		f"-{len(result['review_edges_removed'])} / ~{len(result['review_edges_changed'])}", ""]
+	coverage = result.get("coverage")
+	if coverage:
+		lines.extend(["## Coverage changes", ""])
+		lines.extend(f"- `{field}`: {change:+}" for field, change in coverage["changes"].items())
+		if coverage["regressions"]:
+			lines.extend(["", "## Coverage regressions", ""])
+			lines.extend(f"- {failure}" for failure in coverage["regressions"])
+		lines.append("")
+	if result["nodes_changed"]:
+		lines.extend(["## Changed nodes", ""])
+		for change in result["nodes_changed"][:200]:
+			before_kind = change["before"].get("kind")
+			after_kind = change["after"].get("kind")
+			transition = f" (`{before_kind}` → `{after_kind}`)" if before_kind != after_kind else ""
+			lines.append(f"- `{change['id']}`{transition}")
+		lines.append("")
+	for key, heading in (
+		("review_edges_added", "New review-priority edges"),
+		("review_edges_removed", "Removed review-priority edges"),
+	):
+		if not result[key]:
+			continue
+		lines.extend([f"## {heading}", ""])
+		for edge in result[key][:200]:
+			line = edge.get("location", {}).get("line")
+			where = f" line {line}" if line else ""
+			via = f"::{edge['method']}" if edge.get("method") else ""
+			details = semantic_details(edge)
+			detail = f", {details}" if details else ""
+			lines.append(f"- `{edge['source']}` → `{edge['target']}{via}` (`{edge['kind']}`{where}{detail})")
+		lines.append("")
+	if result["review_edges_changed"]:
+		lines.extend(["## Changed review-priority edges", ""])
+		for change in result["review_edges_changed"][:200]:
+			via = f"::{change['method']}" if change.get("method") else ""
+			lines.append(f"- `{change['source']}` → `{change['target']}{via}` (`{change['kind']}`; "
+				f"before: {variant_details(change['before'])}; after: {variant_details(change['after'])})")
+		lines.append("")
+	return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+	parser = argparse.ArgumentParser()
+	parser.add_argument("before", type=Path)
+	parser.add_argument("after", type=Path)
+	parser.add_argument("--output", type=Path)
+	parser.add_argument("--markdown", type=Path)
+	parser.add_argument("--before-coverage", type=Path)
+	parser.add_argument("--after-coverage", type=Path)
+	parser.add_argument("--coverage-thresholds", type=Path)
+	args = parser.parse_args()
+	difference = diff(json.loads(args.before.read_text()), json.loads(args.after.read_text()))
+	coverage_options = (args.before_coverage, args.after_coverage, args.coverage_thresholds)
+	if any(coverage_options) and not all(coverage_options):
+		parser.error("coverage comparison requires --before-coverage, --after-coverage, and --coverage-thresholds")
+	if all(coverage_options):
+		difference["coverage"] = compare_coverage(
+			json.loads(args.before_coverage.read_text()),
+			json.loads(args.after_coverage.read_text()),
+			json.loads(args.coverage_thresholds.read_text()),
+		)
+	result = json.dumps(difference, indent=2) + "\n"
+	if args.output:
+		args.output.write_text(result)
+	else:
+		print(result, end="")
+	if args.markdown:
+		args.markdown.write_text(markdown(difference))
+	if difference.get("coverage", {}).get("regressions"):
+		failures = "; ".join(difference["coverage"]["regressions"])
+		raise SystemExit("coverage regression check failed: " + failures)
+
+
+if __name__ == "__main__":
+	main()

--- a/scripts/runtime-interaction-graph/diff_snapshots.py
+++ b/scripts/runtime-interaction-graph/diff_snapshots.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+from pathlib import Path
+
+
+def keyed(payload: dict) -> dict:
+	return {(item["project"], item["network"], item["address"]): item for item in payload.get("observations", [])}
+
+
+def diff(before: dict, after: dict) -> dict:
+	left, right = keyed(before), keyed(after)
+	changed = []
+	for key in sorted(left.keys() & right.keys()):
+		fields = {field: {"before": left[key].get(field), "after": right[key].get(field)}
+			for field in ("has_code", "bytecode_sha256", "implementation", "embedded_addresses")
+			if left[key].get(field) != right[key].get(field)}
+		if fields:
+			changed.append({"project": key[0], "network": key[1], "address": key[2], "changes": fields})
+	return {"before": before.get("rpc_snapshot"), "after": after.get("rpc_snapshot"),
+		"added": [right[key] for key in sorted(right.keys() - left.keys())],
+		"removed": [left[key] for key in sorted(left.keys() - right.keys())], "changed": changed}
+
+
+def main() -> None:
+	parser = argparse.ArgumentParser()
+	parser.add_argument("before", type=Path)
+	parser.add_argument("after", type=Path)
+	parser.add_argument("--output", type=Path)
+	args = parser.parse_args()
+	result = json.dumps(diff(json.loads(args.before.read_text()), json.loads(args.after.read_text())), indent=2) + "\n"
+	if args.output:
+		args.output.write_text(result)
+	else:
+		print(result, end="")
+
+
+if __name__ == "__main__":
+	main()

--- a/scripts/runtime-interaction-graph/enrich_contracts_rpc.py
+++ b/scripts/runtime-interaction-graph/enrich_contracts_rpc.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+
+import argparse
+import hashlib
+import json
+import platform
+import urllib.request
+from pathlib import Path
+
+
+EIP1967_IMPLEMENTATION = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc"
+ENRICHER_VERSION = 3
+
+
+def rpc(url: str, method: str, params: list) -> object:
+	payload = json.dumps({"jsonrpc": "2.0", "id": 1, "method": method, "params": params}).encode()
+	request = urllib.request.Request(url, payload, {"Content-Type": "application/json"})
+	with urllib.request.urlopen(request, timeout=30) as response:
+		result = json.loads(response.read())
+	if "error" in result:
+		raise RuntimeError(result["error"])
+	return result["result"]
+
+
+def rpc_batch(url: str, calls: list[tuple[str, list]]) -> list[object]:
+	payload = [{"jsonrpc": "2.0", "id": index, "method": method, "params": params}
+		for index, (method, params) in enumerate(calls)]
+	request = urllib.request.Request(url, json.dumps(payload).encode(), {"Content-Type": "application/json"})
+	with urllib.request.urlopen(request, timeout=120) as response:
+		results = json.loads(response.read())
+	by_id = {item["id"]: item for item in results}
+	values = []
+	for index in range(len(calls)):
+		item = by_id.get(index)
+		if not item or "error" in item or "result" not in item:
+			raise RuntimeError(f"invalid batch RPC response for call {index}: {item!r}")
+		values.append(item["result"])
+	return values
+
+
+def block_tag(value: str) -> str:
+	if value in {"latest", "safe", "finalized"} or value.startswith("0x"):
+		return value
+	return hex(int(value))
+
+
+def validate_collection(payload: dict) -> None:
+	if payload.get("schema_version") != 2:
+		raise ValueError("deployment collection must use schema_version 2")
+	provenance = payload.get("collection_provenance")
+	if not isinstance(provenance, dict) or not provenance.get("descriptor_sha256") or not provenance.get("sources"):
+		raise ValueError("deployment collection has no verifiable source provenance")
+	if not isinstance(payload.get("contracts"), list) or not payload["contracts"]:
+		raise ValueError("deployment collection has no contracts")
+	if any(not source.get("input_sha256") for source in provenance["sources"]):
+		raise ValueError("deployment collection has an unhashed source inventory")
+	if any(not contract.get("artifact_sha256") for contract in payload["contracts"]):
+		raise ValueError("deployment collection has an unhashed contract artifact")
+	references = payload.get("address_references", [])
+	if not isinstance(references, list) or any(
+		not isinstance(reference, dict) or not reference.get("artifact_sha256") or
+		not reference.get("role") or not reference.get("field")
+		for reference in references
+	):
+		raise ValueError("deployment collection has an invalid address reference inventory")
+
+
+def enrich(payload: dict, url: str, block: str, networks: set[str], expected_chain_id: int,
+	input_sha256: str, rpc_call=rpc, rpc_batch_call=rpc_batch) -> dict:
+	validate_collection(payload)
+	if not networks:
+		raise ValueError("at least one deployment network must be selected")
+	selected = [contract for contract in payload["contracts"] if contract["network"] in networks]
+	missing_networks = networks - {contract["network"] for contract in selected}
+	if missing_networks:
+		raise ValueError(f"selected deployment networks have no contracts: {sorted(missing_networks)}")
+	chain_id = int(rpc_call(url, "eth_chainId", []), 16)
+	if chain_id != expected_chain_id:
+		raise ValueError(f"RPC chain id {chain_id} does not match expected chain id {expected_chain_id}")
+	requested_block = block_tag(block)
+	block_number = rpc_call(url, "eth_blockNumber", []) if requested_block == "latest" else requested_block
+	block_data = rpc_call(url, "eth_getBlockByNumber", [block_number, False])
+	if not block_data or not block_data.get("hash"):
+		raise RuntimeError(f"RPC returned no block for {block_number}")
+	resolved_number = int(block_data["number"], 16)
+	if requested_block not in {"latest", "safe", "finalized"} and int(requested_block, 16) != resolved_number:
+		raise RuntimeError(f"RPC returned block {resolved_number} for requested block {requested_block}")
+	known = {contract["address"].lower() for contract in selected}
+	observations = []
+	unique = {(contract["project"], contract["network"], contract["address"].lower()): contract
+		for contract in selected}
+	calls = []
+	for _, _, address in sorted(unique):
+		calls.extend([("eth_getCode", [address, block_data["number"]]),
+			("eth_getStorageAt", [address, EIP1967_IMPLEMENTATION, block_data["number"]])])
+	results = iter(rpc_batch_call(url, calls))
+	for project, network, address in sorted(unique):
+		contract = unique[(project, network, address)]
+		code = next(results)
+		implementation_word = next(results)
+		implementation = "0x" + implementation_word[-40:] if int(implementation_word, 16) else None
+		embedded = sorted(candidate for candidate in known if candidate != address and candidate[2:] in code.lower())
+		has_code = code != "0x"
+		classification = "proxy" if implementation else ("deployed" if has_code else
+			("no-code-implementation-artifact" if "implementation" in contract["name"].lower()
+			else "stale-or-undeployed-artifact"))
+		observations.append({"project": project, "network": network, "chain_id": chain_id, "address": address,
+			"chain_address_id": f"eip155:{chain_id}:{address}", "has_code": has_code,
+			"classification": classification,
+			"bytecode_sha256": hashlib.sha256(bytes.fromhex(code[2:])).hexdigest(),
+			"bytecode_size": (len(code) - 2) // 2, "implementation": implementation,
+			"implementation_chain_address_id": f"eip155:{chain_id}:{implementation}" if implementation else None,
+			"embedded_addresses": embedded})
+	return {**payload, "rpc_snapshot": {"url": url, "chain_id": chain_id,
+		"requested_block": block, "block_number": resolved_number, "block_hash": block_data["hash"],
+		"parent_hash": block_data.get("parentHash"), "state_root": block_data.get("stateRoot")},
+		"enrichment_provenance": {"tool": "enrich_contracts_rpc", "tool_version": ENRICHER_VERSION,
+			"python_version": platform.python_version(),
+			"collector_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+			"input_sha256": input_sha256,
+			"selected_networks": sorted(networks)}, "observations": observations}
+
+
+def main() -> None:
+	parser = argparse.ArgumentParser()
+	parser.add_argument("--input", type=Path, required=True)
+	parser.add_argument("--output", type=Path, required=True)
+	parser.add_argument("--rpc", required=True)
+	parser.add_argument("--block", required=True)
+	parser.add_argument("--expected-chain-id", type=int, required=True)
+	parser.add_argument("--network", action="append", required=True)
+	args = parser.parse_args()
+	input_bytes = args.input.read_bytes()
+	payload = enrich(json.loads(input_bytes), args.rpc, args.block, set(args.network), args.expected_chain_id,
+		hashlib.sha256(input_bytes).hexdigest())
+	args.output.parent.mkdir(parents=True, exist_ok=True)
+	args.output.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+	main()

--- a/scripts/runtime-interaction-graph/fixtures/ci-contracts.json
+++ b/scripts/runtime-interaction-graph/fixtures/ci-contracts.json
@@ -1,0 +1,261 @@
+{
+  "schema_version": 2,
+  "chains": [
+    {
+      "id": "hydration-mainnet-ci",
+      "evm_chain_id": 222222,
+      "substrate_genesis_hash": "0xafdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
+      "substrate_spec_name": "hydradx",
+      "runtime_configuration_minimums": {
+        "total": 4,
+        "asset_registry_erc20": 1,
+        "required_bindings": {
+          "gigaHdx.gigaHdxPoolContract": 1,
+          "hsm.flashMinter": 1,
+          "liquidation.borrowingContract": 1
+        }
+      },
+      "deployment_networks": [
+        "hydration",
+        "gigahdx"
+      ]
+    }
+  ],
+  "contracts": [
+    {
+      "project": "aave-v3-deploy",
+      "network": "hydration",
+      "name": "Pool-Proxy",
+      "address": "0x1111111111111111111111111111111111111111",
+      "artifact": "fixtures/aave/Pool-Proxy.json",
+      "abi_functions": [
+        {
+          "signature": "supply(address,uint256,address,uint16)",
+          "selector": "0x617ba037"
+        },
+        {
+          "signature": "withdraw(address,uint256,address)",
+          "selector": "0x69328dec"
+        }
+      ]
+    },
+    {
+      "project": "aave-v3-deploy",
+      "network": "hydration",
+      "name": "Pool-Implementation",
+      "address": "0x2222222222222222222222222222222222222222",
+      "artifact": "fixtures/aave/Pool-Implementation.json",
+      "abi_functions": []
+    },
+    {
+      "project": "aave-v3-deploy",
+      "network": "gigahdx",
+      "name": "GigaHDXPool",
+      "address": "0x3333333333333333333333333333333333333333",
+      "artifact": "fixtures/gigahdx/GigaHDXPool.json",
+      "abi_functions": []
+    },
+    {
+      "project": "hollar",
+      "network": "hydration",
+      "name": "HollarFlashMinter",
+      "address": "0x4444444444444444444444444444444444444444",
+      "artifact": "fixtures/hollar/HollarFlashMinter.json",
+      "abi_functions": []
+    },
+    {
+      "project": "hollar",
+      "network": "hydration",
+      "name": "BorrowingContract",
+      "address": "0x5555555555555555555555555555555555555555",
+      "artifact": "fixtures/hollar/BorrowingContract.json",
+      "abi_functions": []
+    },
+    {
+      "project": "hollar",
+      "network": "hydration",
+      "name": "BridgedAsset",
+      "address": "0x6666666666666666666666666666666666666666",
+      "artifact": "fixtures/hollar/BridgedAsset.json",
+      "abi_functions": [
+        {
+          "signature": "balanceOf(address)",
+          "selector": "0x70a08231"
+        },
+        {
+          "signature": "transfer(address,uint256)",
+          "selector": "0xa9059cbb"
+        }
+      ]
+    }
+  ],
+  "observations": [
+    {
+      "project": "aave-v3-deploy",
+      "network": "hydration",
+      "chain_id": 222222,
+      "address": "0x1111111111111111111111111111111111111111",
+      "chain_address_id": "eip155:222222:0x1111111111111111111111111111111111111111",
+      "has_code": true,
+      "implementation": "0x2222222222222222222222222222222222222222",
+      "implementation_chain_address_id": "eip155:222222:0x2222222222222222222222222222222222222222",
+      "embedded_addresses": [
+        "0x2222222222222222222222222222222222222222"
+      ]
+    },
+    {
+      "project": "aave-v3-deploy",
+      "network": "hydration",
+      "chain_id": 222222,
+      "address": "0x2222222222222222222222222222222222222222",
+      "chain_address_id": "eip155:222222:0x2222222222222222222222222222222222222222",
+      "has_code": true,
+      "implementation": null,
+      "implementation_chain_address_id": null,
+      "embedded_addresses": []
+    },
+    {
+      "project": "aave-v3-deploy",
+      "network": "gigahdx",
+      "chain_id": 222222,
+      "address": "0x3333333333333333333333333333333333333333",
+      "chain_address_id": "eip155:222222:0x3333333333333333333333333333333333333333",
+      "has_code": true,
+      "implementation": null,
+      "implementation_chain_address_id": null,
+      "embedded_addresses": []
+    },
+    {
+      "project": "hollar",
+      "network": "hydration",
+      "chain_id": 222222,
+      "address": "0x4444444444444444444444444444444444444444",
+      "chain_address_id": "eip155:222222:0x4444444444444444444444444444444444444444",
+      "has_code": true,
+      "implementation": null,
+      "implementation_chain_address_id": null,
+      "embedded_addresses": []
+    },
+    {
+      "project": "hollar",
+      "network": "hydration",
+      "chain_id": 222222,
+      "address": "0x5555555555555555555555555555555555555555",
+      "chain_address_id": "eip155:222222:0x5555555555555555555555555555555555555555",
+      "has_code": true,
+      "implementation": null,
+      "implementation_chain_address_id": null,
+      "embedded_addresses": []
+    },
+    {
+      "project": "hollar",
+      "network": "hydration",
+      "chain_id": 222222,
+      "address": "0x6666666666666666666666666666666666666666",
+      "chain_address_id": "eip155:222222:0x6666666666666666666666666666666666666666",
+      "has_code": true,
+      "implementation": null,
+      "implementation_chain_address_id": null,
+      "embedded_addresses": []
+    }
+  ],
+  "rpc_snapshot": {
+    "chain_id": 222222,
+    "block_hash": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "block_number": 13161523
+  },
+  "substrate_snapshot": {
+    "genesis_hash": "0xafdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
+    "block_hash": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "block_number": 13161523,
+    "spec_name": "hydradx"
+  },
+  "chain_context": {
+    "evm_chain_id": 222222,
+    "evm_block_hash": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "substrate_genesis_hash": "0xafdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
+    "substrate_block_hash": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "substrate_spec_name": "hydradx",
+    "block_number": 13161523
+  },
+  "collection_provenance": {
+    "descriptor_sha256": "1111111111111111111111111111111111111111111111111111111111111111"
+  },
+  "enrichment_provenance": {
+    "input_sha256": "2222222222222222222222222222222222222222222222222222222222222222"
+  },
+  "runtime_collection_provenance": {
+    "input_sha256": "3333333333333333333333333333333333333333333333333333333333333333",
+    "query_coverage": {
+      "required_query_count": 5,
+      "available_query_count": 5,
+      "collected_configuration_count": 4,
+      "unique_configuration_count": 4,
+      "queries": {
+        "gigaHdx.gigaHdxPoolContract": {
+          "available": true,
+          "calls": 1,
+          "records": 1,
+          "configurations": 1
+        },
+        "hsm.flashMinter": {
+          "available": true,
+          "calls": 1,
+          "records": 1,
+          "configurations": 1
+        },
+        "liquidation.borrowingContract": {
+          "available": true,
+          "calls": 1,
+          "records": 1,
+          "configurations": 1
+        },
+        "assetRegistry.assets": {
+          "available": true,
+          "calls": 1,
+          "records": 1,
+          "configurations": 0,
+          "erc20_assets": 1
+        },
+        "assetRegistry.assetLocations": {
+          "available": true,
+          "calls": 1,
+          "records": 1,
+          "configurations": 1
+        }
+      }
+    }
+  },
+  "runtime_configurations": [
+    {
+      "component": "pallet:gigahdx",
+      "storage": "gigaHdx.gigaHdxPoolContract",
+      "chain_id": 222222,
+      "address": "0x3333333333333333333333333333333333333333",
+      "chain_address_id": "eip155:222222:0x3333333333333333333333333333333333333333"
+    },
+    {
+      "component": "pallet:hsm",
+      "storage": "hsm.flashMinter",
+      "chain_id": 222222,
+      "address": "0x4444444444444444444444444444444444444444",
+      "chain_address_id": "eip155:222222:0x4444444444444444444444444444444444444444"
+    },
+    {
+      "component": "pallet:liquidation",
+      "storage": "liquidation.borrowingContract",
+      "chain_id": 222222,
+      "address": "0x5555555555555555555555555555555555555555",
+      "chain_address_id": "eip155:222222:0x5555555555555555555555555555555555555555"
+    },
+    {
+      "component": "pallet:asset-registry",
+      "storage": "assetRegistry.assetLocations",
+      "asset_id": "1000000",
+      "asset_type": "erc20",
+      "chain_id": 222222,
+      "address": "0x6666666666666666666666666666666666666666",
+      "chain_address_id": "eip155:222222:0x6666666666666666666666666666666666666666"
+    }
+  ]
+}

--- a/scripts/runtime-interaction-graph/fixtures/nested-tuple-abi.json
+++ b/scripts/runtime-interaction-graph/fixtures/nested-tuple-abi.json
@@ -1,0 +1,46 @@
+[
+  {
+    "type": "function",
+    "name": "bar",
+    "inputs": [
+      {
+        "name": "entries",
+        "type": "tuple[]",
+        "components": [
+          {
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "name": "values",
+            "type": "tuple[]",
+            "components": [
+              {
+                "name": "amount",
+                "type": "uint256"
+              },
+              {
+                "name": "key",
+                "type": "bytes32"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "function",
+    "name": "transfer",
+    "inputs": [
+      {
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256"
+      }
+    ]
+  }
+]

--- a/scripts/runtime-interaction-graph/graph_explorer.css
+++ b/scripts/runtime-interaction-graph/graph_explorer.css
@@ -1,0 +1,575 @@
+:root {
+	color-scheme: dark;
+	font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+	background: #070b14;
+	color: #dbe7ff;
+}
+
+* {
+	box-sizing: border-box;
+}
+
+body {
+	margin: 0;
+	min-width: 320px;
+	background:
+		radial-gradient(circle at 18% -10%, rgba(77, 113, 255, .18), transparent 34rem),
+		radial-gradient(circle at 82% 0, rgba(23, 201, 181, .1), transparent 30rem),
+		#070b14;
+}
+
+button,
+input,
+select {
+	font: inherit;
+}
+
+button,
+select,
+input {
+	border: 1px solid #263650;
+	border-radius: 9px;
+	background: #101827;
+	color: #e5efff;
+}
+
+button,
+select {
+	cursor: pointer;
+}
+
+button {
+	padding: 9px 12px;
+}
+
+button:hover,
+button:focus-visible,
+select:hover,
+select:focus-visible,
+input:focus-visible {
+	border-color: #6684ff;
+	outline: 2px solid rgba(102, 132, 255, .2);
+	outline-offset: 1px;
+}
+
+a {
+	color: #8da6ff;
+}
+
+.topbar {
+	display: grid;
+	grid-template-columns: minmax(280px, 1fr) auto auto;
+	align-items: end;
+	gap: 28px;
+	padding: 22px 28px 18px;
+	border-bottom: 1px solid #1d293d;
+	background: rgba(7, 11, 20, .84);
+	backdrop-filter: blur(14px);
+}
+
+.eyebrow {
+	margin: 0 0 2px;
+	color: #6ee7d8;
+	font-size: 11px;
+	font-weight: 750;
+	letter-spacing: .16em;
+	text-transform: uppercase;
+}
+
+h1 {
+	margin: 0;
+	font-size: clamp(24px, 3vw, 36px);
+	letter-spacing: -.04em;
+}
+
+.subtitle {
+	margin: 5px 0 0;
+	color: #8ea0ba;
+	font-size: 13px;
+}
+
+.headline-stats {
+	display: flex;
+	gap: 20px;
+}
+
+.headline-stats div {
+	display: grid;
+	gap: 1px;
+	min-width: 78px;
+}
+
+.headline-stats strong {
+	font-size: 20px;
+	font-variant-numeric: tabular-nums;
+}
+
+.headline-stats span {
+	color: #72839d;
+	font-size: 11px;
+	text-transform: uppercase;
+}
+
+nav {
+	display: flex;
+	gap: 12px;
+	padding-bottom: 3px;
+}
+
+nav a {
+	color: #a7b7cf;
+	font-size: 12px;
+	text-decoration: none;
+}
+
+nav a:hover {
+	color: #fff;
+}
+
+.app {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) 370px;
+	gap: 0;
+	min-height: calc(100vh - 110px);
+}
+
+.workspace {
+	min-width: 0;
+	padding: 16px 16px 20px;
+}
+
+.toolbar {
+	display: flex;
+	align-items: end;
+	gap: 9px;
+	position: relative;
+	z-index: 4;
+}
+
+.toolbar label:not(.check) {
+	display: grid;
+	gap: 5px;
+	color: #7f91ab;
+	font-size: 10px;
+	font-weight: 700;
+	letter-spacing: .08em;
+	text-transform: uppercase;
+}
+
+.toolbar select,
+.toolbar input {
+	height: 38px;
+	min-width: 145px;
+	padding: 0 10px;
+	font-size: 13px;
+	letter-spacing: normal;
+	text-transform: none;
+}
+
+.search-field {
+	position: relative;
+	flex: 1;
+	min-width: 190px;
+}
+
+.search-field input {
+	width: 100%;
+}
+
+.search-results {
+	display: none;
+	position: absolute;
+	top: calc(100% + 5px);
+	left: 0;
+	right: 0;
+	max-height: 340px;
+	overflow: auto;
+	padding: 5px;
+	border: 1px solid #2a3b56;
+	border-radius: 10px;
+	background: #0b1321;
+	box-shadow: 0 18px 45px rgba(0, 0, 0, .46);
+}
+
+.search-results.open {
+	display: grid;
+}
+
+.search-results button {
+	display: grid;
+	grid-template-columns: 11px minmax(0, 1fr) auto;
+	gap: 8px;
+	align-items: center;
+	width: 100%;
+	padding: 7px 8px;
+	border: 0;
+	background: transparent;
+	text-align: left;
+}
+
+.search-results button:hover,
+.search-results button:focus-visible {
+	background: #15233a;
+}
+
+.search-results button span:nth-child(2) {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.search-results small {
+	color: #6f829d;
+}
+
+.check {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	height: 38px;
+	color: #9aabc2;
+	font-size: 12px;
+	white-space: nowrap;
+}
+
+.check input {
+	width: auto;
+	height: auto;
+	min-width: 0;
+}
+
+.projection-strip {
+	display: flex;
+	justify-content: space-between;
+	gap: 20px;
+	padding: 11px 4px 9px;
+	color: #7689a5;
+	font-size: 12px;
+}
+
+.projection-strip strong {
+	color: #b6c8e3;
+	font-variant-numeric: tabular-nums;
+}
+
+.canvas-shell {
+	position: relative;
+	height: calc(100vh - 236px);
+	min-height: 520px;
+	overflow: hidden;
+	border: 1px solid #1d2a40;
+	border-radius: 15px;
+	background: rgba(6, 11, 20, .74);
+	box-shadow: inset 0 1px 0 rgba(255, 255, 255, .025), 0 22px 70px rgba(0, 0, 0, .2);
+}
+
+#graph-canvas {
+	display: block;
+	width: 100%;
+	height: 100%;
+	touch-action: none;
+	cursor: grab;
+}
+
+#graph-canvas:active {
+	cursor: grabbing;
+}
+
+#graph-canvas:focus-visible {
+	outline: 2px solid #6684ff;
+	outline-offset: -3px;
+}
+
+.canvas-hint {
+	position: absolute;
+	right: 12px;
+	bottom: 10px;
+	padding: 5px 8px;
+	border-radius: 7px;
+	background: rgba(5, 9, 17, .78);
+	color: #647792;
+	font-size: 10px;
+	pointer-events: none;
+}
+
+.legend {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 5px;
+	position: absolute;
+	top: 10px;
+	left: 10px;
+	max-width: calc(100% - 20px);
+}
+
+.legend button {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 4px 7px;
+	border-color: rgba(90, 112, 145, .34);
+	border-radius: 999px;
+	background: rgba(8, 14, 25, .84);
+	color: #9aabc2;
+	font-size: 10px;
+}
+
+.legend button.active {
+	border-color: #89a2ff;
+	color: #fff;
+}
+
+.swatch,
+.search-dot {
+	display: inline-block;
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	background: var(--color);
+}
+
+.inspector {
+	min-width: 0;
+	max-height: calc(100vh - 110px);
+	overflow: auto;
+	padding: 22px 20px 40px;
+	border-left: 1px solid #1d293d;
+	background: rgba(9, 14, 25, .88);
+}
+
+.empty-inspector {
+	display: grid;
+	place-items: center;
+	align-content: center;
+	min-height: 60vh;
+	color: #71839d;
+	text-align: center;
+}
+
+.empty-inspector span {
+	font-size: 34px;
+	color: #6684ff;
+}
+
+.empty-inspector h2 {
+	margin: 10px 0 5px;
+	color: #c9d7eb;
+	font-size: 17px;
+}
+
+.empty-inspector p {
+	max-width: 270px;
+	margin: 0;
+	font-size: 12px;
+	line-height: 1.55;
+}
+
+.inspector h2 {
+	margin: 0;
+	font-size: 19px;
+	line-height: 1.25;
+}
+
+.inspector h3 {
+	margin: 22px 0 8px;
+	color: #94a8c5;
+	font-size: 11px;
+	letter-spacing: .1em;
+	text-transform: uppercase;
+}
+
+.node-id {
+	display: block;
+	margin-top: 6px;
+	color: #6ee7d8;
+	font: 11px ui-monospace, SFMono-Regular, Menlo, monospace;
+	word-break: break-all;
+}
+
+.description {
+	color: #9cafc9;
+	font-size: 12px;
+	line-height: 1.55;
+}
+
+.metadata {
+	display: grid;
+	grid-template-columns: minmax(80px, auto) 1fr;
+	gap: 7px 12px;
+	margin: 16px 0 0;
+	font-size: 11px;
+}
+
+.metadata dt {
+	color: #657895;
+}
+
+.metadata dd {
+	margin: 0;
+	color: #b8c8dd;
+	word-break: break-word;
+}
+
+.neighbor-list {
+	display: grid;
+	gap: 5px;
+}
+
+.neighbor-list button,
+.endpoint {
+	display: grid;
+	grid-template-columns: auto minmax(0, 1fr) auto;
+	gap: 7px;
+	align-items: center;
+	width: 100%;
+	padding: 7px 8px;
+	text-align: left;
+}
+
+.neighbor-list button span:nth-child(2),
+.endpoint span:nth-child(2) {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.neighbor-list small,
+.endpoint small {
+	color: #71839d;
+}
+
+.kind-list {
+	display: grid;
+	gap: 5px;
+}
+
+.kind-row {
+	display: flex;
+	justify-content: space-between;
+	gap: 10px;
+	padding: 6px 8px;
+	border-radius: 7px;
+	background: #101a2b;
+	font: 11px ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.kind-row strong {
+	color: #7f97ff;
+}
+
+details {
+	margin-top: 16px;
+	border: 1px solid #22324a;
+	border-radius: 9px;
+	background: #0b1321;
+}
+
+summary {
+	cursor: pointer;
+	padding: 9px 10px;
+	color: #9db0ca;
+	font-size: 11px;
+}
+
+pre {
+	max-height: 360px;
+	margin: 0;
+	overflow: auto;
+	padding: 10px;
+	border-top: 1px solid #22324a;
+	color: #aebfd5;
+	font: 10px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace;
+	white-space: pre-wrap;
+	word-break: break-word;
+}
+
+.pill {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	margin: 10px 5px 0 0;
+	padding: 4px 7px;
+	border: 1px solid #283a54;
+	border-radius: 999px;
+	color: #94a8c5;
+	font-size: 10px;
+}
+
+.pill::before {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: var(--color, #71839d);
+	content: "";
+}
+
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
+noscript {
+	display: block;
+	padding: 30px;
+}
+
+@media (max-width: 1100px) {
+	.topbar {
+		grid-template-columns: 1fr auto;
+	}
+
+	.topbar nav {
+		display: none;
+	}
+
+	.app {
+		grid-template-columns: minmax(0, 1fr) 320px;
+	}
+
+	.toolbar {
+		flex-wrap: wrap;
+	}
+}
+
+@media (max-width: 780px) {
+	.topbar {
+		grid-template-columns: 1fr;
+		gap: 14px;
+	}
+
+	.headline-stats {
+		justify-content: space-between;
+	}
+
+	.app {
+		display: block;
+	}
+
+	.canvas-shell {
+		height: 62vh;
+		min-height: 430px;
+	}
+
+	.inspector {
+		max-height: none;
+		border-top: 1px solid #1d293d;
+		border-left: 0;
+	}
+
+	.empty-inspector {
+		min-height: 260px;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	* {
+		scroll-behavior: auto !important;
+	}
+}

--- a/scripts/runtime-interaction-graph/graph_explorer.js
+++ b/scripts/runtime-interaction-graph/graph_explorer.js
@@ -1,0 +1,855 @@
+"use strict";
+
+const canvas = document.querySelector("#graph-canvas");
+const shell = canvas.parentElement;
+const context = canvas.getContext("2d", { alpha: false });
+const projectionControl = document.querySelector("#projection");
+const domainControl = document.querySelector("#domain");
+const kindControl = document.querySelector("#edge-kind");
+const searchControl = document.querySelector("#search");
+const searchResults = document.querySelector("#search-results");
+const labelsControl = document.querySelector("#labels");
+const inspector = document.querySelector("#inspector");
+const legend = document.querySelector("#legend");
+const relationCount = document.querySelector("#relation-count");
+const projectionNote = document.querySelector("#projection-note");
+const liveStatus = document.querySelector("#live-status");
+const numberFormat = new Intl.NumberFormat("en-US");
+const projectionLabels = {
+	execution: "execution",
+	callback: "callbacks",
+	configuration: "configuration",
+	state: "state & invariants",
+	asset: "assets & tokens",
+	authorization: "authorization",
+	"evm-interface": "EVM interfaces",
+	deployment: "deployments",
+};
+const projectionOrder = [
+	"execution",
+	"callback",
+	"configuration",
+	"state",
+	"asset",
+	"authorization",
+	"evm-interface",
+	"deployment",
+];
+const availableProjections = [
+	...projectionOrder.filter((name) => payload.projections[name]),
+	...Object.keys(payload.projections).filter((name) => !projectionOrder.includes(name)),
+];
+const projectionDescriptions = {
+	execution: "Calls, callbacks, dispatch, XCM, EVM, and precompile execution.",
+	callback: "Dynamic and runtime-resolved callback relationships.",
+	configuration: "Runtime instances, associated bindings, weights, and configuration reads.",
+	state: "Storage access, coupled state, guards, and invariants.",
+	asset: "Balances, ORML Tokens, ERC-20, pool shares, and routed asset operations.",
+	authorization: "Configured origins and privileged entry authorization.",
+	"evm-interface": "Selectors, signatures, precompile dispatch, and contract functions.",
+	deployment: "Runtime bindings, proxies, deployed contracts, and address references.",
+};
+const domainColors = {
+	frame: "#6f8cff",
+	runtime: "#a78bfa",
+	"runtime-adapter": "#8b9cff",
+	precompile: "#f59e72",
+	evm: "#ef7aa8",
+	"evm-adapter": "#e879f9",
+	"evm-contract": "#fb7185",
+	xcm: "#3dd9c5",
+	asset: "#f7c65c",
+	state: "#65d990",
+	authorization: "#c4b5fd",
+	dynamic: "#38bdf8",
+	unspecified: "#8191a8",
+};
+const nodes = payload.nodes.map((node) => ({ ...node, x: 0, y: 0, degree: 0, radius: 6 }));
+const nodeById = new Map(nodes.map((node) => [node.id, node]));
+const edges = payload.edges.map((edge) => ({ ...edge, key: `${edge.source}\u0000${edge.target}`, weight: 0 }));
+const edgeKeys = new Set(edges.map((edge) => edge.key));
+const apiCache = new Map();
+const state = {
+	projection: payload.projections.execution?.pairs
+		? "execution"
+		: availableProjections.find((name) => payload.projections[name].pairs) || availableProjections[0],
+	domain: "",
+	kind: "",
+	selectedNode: null,
+	selectedEdge: null,
+	matchIds: new Set(),
+	showLabels: false,
+	zoom: 1,
+	panX: 0,
+	panY: 0,
+};
+let activeEdges = [];
+let activeNodes = [];
+let activeNodeIds = new Set();
+let neighborIds = new Set();
+let spatial = new Map();
+let dpr = 1;
+let width = 0;
+let height = 0;
+let gesture = null;
+let apiController = null;
+
+function formatNumber(value) {
+	return numberFormat.format(value || 0);
+}
+
+function domainColor(domain) {
+	if (domainColors[domain]) return domainColors[domain];
+	let hash = 2166136261;
+	for (const character of domain) hash = Math.imul(hash ^ character.charCodeAt(0), 16777619);
+	return `hsl(${Math.abs(hash) % 360} 62% 65%)`;
+}
+
+function stableHash(value) {
+	let hash = 2166136261;
+	for (const character of value) hash = Math.imul(hash ^ character.charCodeAt(0), 16777619);
+	return hash >>> 0;
+}
+
+function create(tag, className, text) {
+	const element = document.createElement(tag);
+	if (className) element.className = className;
+	if (text !== undefined) element.textContent = String(text);
+	return element;
+}
+
+function compactId(value, limit = 42) {
+	return value.length <= limit ? value : `${value.slice(0, limit - 1)}…`;
+}
+
+function edgeWeight(edge) {
+	if (state.kind) return edge.kind_counts[state.kind] || 0;
+	return edge.projection_counts[state.projection] || 0;
+}
+
+function fillProjectionControl() {
+	for (const projection of availableProjections) {
+		const stats = payload.projections[projection];
+		const option = new Option(`${projectionLabels[projection] || projection} · ${formatNumber(stats.nodes)}`, projection);
+		projectionControl.add(option);
+	}
+	projectionControl.value = state.projection;
+}
+
+function fillDomainControl() {
+	const domains = [...new Set(nodes.map((node) => node.domain || "unspecified"))].sort();
+	for (const domain of domains) domainControl.add(new Option(domain, domain));
+}
+
+function fillKindControl() {
+	const previous = state.kind;
+	kindControl.replaceChildren(new Option("all kinds", ""));
+	for (const kind of payload.projections[state.projection].kinds) kindControl.add(new Option(kind, kind));
+	state.kind = payload.projections[state.projection].kinds.includes(previous) ? previous : "";
+	kindControl.value = state.kind;
+}
+
+function recompute(fit = true) {
+	activeEdges = edges.filter((edge) => {
+		if (!edge.projection_counts[state.projection]) return false;
+		if (state.kind && !edge.kind_counts[state.kind]) return false;
+		if (!state.domain) return true;
+		return nodeById.get(edge.source)?.domain === state.domain || nodeById.get(edge.target)?.domain === state.domain;
+	});
+	activeNodeIds = new Set();
+	for (const edge of activeEdges) {
+		activeNodeIds.add(edge.source);
+		activeNodeIds.add(edge.target);
+		edge.weight = edgeWeight(edge);
+	}
+	activeNodes = nodes.filter((node) => activeNodeIds.has(node.id));
+	for (const node of activeNodes) node.degree = 0;
+	for (const edge of activeEdges) {
+		nodeById.get(edge.source).degree += edge.weight;
+		nodeById.get(edge.target).degree += edge.weight;
+	}
+	for (const node of activeNodes) node.radius = 5 + Math.min(9, Math.log2(node.degree + 1) * 1.6);
+	layoutNodes();
+	buildSpatialIndex();
+	const selectionRemoved = (state.selectedNode && !activeNodeIds.has(state.selectedNode)) ||
+		(state.selectedEdge && !activeEdges.includes(state.selectedEdge));
+	if (state.selectedNode && !activeNodeIds.has(state.selectedNode)) state.selectedNode = null;
+	if (state.selectedEdge && !activeEdges.includes(state.selectedEdge)) state.selectedEdge = null;
+	refreshNeighbors();
+	renderLegend();
+	updateProjectionSummary();
+	if (state.selectedNode) renderNodeInspector(nodeById.get(state.selectedNode));
+	else if (state.selectedEdge) renderEdgeInspector(state.selectedEdge);
+	else if (selectionRemoved) {
+		renderEmptyInspector();
+		updateHash();
+	}
+	if (fit) fitGraph();
+	else draw();
+}
+
+function layoutNodes() {
+	const groups = new Map();
+	for (const node of activeNodes) {
+		const domain = node.domain || "unspecified";
+		if (!groups.has(domain)) groups.set(domain, []);
+		groups.get(domain).push(node);
+	}
+	const ordered = [...groups.entries()].sort((left, right) => {
+		const count = right[1].length - left[1].length;
+		return count || left[0].localeCompare(right[0]);
+	});
+	const targetWidth = Math.max(1500, Math.sqrt(Math.max(activeNodes.length, 1)) * 72);
+	let cursorX = 0;
+	let cursorY = 0;
+	let rowHeight = 0;
+	const golden = Math.PI * (3 - Math.sqrt(5));
+	for (const [domain, group] of ordered) {
+		group.sort((left, right) => right.degree - left.degree || left.id.localeCompare(right.id));
+		const spread = Math.max(120, 20 * Math.sqrt(group.length));
+		const clusterWidth = spread * 2 + 150;
+		const clusterHeight = spread * 2 + 120;
+		if (cursorX && cursorX + clusterWidth > targetWidth) {
+			cursorX = 0;
+			cursorY += rowHeight + 90;
+			rowHeight = 0;
+		}
+		const centerX = cursorX + clusterWidth / 2;
+		const centerY = cursorY + clusterHeight / 2;
+		const phase = (stableHash(domain) % 6283) / 1000;
+		group.forEach((node, index) => {
+			const distance = index ? 19 * Math.sqrt(index) : 0;
+			const angle = phase + index * golden;
+			node.x = centerX + Math.cos(angle) * distance;
+			node.y = centerY + Math.sin(angle) * distance;
+		});
+		cursorX += clusterWidth + 70;
+		rowHeight = Math.max(rowHeight, clusterHeight);
+	}
+}
+
+function buildSpatialIndex() {
+	spatial = new Map();
+	for (const node of activeNodes) {
+		const key = `${Math.floor(node.x / 100)},${Math.floor(node.y / 100)}`;
+		if (!spatial.has(key)) spatial.set(key, []);
+		spatial.get(key).push(node);
+	}
+}
+
+function resizeCanvas() {
+	const bounds = shell.getBoundingClientRect();
+	width = Math.max(1, bounds.width);
+	height = Math.max(1, bounds.height);
+	dpr = Math.min(window.devicePixelRatio || 1, 2);
+	canvas.width = Math.floor(width * dpr);
+	canvas.height = Math.floor(height * dpr);
+	canvas.style.width = `${width}px`;
+	canvas.style.height = `${height}px`;
+	draw();
+}
+
+function fitGraph() {
+	if (!activeNodes.length || !width || !height) {
+		draw();
+		return;
+	}
+	const xs = activeNodes.map((node) => node.x);
+	const ys = activeNodes.map((node) => node.y);
+	const minX = Math.min(...xs) - 70;
+	const maxX = Math.max(...xs) + 70;
+	const minY = Math.min(...ys) - 70;
+	const maxY = Math.max(...ys) + 70;
+	state.zoom = Math.max(.08, Math.min(2.2, .9 * Math.min(width / Math.max(maxX - minX, 1), height / Math.max(maxY - minY, 1))));
+	state.panX = width / 2 - ((minX + maxX) / 2) * state.zoom;
+	state.panY = height / 2 - ((minY + maxY) / 2) * state.zoom;
+	draw();
+}
+
+function screenPoint(node) {
+	return { x: node.x * state.zoom + state.panX, y: node.y * state.zoom + state.panY };
+}
+
+function worldPoint(x, y) {
+	return { x: (x - state.panX) / state.zoom, y: (y - state.panY) / state.zoom };
+}
+
+function edgePoints(edge) {
+	const sourceNode = nodeById.get(edge.source);
+	const targetNode = nodeById.get(edge.target);
+	const source = screenPoint(sourceNode);
+	const target = screenPoint(targetNode);
+	const dx = target.x - source.x;
+	const dy = target.y - source.y;
+	const length = Math.hypot(dx, dy) || 1;
+	const ux = dx / length;
+	const uy = dy / length;
+	const reciprocal = edgeKeys.has(`${edge.target}\u0000${edge.source}`);
+	const offset = reciprocal ? (edge.source < edge.target ? 3.5 : -3.5) : 0;
+	const sourceInset = Math.min(sourceNode.radius + 1, length * .4);
+	const targetInset = Math.min(targetNode.radius + 2, length * .4);
+	return {
+		sx: source.x + ux * sourceInset - uy * offset,
+		sy: source.y + uy * sourceInset + ux * offset,
+		tx: target.x - ux * targetInset - uy * offset,
+		ty: target.y - uy * targetInset + ux * offset,
+	};
+}
+
+function drawGrid() {
+	const step = 100 * state.zoom;
+	if (step < 24) return;
+	context.strokeStyle = "rgba(80, 105, 142, .075)";
+	context.lineWidth = 1;
+	context.beginPath();
+	for (let x = ((state.panX % step) + step) % step; x < width; x += step) {
+		context.moveTo(x, 0);
+		context.lineTo(x, height);
+	}
+	for (let y = ((state.panY % step) + step) % step; y < height; y += step) {
+		context.moveTo(0, y);
+		context.lineTo(width, y);
+	}
+	context.stroke();
+}
+
+function drawArrow(points, color) {
+	const angle = Math.atan2(points.ty - points.sy, points.tx - points.sx);
+	const size = 6;
+	context.fillStyle = color;
+	context.beginPath();
+	context.moveTo(points.tx, points.ty);
+	context.lineTo(points.tx - Math.cos(angle - .55) * size, points.ty - Math.sin(angle - .55) * size);
+	context.lineTo(points.tx - Math.cos(angle + .55) * size, points.ty - Math.sin(angle + .55) * size);
+	context.closePath();
+	context.fill();
+}
+
+function drawNodeShape(node, point, color, alpha) {
+	const radius = node.radius;
+	context.globalAlpha = alpha;
+	context.fillStyle = color;
+	context.beginPath();
+	if (node.id.startsWith("boundary:") || node.kind === "execution-boundary") {
+		context.moveTo(point.x, point.y - radius - 1);
+		context.lineTo(point.x + radius + 1, point.y);
+		context.lineTo(point.x, point.y + radius + 1);
+		context.lineTo(point.x - radius - 1, point.y);
+		context.closePath();
+	} else if (node.kind === "precompile") {
+		context.rect(point.x - radius, point.y - radius, radius * 2, radius * 2);
+	} else if (["deployed-contract", "deployment-alias", "evm-address"].includes(node.kind)) {
+		context.moveTo(point.x, point.y - radius - 1);
+		context.lineTo(point.x + radius + 1, point.y + radius);
+		context.lineTo(point.x - radius - 1, point.y + radius);
+		context.closePath();
+	} else {
+		context.arc(point.x, point.y, radius, 0, Math.PI * 2);
+	}
+	context.fill();
+	context.globalAlpha = 1;
+}
+
+function draw() {
+	if (!context) return;
+	context.setTransform(dpr, 0, 0, dpr, 0, 0);
+	context.fillStyle = "#070c16";
+	context.fillRect(0, 0, width, height);
+	drawGrid();
+	const baseEdgeAlpha = activeEdges.length < 100 ? .28 : activeEdges.length < 700 ? .16 : .09;
+	for (const edge of activeEdges) {
+		const related = state.selectedNode && (edge.source === state.selectedNode || edge.target === state.selectedNode);
+		const selected = state.selectedEdge === edge;
+		const alpha = selected ? .95 : state.selectedNode ? (related ? .72 : .025) : baseEdgeAlpha;
+		const color = selected ? "#f8c15c" : related ? "#75d9ff" : "#51627c";
+		const points = edgePoints(edge);
+		if (Math.max(points.sx, points.tx) < -30 || Math.min(points.sx, points.tx) > width + 30 ||
+			Math.max(points.sy, points.ty) < -30 || Math.min(points.sy, points.ty) > height + 30) continue;
+		context.globalAlpha = alpha;
+		context.strokeStyle = color;
+		context.lineWidth = Math.min(4, .55 + Math.log2(edge.weight + 1) * .55);
+		context.beginPath();
+		context.moveTo(points.sx, points.sy);
+		context.lineTo(points.tx, points.ty);
+		context.stroke();
+		context.globalAlpha = 1;
+		if (selected || related) drawArrow(points, color);
+	}
+	const labelThreshold = activeNodes.length <= 450 && state.zoom > .55;
+	for (const node of activeNodes) {
+		const point = screenPoint(node);
+		if (point.x < -30 || point.x > width + 30 || point.y < -30 || point.y > height + 30) continue;
+		const selected = node.id === state.selectedNode;
+		const related = selected || neighborIds.has(node.id);
+		const matched = state.matchIds.has(node.id);
+		const alpha = state.selectedNode ? (related ? 1 : .14) : 1;
+		drawNodeShape(node, point, domainColor(node.domain || "unspecified"), alpha);
+		if (selected || matched) {
+			context.strokeStyle = selected ? "#fff" : "#f8d86b";
+			context.lineWidth = selected ? 2.5 : 2;
+			context.beginPath();
+			context.arc(point.x, point.y, node.radius + 4, 0, Math.PI * 2);
+			context.stroke();
+		}
+		const show = selected || matched || (state.selectedNode && related) || state.showLabels ||
+			(labelThreshold && node.degree >= 2);
+		if (!show) continue;
+		const label = compactId(node.label === node.id ? node.id : `${node.label} · ${node.id}`, 52);
+		context.font = selected ? "600 11px system-ui" : "10px system-ui";
+		const measured = context.measureText(label).width;
+		context.globalAlpha = Math.max(alpha, .72);
+		context.fillStyle = "rgba(7, 12, 22, .88)";
+		context.fillRect(point.x + node.radius + 5, point.y - 8, measured + 8, 16);
+		context.fillStyle = selected ? "#fff" : "#b8c7dc";
+		context.fillText(label, point.x + node.radius + 9, point.y + 3.5);
+		context.globalAlpha = 1;
+	}
+}
+
+function hitNode(x, y) {
+	const world = worldPoint(x, y);
+	const range = Math.max(1, Math.ceil(18 / state.zoom / 100));
+	const cellX = Math.floor(world.x / 100);
+	const cellY = Math.floor(world.y / 100);
+	let found = null;
+	let distance = Infinity;
+	for (let dx = -range; dx <= range; dx += 1) {
+		for (let dy = -range; dy <= range; dy += 1) {
+			for (const node of spatial.get(`${cellX + dx},${cellY + dy}`) || []) {
+				const point = screenPoint(node);
+				const candidate = Math.hypot(point.x - x, point.y - y);
+				if (candidate <= node.radius + 6 && candidate < distance) {
+					found = node;
+					distance = candidate;
+				}
+			}
+		}
+	}
+	return found;
+}
+
+function segmentDistance(x, y, points) {
+	const dx = points.tx - points.sx;
+	const dy = points.ty - points.sy;
+	const length = dx * dx + dy * dy || 1;
+	const position = Math.max(0, Math.min(1, ((x - points.sx) * dx + (y - points.sy) * dy) / length));
+	return Math.hypot(x - (points.sx + position * dx), y - (points.sy + position * dy));
+}
+
+function hitEdge(x, y) {
+	let found = null;
+	let distance = 7;
+	for (const edge of activeEdges) {
+		const candidate = segmentDistance(x, y, edgePoints(edge));
+		if (candidate < distance) {
+			found = edge;
+			distance = candidate;
+		}
+	}
+	return found;
+}
+
+function eventPoint(event) {
+	const bounds = canvas.getBoundingClientRect();
+	return { x: event.clientX - bounds.left, y: event.clientY - bounds.top };
+}
+
+function refreshNeighbors() {
+	neighborIds = new Set(state.selectedNode ? [state.selectedNode] : []);
+	if (!state.selectedNode) return;
+	for (const edge of activeEdges) {
+		if (edge.source === state.selectedNode) neighborIds.add(edge.target);
+		if (edge.target === state.selectedNode) neighborIds.add(edge.source);
+	}
+}
+
+function metadataList(node) {
+	const list = create("dl", "metadata");
+	const fields = ["kind", "domain", "activity", "runtime_alias", "entrypoint_kind", "network", "address",
+		"chain_address_id", "file", "source", "configured_by", "roles", "semantic_domains"];
+	for (const field of fields) {
+		if (node[field] === undefined || node[field] === null || node[field] === "") continue;
+		list.append(create("dt", "", field.replaceAll("_", " ")),
+			create("dd", "", Array.isArray(node[field]) ? node[field].join(", ") : node[field]));
+	}
+	return list;
+}
+
+function nodeButton(node, direction, edge) {
+	const button = create("button");
+	button.type = "button";
+	button.append(create("span", "", direction), create("span", "", compactId(node.id, 48)),
+		create("small", "", formatNumber(edge.weight)));
+	button.addEventListener("click", () => selectNode(node.id));
+	return button;
+}
+
+function renderNodeInspector(node) {
+	inspector.replaceChildren();
+	inspector.append(create("h2", "", node.label), create("code", "node-id", node.id));
+	const description = node.semantic_description || node.description;
+	if (description) inspector.append(create("p", "description", description));
+	const domainPill = create("span", "pill", node.domain || "unspecified");
+	domainPill.style.setProperty("--color", domainColor(node.domain || "unspecified"));
+	inspector.append(domainPill, create("span", "pill", node.kind), metadataList(node));
+	const relationships = activeEdges.filter((edge) => edge.source === node.id || edge.target === node.id)
+		.sort((left, right) => right.weight - left.weight || left.key.localeCompare(right.key));
+	inspector.append(create("h3", "", `neighbors · ${relationships.length}`));
+	const neighborList = create("div", "neighbor-list");
+	for (const edge of relationships.slice(0, 80)) {
+		const outgoing = edge.source === node.id;
+		neighborList.append(nodeButton(nodeById.get(outgoing ? edge.target : edge.source), outgoing ? "→" : "←", edge));
+	}
+	if (!relationships.length) neighborList.append(create("p", "description", "No relationships in the selected projection."));
+	inspector.append(neighborList);
+	const details = create("details");
+	details.append(create("summary", "", "bounded API metadata"));
+	const pre = create("pre", "", "loading…");
+	details.append(pre);
+	inspector.append(details);
+	loadApiNode(node.id, pre);
+}
+
+function renderEdgeInspector(edge) {
+	inspector.replaceChildren();
+	inspector.append(create("h2", "", "Directed relationship"));
+	const source = nodeById.get(edge.source);
+	const target = nodeById.get(edge.target);
+	inspector.append(create("h3", "", "endpoints"));
+	const endpoints = create("div", "neighbor-list");
+	endpoints.append(nodeButton(source, "from", edge), nodeButton(target, "to", edge));
+	inspector.append(endpoints, create("h3", "", `edge kinds · ${Object.keys(edge.kind_counts).length}`));
+	const kinds = create("div", "kind-list");
+	for (const [kind, count] of Object.entries(edge.kind_counts).sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))) {
+		const row = create("div", "kind-row");
+		row.append(create("span", "", kind), create("strong", "", formatNumber(count)));
+		kinds.append(row);
+	}
+	inspector.append(kinds);
+	const projections = create("p", "description", `Appears in: ${Object.keys(edge.projection_counts).join(", ")}. Aggregated evidence variants: ${formatNumber(edge.count)}.`);
+	inspector.append(projections);
+	const details = create("details");
+	details.open = true;
+	details.append(create("summary", "", "representative evidence by kind"),
+		create("pre", "", JSON.stringify(edge.samples, null, 2)));
+	inspector.append(details);
+}
+
+async function loadApiNode(id, target) {
+	if (apiCache.has(id)) {
+		target.textContent = apiCache.get(id);
+		return;
+	}
+	if (!/^https?:$/.test(location.protocol)) {
+		target.textContent = "API drill-down is available when this page is served by the graph container.";
+		return;
+	}
+	apiController?.abort();
+	apiController = new AbortController();
+	try {
+		const response = await fetch("api/v1/query", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ operation: "node", id, max_records: 20, max_tokens: 4000 }),
+			signal: apiController.signal,
+		});
+		if (!response.ok) throw new Error(`API returned ${response.status}`);
+		const value = await response.json();
+		const record = value.result?.records?.[0] || value;
+		const encoded = JSON.stringify(record, null, 2);
+		apiCache.set(id, encoded);
+		target.textContent = encoded;
+	} catch (error) {
+		if (error.name !== "AbortError") target.textContent = `API metadata unavailable: ${error.message}`;
+	}
+}
+
+function ensureNodeVisible(node) {
+	if (activeNodeIds.has(node.id)) return;
+	state.domain = "";
+	state.kind = "";
+	domainControl.value = "";
+	kindControl.value = "";
+	const projection = node.projections.includes(state.projection) ? state.projection : node.projections[0];
+	if (projection) {
+		state.projection = projection;
+		projectionControl.value = projection;
+		fillKindControl();
+	}
+	recompute(true);
+}
+
+function updateHash(values = {}) {
+	const parameters = new URLSearchParams(values);
+	history.replaceState(null, "", `${location.pathname}${location.search}${parameters.size ? `#${parameters}` : ""}`);
+}
+
+function selectNode(id, setHash = true) {
+	const node = nodeById.get(id);
+	if (!node) return;
+	ensureNodeVisible(node);
+	const point = screenPoint(node);
+	if (point.x < 0 || point.x > width || point.y < 0 || point.y > height) {
+		state.panX = width / 2 - node.x * state.zoom;
+		state.panY = height / 2 - node.y * state.zoom;
+	}
+	state.selectedNode = id;
+	state.selectedEdge = null;
+	refreshNeighbors();
+	renderNodeInspector(node);
+	if (setHash) updateHash({ node: id });
+	liveStatus.textContent = `Selected ${id} with ${neighborIds.size - 1} visible neighbors.`;
+	draw();
+}
+
+function selectEdge(edge, setHash = true) {
+	state.selectedNode = null;
+	state.selectedEdge = edge;
+	refreshNeighbors();
+	renderEdgeInspector(edge);
+	if (setHash) updateHash({ source: edge.source, target: edge.target });
+	liveStatus.textContent = `Selected relationship from ${edge.source} to ${edge.target}.`;
+	draw();
+}
+
+function renderEmptyInspector() {
+	const empty = create("div", "empty-inspector");
+	empty.append(
+		create("span", "", "↗"),
+		create("h2", "", "Select a node or relationship"),
+		create("p", "", "Neighbors, edge kinds, evidence samples, and bounded API metadata appear here."),
+	);
+	inspector.replaceChildren(empty);
+}
+
+function clearSelection() {
+	state.selectedNode = null;
+	state.selectedEdge = null;
+	refreshNeighbors();
+	renderEmptyInspector();
+	updateHash();
+	draw();
+}
+
+function searchRank(node, query) {
+	const id = node.id.toLowerCase();
+	const label = String(node.label).toLowerCase();
+	if (id === query || label === query) return 0;
+	if (id.startsWith(query) || label.startsWith(query)) return 1;
+	if (id.includes(query) || label.includes(query)) return 2;
+	const metadata = [node.kind, node.domain, node.runtime_alias, node.network, ...(node.names || [])].join(" ").toLowerCase();
+	return metadata.includes(query) ? 3 : Infinity;
+}
+
+function runSearch() {
+	const query = searchControl.value.trim().toLowerCase();
+	searchResults.replaceChildren();
+	if (!query) {
+		state.matchIds = new Set();
+		searchResults.classList.remove("open");
+		draw();
+		return [];
+	}
+	const matches = nodes.map((node) => ({ node, rank: searchRank(node, query) }))
+		.filter((item) => Number.isFinite(item.rank))
+		.sort((left, right) => left.rank - right.rank || right.node.degree - left.node.degree || left.node.id.localeCompare(right.node.id));
+	state.matchIds = new Set(matches.slice(0, 100).map((item) => item.node.id));
+	for (const { node } of matches.slice(0, 16)) {
+		const button = create("button");
+		const dot = create("span", "search-dot");
+		dot.style.setProperty("--color", domainColor(node.domain || "unspecified"));
+		button.append(dot, create("span", "", node.id), create("small", "", node.kind));
+		button.type = "button";
+		button.addEventListener("click", () => {
+			selectNode(node.id);
+			searchResults.classList.remove("open");
+		});
+		searchResults.append(button);
+	}
+	if (!matches.length) searchResults.append(create("span", "description", "No matching nodes."));
+	searchResults.classList.add("open");
+	draw();
+	return matches;
+}
+
+function renderLegend() {
+	legend.replaceChildren();
+	const counts = new Map();
+	for (const node of activeNodes) counts.set(node.domain || "unspecified", (counts.get(node.domain || "unspecified") || 0) + 1);
+	for (const [domain, count] of [...counts.entries()].sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))) {
+		const button = create("button", state.domain === domain ? "active" : "");
+		button.type = "button";
+		const swatch = create("span", "swatch");
+		swatch.style.setProperty("--color", domainColor(domain));
+		button.append(swatch, create("span", "", `${domain} · ${formatNumber(count)}`));
+		button.addEventListener("click", () => {
+			state.domain = state.domain === domain ? "" : domain;
+			domainControl.value = state.domain;
+			recompute(true);
+		});
+		legend.append(button);
+	}
+}
+
+function updateProjectionSummary() {
+	const evidence = activeEdges.reduce((total, edge) => total + edge.weight, 0);
+	projectionNote.textContent = projectionDescriptions[state.projection] || "Evidence-backed component relationships.";
+	relationCount.textContent = `${formatNumber(activeNodes.length)} nodes · ${formatNumber(activeEdges.length)} pairs · ${formatNumber(evidence)} evidence edges`;
+	liveStatus.textContent = relationCount.textContent;
+}
+
+function zoomAt(factor, x = width / 2, y = height / 2) {
+	const world = worldPoint(x, y);
+	state.zoom = Math.max(.05, Math.min(5, state.zoom * factor));
+	state.panX = x - world.x * state.zoom;
+	state.panY = y - world.y * state.zoom;
+	draw();
+}
+
+canvas.addEventListener("pointerdown", (event) => {
+	const point = eventPoint(event);
+	const node = hitNode(point.x, point.y);
+	gesture = { type: node ? "node" : "pan", node, startX: point.x, startY: point.y,
+		lastX: point.x, lastY: point.y, moved: false };
+	canvas.setPointerCapture(event.pointerId);
+});
+
+canvas.addEventListener("pointermove", (event) => {
+	const point = eventPoint(event);
+	if (!gesture) {
+		canvas.style.cursor = hitNode(point.x, point.y) ? "pointer" : "grab";
+		return;
+	}
+	if (Math.hypot(point.x - gesture.startX, point.y - gesture.startY) > 3) gesture.moved = true;
+	if (gesture.type === "node" && gesture.moved) {
+		const world = worldPoint(point.x, point.y);
+		gesture.node.x = world.x;
+		gesture.node.y = world.y;
+		buildSpatialIndex();
+	} else if (gesture.type === "pan") {
+		state.panX += point.x - gesture.lastX;
+		state.panY += point.y - gesture.lastY;
+	}
+	gesture.lastX = point.x;
+	gesture.lastY = point.y;
+	draw();
+});
+
+canvas.addEventListener("pointerup", (event) => {
+	const point = eventPoint(event);
+	if (gesture && !gesture.moved) {
+		if (gesture.node) selectNode(gesture.node.id);
+		else {
+			const edge = hitEdge(point.x, point.y);
+			if (edge) selectEdge(edge);
+		}
+	}
+	gesture = null;
+	canvas.releasePointerCapture(event.pointerId);
+});
+
+canvas.addEventListener("pointercancel", () => {
+	gesture = null;
+});
+
+canvas.addEventListener("wheel", (event) => {
+	event.preventDefault();
+	const point = eventPoint(event);
+	zoomAt(Math.exp(-event.deltaY * .0012), point.x, point.y);
+}, { passive: false });
+
+canvas.addEventListener("dblclick", (event) => {
+	const point = eventPoint(event);
+	const node = hitNode(point.x, point.y);
+	if (!node) return;
+	selectNode(node.id);
+	state.panX = width / 2 - node.x * state.zoom;
+	state.panY = height / 2 - node.y * state.zoom;
+	draw();
+});
+
+canvas.addEventListener("keydown", (event) => {
+	if (event.key === "Escape") clearSelection();
+	else if (event.key === "0") fitGraph();
+	else if (["+", "="].includes(event.key)) zoomAt(1.2);
+	else if (event.key === "-") zoomAt(1 / 1.2);
+	else if (event.key === "ArrowLeft") state.panX += 35;
+	else if (event.key === "ArrowRight") state.panX -= 35;
+	else if (event.key === "ArrowUp") state.panY += 35;
+	else if (event.key === "ArrowDown") state.panY -= 35;
+	else return;
+	event.preventDefault();
+	draw();
+});
+
+projectionControl.addEventListener("change", () => {
+	state.projection = projectionControl.value;
+	fillKindControl();
+	recompute(true);
+});
+
+domainControl.addEventListener("change", () => {
+	state.domain = domainControl.value;
+	recompute(true);
+});
+
+kindControl.addEventListener("change", () => {
+	state.kind = kindControl.value;
+	recompute(true);
+});
+
+labelsControl.addEventListener("change", () => {
+	state.showLabels = labelsControl.checked;
+	draw();
+});
+
+searchControl.addEventListener("input", runSearch);
+searchControl.addEventListener("keydown", (event) => {
+	if (event.key === "Enter") {
+		const first = runSearch()[0];
+		if (first) selectNode(first.node.id);
+		searchResults.classList.remove("open");
+	} else if (event.key === "Escape") {
+		searchResults.classList.remove("open");
+	}
+});
+
+document.addEventListener("pointerdown", (event) => {
+	if (!event.target.closest(".search-field")) searchResults.classList.remove("open");
+});
+document.querySelector("#fit").addEventListener("click", fitGraph);
+document.querySelector("#reset-selection").addEventListener("click", clearSelection);
+
+function restoreHash() {
+	const parameters = new URLSearchParams(location.hash.slice(1));
+	const node = parameters.get("node");
+	if (nodeById.has(node)) {
+		selectNode(node, false);
+		return;
+	}
+	const source = parameters.get("source");
+	const target = parameters.get("target");
+	const edge = edges.find((candidate) => candidate.source === source && candidate.target === target);
+	if (edge) {
+		const projection = Object.keys(edge.projection_counts)[0];
+		if (projection && projection !== state.projection) {
+			state.projection = projection;
+			projectionControl.value = projection;
+			fillKindControl();
+			recompute(true);
+		}
+		selectEdge(edge, false);
+	}
+}
+
+document.querySelector("#full-node-count").textContent = formatNumber(payload.summary.nodes.raw);
+document.querySelector("#full-edge-count").textContent = formatNumber(payload.summary.edges.raw);
+document.querySelector("#component-count").textContent = formatNumber(payload.summary.components.raw);
+fillProjectionControl();
+fillDomainControl();
+fillKindControl();
+resizeCanvas();
+recompute(true);
+restoreHash();
+if ("ResizeObserver" in window) new ResizeObserver(resizeCanvas).observe(shell);
+else window.addEventListener("resize", resizeCanvas);

--- a/scripts/runtime-interaction-graph/historical-interactions.json
+++ b/scripts/runtime-interaction-graph/historical-interactions.json
@@ -1,0 +1,12 @@
+{
+  "required_component_paths": [
+    ["pallet:route-executor", "pallet:hsm", "boundary:evm-execution"],
+    ["boundary:evm-execution", "precompile:dispatch", "boundary:frame-dispatch"]
+  ],
+  "required_runtime_properties": [
+    "call-permit-nonce-write-before-subcall",
+    "router-resolves-all-amm-backends",
+    "asset-kinds-cover-native-tokens-pool-shares-and-erc20",
+    "xcm-connects-message-and-asset-boundaries"
+  ]
+}

--- a/scripts/runtime-interaction-graph/mir_parser.py
+++ b/scripts/runtime-interaction-graph/mir_parser.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import hashlib
+import re
+
+
+MIR_FUNCTION = re.compile(r"^fn\s+(.+?)\(.*\)\s*->\s*.+\s*\{$")
+SOURCE_LOCATION = re.compile(r"(?:<impl|\{closure)\s+at\s+([^:]+(?:/[^:]+)*\.rs):(\d+):\d+")
+BLOCK = re.compile(r"^bb(\d+):\s*\{")
+CALL_TARGET = re.compile(r"(?:^|=\s*)([A-Za-z_<][^=;]*?)\s*\(.*\)\s*->\s*\[")
+
+
+def symbol_name(symbol: str) -> str:
+	without_closures = symbol.split("::{closure", 1)[0]
+	name = without_closures.rsplit("::", 1)[-1]
+	return name.split("{", 1)[0].strip()
+
+
+def source_location(symbol: str) -> tuple[str | None, int | None]:
+	match = SOURCE_LOCATION.search(symbol)
+	return (match.group(1), int(match.group(2))) if match else (None, None)
+
+
+def instance_id(symbol: str) -> str:
+	return hashlib.sha256(symbol.encode()).hexdigest()[:16]
+
+
+def call_target(statement: str) -> str | None:
+	match = CALL_TARGET.search(statement)
+	if not match:
+		return None
+	target = match.group(1).strip()
+	if target.startswith(("switchInt", "assert", "drop")):
+		return None
+	return target
+
+
+def operation(statement: str) -> dict | None:
+	target = call_target(statement)
+	if "start_transaction" in statement or "with_transaction" in statement:
+		kind = "transaction-start"
+	elif "::commit_transaction(" in statement:
+		kind = "transaction-commit"
+	elif "::rollback_transaction(" in statement:
+		kind = "transaction-rollback"
+	elif re.search(r"(?:Counted)?Storage(?:Map|NMap|Value|DoubleMap).*::(?:insert|remove|take|put|mutate|try_mutate|append|clear)", statement):
+		kind = "storage-write"
+	elif re.search(r"(?:Counted)?Storage(?:Map|NMap|Value|DoubleMap).*::(?:get|contains_key|iter)", statement):
+		kind = "storage-read"
+	elif "hydradx_traits::evm::EVM" in statement and ">::call" in statement:
+		kind = "evm-call"
+	elif target and re.search(r"::(?:dispatch|try_dispatch)$", target):
+		kind = "frame-dispatch"
+	elif target and re.search(r"::(?:transfer|deposit|withdraw|mint_into|burn_from)$", target):
+		kind = "external-call"
+	elif target:
+		kind = "call"
+	else:
+		return None
+	return {"kind": kind, "statement": statement, "callee": target}
+
+
+def successors(statement: str) -> tuple[list[int], list[int]]:
+	all_targets = [int(value) for value in re.findall(r"\bbb(\d+)\b", statement)]
+	unwind_match = re.search(r"unwind:\s*bb(\d+)", statement)
+	unwind = [int(unwind_match.group(1))] if unwind_match else []
+	normal = []
+	removed_unwind = False
+	for target in all_targets:
+		if unwind and target == unwind[0] and not removed_unwind:
+			removed_unwind = True
+			continue
+		normal.append(target)
+	return list(dict.fromkeys(normal)), unwind
+
+
+def parse(text: str) -> list[dict]:
+	instances = []
+	current = None
+	current_block = None
+	statement_parts: list[str] = []
+
+	def consume_statement() -> None:
+		nonlocal statement_parts
+		if current is None or current_block is None or not statement_parts:
+			statement_parts = []
+			return
+		statement = " ".join(statement_parts)
+		statement_parts = []
+		item = operation(statement)
+		if item:
+			current["blocks"][current_block]["operations"].append(item)
+		normal, unwind = successors(statement)
+		current["blocks"][current_block]["normal_successors"].extend(normal)
+		current["blocks"][current_block]["unwind_successors"].extend(unwind)
+
+	def finish() -> None:
+		nonlocal current, current_block
+		consume_statement()
+		if current is not None:
+			for block in current["blocks"].values():
+				block["normal_successors"] = list(dict.fromkeys(block["normal_successors"]))
+				block["unwind_successors"] = list(dict.fromkeys(block["unwind_successors"]))
+			instances.append(current)
+		current = None
+		current_block = None
+
+	for raw_line in text.splitlines():
+		function = MIR_FUNCTION.match(raw_line)
+		if function:
+			finish()
+			symbol = function.group(1)
+			file, impl_line = source_location(symbol)
+			current = {"id": instance_id(symbol), "symbol": symbol, "name": symbol_name(symbol),
+				"source_file": file, "impl_line": impl_line, "blocks": {}}
+			continue
+		if current is None:
+			continue
+		block = BLOCK.match(raw_line.strip())
+		if block:
+			consume_statement()
+			current_block = int(block.group(1))
+			current["blocks"][current_block] = {"operations": [], "normal_successors": [],
+				"unwind_successors": []}
+			continue
+		if raw_line == "}":
+			finish()
+			continue
+		if current_block is None:
+			continue
+		line = raw_line.strip()
+		if not line or line == "}":
+			continue
+		statement_parts.append(line)
+		if line.endswith(";"):
+			consume_statement()
+	finish()
+	return instances
+
+
+def order_flags(blocks: dict[int, dict], successor_kind: str = "normal_successors") -> tuple[bool, bool]:
+	before = after = False
+	queue = [(0, False, False)]
+	seen = set()
+	while queue:
+		block_id, wrote, external = queue.pop(0)
+		state = (block_id, wrote, external)
+		if state in seen or block_id not in blocks:
+			continue
+		seen.add(state)
+		for item in blocks[block_id]["operations"]:
+			if item["kind"] in {"external-call", "evm-call", "frame-dispatch"}:
+				before |= wrote
+				external = True
+			elif item["kind"] == "storage-write":
+				after |= external
+				wrote = True
+		for target in blocks[block_id].get(successor_kind, []):
+			queue.append((target, wrote, external))
+	return before, after

--- a/scripts/runtime-interaction-graph/query-response.schema.json
+++ b/scripts/runtime-interaction-graph/query-response.schema.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hydration.net/schemas/runtime-interaction-graph-query-response.schema.json",
+  "title": "Runtime interaction graph query response",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "tool",
+    "graph",
+    "query",
+    "result",
+    "truncated",
+    "truncation_reasons",
+    "warnings",
+    "budget"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "tool": {
+      "const": "runtime-interaction-graph-query"
+    },
+    "graph": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fingerprint", "companions"],
+      "properties": {
+        "fingerprint": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["algorithm", "value"],
+          "properties": {
+            "algorithm": {
+              "const": "sha256"
+            },
+            "value": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "pattern": "^[0-9a-f]{64}$"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        "companions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          }
+        }
+      }
+    },
+    "query": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["operation", "parameters"],
+      "properties": {
+        "operation": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "object"
+        }
+      }
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["matched", "returned", "total_is_exact", "omitted", "records", "metadata"],
+      "properties": {
+        "matched": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "returned": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "total_is_exact": {
+          "type": "boolean"
+        },
+        "omitted": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 0
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "records": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "metadata": {
+          "type": "object"
+        }
+      }
+    },
+    "truncated": {
+      "type": "boolean"
+    },
+    "truncation_reasons": {
+      "type": "array",
+      "items": {
+        "enum": [
+          "depth-limit",
+          "expansion-limit",
+          "field-limit",
+          "path-limit",
+          "record-limit",
+          "token-limit"
+        ]
+      },
+      "uniqueItems": true
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["code", "severity", "message"],
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "severity": {
+            "enum": ["error", "info", "warning"]
+          },
+          "message": {
+            "type": "string"
+          },
+          "details": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["max_records", "max_tokens", "estimation", "estimated_tokens"],
+      "properties": {
+        "max_records": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "max_tokens": {
+          "type": "integer",
+          "minimum": 256
+        },
+        "estimation": {
+          "const": "ceil(serialized ASCII characters / 4)"
+        },
+        "estimated_tokens": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  }
+}

--- a/scripts/runtime-interaction-graph/query_graph.py
+++ b/scripts/runtime-interaction-graph/query_graph.py
@@ -1,0 +1,1028 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import sys
+from collections import Counter, defaultdict, deque
+from pathlib import Path
+
+
+SCHEMA_VERSION = 1
+TOOL = "runtime-interaction-graph-query"
+DEFAULT_MAX_RECORDS = 50
+DEFAULT_MAX_TOKENS = 4_000
+MAX_QUERY_LENGTH = 512
+ACTIVITY_POLICY = (
+	"exclude explicit inactive (including inherited owner/function false); "
+	"retain missing as unclassified"
+)
+
+
+class QueryFailure(ValueError):
+	def __init__(self, code: str, message: str) -> None:
+		super().__init__(message)
+		self.code = code
+
+
+def json_key(value: object) -> str:
+	return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def load_json(path: Path, expected: type, label: str) -> object:
+	try:
+		value = json.loads(path.read_text())
+	except (OSError, json.JSONDecodeError) as error:
+		raise QueryFailure(f"invalid-{label}", f"cannot load {label} from {path}: {error}") from error
+	if not isinstance(value, expected):
+		raise QueryFailure(f"invalid-{label}", f"{label} must contain a JSON {expected.__name__}")
+	return value
+
+
+class GraphIndex:
+	def __init__(self, payload: dict) -> None:
+		if payload.get("schema_version") != 2:
+			raise QueryFailure("invalid-graph", "graph must use schema_version 2")
+		nodes = payload.get("nodes")
+		edges = payload.get("edges")
+		if not isinstance(nodes, list) or not isinstance(edges, list):
+			raise QueryFailure("invalid-graph", "graph must contain node and edge arrays")
+		self.nodes: dict[str, dict] = {}
+		for node in nodes:
+			if not isinstance(node, dict) or not isinstance(node.get("id"), str) or not node["id"]:
+				raise QueryFailure("invalid-graph", "every graph node must have a non-empty string id")
+			if node["id"] in self.nodes:
+				raise QueryFailure("invalid-graph", f"duplicate graph node: {node['id']}")
+			self.nodes[node["id"]] = node
+		self.edges = []
+		for edge in edges:
+			if not isinstance(edge, dict) or any(not isinstance(edge.get(field), str) or not edge[field]
+				for field in ("source", "target", "kind")):
+				raise QueryFailure("invalid-graph", "every graph edge must have source, target, and kind strings")
+			if edge["source"] not in self.nodes or edge["target"] not in self.nodes:
+				raise QueryFailure("invalid-graph",
+					f"dangling graph edge: {edge['source']} -> {edge['target']}")
+			self.edges.append(edge)
+		self.edges.sort(key=lambda edge: (
+			edge["source"], edge["target"], edge["kind"], json_key(edge)))
+		self.node_search_text = {ident: json_key(node).casefold() for ident, node in self.nodes.items()}
+		self.edge_search_text = {json_key(edge): json_key(edge).casefold() for edge in self.edges}
+		self.edge_fingerprints = {key: hashlib.sha256(key.encode()).hexdigest()
+			for key in self.edge_search_text}
+		self.outgoing: dict[str, list[dict]] = defaultdict(list)
+		self.incoming: dict[str, list[dict]] = defaultdict(list)
+		for edge in self.edges:
+			self.outgoing[edge["source"]].append(edge)
+			self.incoming[edge["target"]].append(edge)
+
+	def node_activity(self, node: dict) -> str:
+		if node.get("runtime_active") is False:
+			return "inactive"
+		for field in ("owner", "function"):
+			dependency = node.get(field)
+			if isinstance(dependency, str) and self.nodes.get(dependency, {}).get("runtime_active") is False:
+				return "inactive"
+		return "active" if node.get("runtime_active") is True else "unclassified"
+
+	def node_operational(self, node: dict) -> bool:
+		return self.node_activity(node) != "inactive"
+
+	def edge_activity(self, edge: dict) -> str:
+		statuses = {self.node_activity(self.nodes[edge[endpoint]]) for endpoint in ("source", "target")}
+		if "inactive" in statuses:
+			return "inactive"
+		return "active" if statuses == {"active"} else "unclassified"
+
+	def edge_operational(self, edge: dict) -> bool:
+		return self.edge_activity(edge) != "inactive"
+
+	def evidence_fingerprint(self, edge: dict) -> str:
+		return self.edge_fingerprints[json_key(edge)]
+
+
+def edge_fingerprint(edge: dict) -> str:
+	return hashlib.sha256(json_key(edge).encode()).hexdigest()
+
+
+def graph_fingerprint(path: Path) -> str | None:
+	try:
+		return hashlib.sha256(path.read_bytes()).hexdigest()
+	except OSError:
+		return None
+
+
+def companion_path(graph: Path, explicit: Path | None, filename: str, auto: bool) -> Path | None:
+	if explicit is not None:
+		if not explicit.is_file():
+			raise QueryFailure("missing-companion", f"companion file does not exist: {explicit}")
+		return explicit
+	candidate = graph.parent / filename
+	return candidate if auto and candidate.is_file() else None
+
+
+def load_companions(args: argparse.Namespace) -> tuple[dict[str, dict | None], dict[str, str]]:
+	auto = not args.no_auto_companions
+	paths = {
+		"coverage": companion_path(args.graph, args.coverage, "coverage.json", auto),
+		"completeness": companion_path(args.graph, args.completeness, "completeness.json", auto),
+		"query_packs": companion_path(args.graph, args.query_packs, "query-packs.json", auto),
+		"component_graph": companion_path(args.graph, args.component_graph, "component-graph.json", auto),
+	}
+	companions = {name: load_json(path, dict, name.replace("_", "-")) if path else None
+		for name, path in paths.items()}
+	fingerprints = {name: hashlib.sha256(path.read_bytes()).hexdigest()
+		for name, path in paths.items() if path is not None}
+	return companions, fingerprints
+
+
+def warning(code: str, severity: str, message: str, **details: object) -> dict:
+	result = {"code": code, "severity": severity, "message": message}
+	if details:
+		result["details"] = details
+	return result
+
+
+def companion_warnings(companions: dict[str, dict | None], index: GraphIndex | None = None) -> list[dict]:
+	result = []
+	coverage = companions.get("coverage")
+	if coverage is None:
+		result.append(warning("coverage-unavailable", "info", "coverage.json was not loaded"))
+	else:
+		unresolved = coverage.get("unresolved_targets")
+		if isinstance(unresolved, int) and unresolved:
+			result.append(warning("unresolved-targets", "warning",
+				f"coverage reports {unresolved} unresolved runtime targets", count=unresolved))
+		inventory = coverage.get("inventory_only_targets")
+		if isinstance(inventory, int) and inventory:
+			result.append(warning("inventory-only-targets", "info",
+				f"coverage reports {inventory} inventory-only targets", count=inventory))
+		failed = coverage.get("mir_packages_failed")
+		if isinstance(failed, int) and failed:
+			result.append(warning("mir-packages-failed", "warning",
+				f"coverage reports {failed} failed MIR packages", count=failed))
+		if index is not None:
+			for field, actual in (("nodes", len(index.nodes)), ("edges", len(index.edges))):
+				reported = coverage.get(field)
+				if isinstance(reported, int) and reported != actual:
+					result.append(warning("companion-count-mismatch", "warning",
+						f"coverage {field} count does not match the loaded graph",
+						companion="coverage", field=field, reported=reported, actual=actual))
+	completeness = companions.get("completeness")
+	if completeness is None:
+		result.append(warning("completeness-unavailable", "info", "completeness.json was not loaded"))
+	else:
+		missing = completeness.get("source_components_without_entrypoints")
+		if isinstance(missing, list) and missing:
+			result.append(warning("components-without-entrypoints", "info",
+				f"completeness reports {len(missing)} source components without entrypoints", count=len(missing)))
+		historical = completeness.get("historical_properties")
+		if isinstance(historical, dict):
+			failed_properties = sorted(str(name) for name, present in historical.items() if present is False)
+			if failed_properties:
+				result.append(warning("historical-properties-missing", "warning",
+					f"{len(failed_properties)} historical graph properties are missing",
+					properties=failed_properties[:20]))
+		path_search = completeness.get("path_search")
+		if isinstance(path_search, dict):
+			limited = path_search.get("limit_truncated_starts", [])
+			depth = path_search.get("depth_truncated_starts", [])
+			if isinstance(limited, list) and isinstance(depth, list) and (limited or depth):
+				result.append(warning("stored-path-search-truncated", "info",
+					"stored path search reports truncated starts",
+					limit_truncated=len(limited), depth_truncated=len(depth)))
+	query_packs = companions.get("query_packs")
+	if query_packs is not None and query_packs.get("schema_version") != 1:
+		result.append(warning("query-packs-schema-mismatch", "warning",
+			"query-packs.json is missing or does not use schema_version 1",
+			expected=1, actual=query_packs.get("schema_version")))
+	return sorted(result, key=lambda item: (item["severity"], item["code"], item["message"]))
+
+
+def activity_warnings(index: GraphIndex) -> list[dict]:
+	unclassified_nodes = sum(index.node_activity(node) == "unclassified" for node in index.nodes.values())
+	unclassified_edges = sum(index.edge_activity(edge) == "unclassified" for edge in index.edges)
+	if not unclassified_nodes and not unclassified_edges:
+		return []
+	return [warning("runtime-activity-unclassified", "info",
+		"missing runtime_active metadata is retained as unclassified and is not treated as explicit active evidence",
+		nodes=unclassified_nodes, edges=unclassified_edges,
+		operational_policy="exclude only explicit inactive nodes and their dependants")]
+
+
+def compact_value(value: object, depth: int = 0, max_depth: int = 6,
+	max_items: int = 20, max_string: int = 256) -> object:
+	if depth >= max_depth and isinstance(value, (dict, list)):
+		return {"_truncated": "depth"}
+	if isinstance(value, dict):
+		items = sorted(value.items(), key=lambda item: str(item[0]))
+		result = {str(key): compact_value(item, depth + 1, max_depth, max_items, max_string)
+			for key, item in items[:max_items]}
+		if len(items) > max_items:
+			result["_truncated_fields"] = len(items) - max_items
+		return result
+	if isinstance(value, list):
+		result = [compact_value(item, depth + 1, max_depth, max_items, max_string)
+			for item in value[:max_items]]
+		if len(value) > max_items:
+			result.append({"_truncated_items": len(value) - max_items})
+		return result
+	if isinstance(value, str) and len(value) > max_string:
+		return f"{value[:max_string]}...[{len(value) - max_string} chars omitted]"
+	return value
+
+
+def minimal_node(node: dict) -> dict:
+	return {key: node[key] for key in ("id", "kind", "name", "owner", "file", "runtime_active")
+		if key in node}
+
+
+def minimal_edge(edge: dict, evidence_sha256: str | None = None) -> dict:
+	return {**{key: edge[key] for key in ("source", "target", "kind", "method", "file", "line")
+		if key in edge}, "_evidence_sha256": evidence_sha256 or edge.get("_evidence_sha256")
+		or edge_fingerprint(edge)}
+
+
+def minimal_record(record: dict) -> dict:
+	record_type = record.get("record_type")
+	if record_type == "node" and isinstance(record.get("node"), dict):
+		return {"record_type": "node", "node": minimal_node(record["node"]),
+			"runtime_activity": record.get("runtime_activity"), "_record_truncated": True}
+	if record_type == "edge" and isinstance(record.get("edge"), dict):
+		return {"record_type": "edge",
+			"edge": minimal_edge(record["edge"], record.get("evidence_sha256")),
+			"runtime_activity": record.get("runtime_activity"),
+			"evidence_sha256": record.get("evidence_sha256"), "_record_truncated": True}
+	if record_type == "neighbor":
+		return {"record_type": "neighbor", "depth": record.get("depth"),
+			"from": record.get("from"), "to": record.get("to"),
+			"relation": record.get("relation"),
+			"node": minimal_node(record.get("node", {})),
+			"edge": minimal_edge(record.get("edge", {}), record.get("evidence_sha256")),
+			"node_runtime_activity": record.get("node_runtime_activity"),
+			"edge_runtime_activity": record.get("edge_runtime_activity"),
+			"evidence_sha256": record.get("evidence_sha256"),
+			"_record_truncated": True}
+	if record_type == "path":
+		return {"record_type": "path", "length": record.get("length"), "nodes": record.get("nodes", []),
+			"steps": [{"from": step.get("from"), "to": step.get("to"),
+				"edge_runtime_activity": step.get("edge_runtime_activity"),
+				"edge_kind": step.get("edge_kind"), "edge_kinds": step.get("edge_kinds", []),
+				"traversal": step.get("traversal"), "traversals": step.get("traversals", []),
+				"evidence_count": step.get("evidence_count"),
+				"evidence_sha256": step.get("evidence_sha256"),
+				"evidence_sha256s": step.get("evidence_sha256s", []),
+				"edge": minimal_edge(step.get("edge", {}), step.get("evidence_sha256"))}
+				for step in record.get("steps", [])],
+			"_record_truncated": True}
+	result = {"_record_truncated": True}
+	for key, value in sorted(record.items()):
+		if key in {"record_type", "section", "key", "count", "type"} or isinstance(value, (bool, int, float)):
+			result[key] = value
+	return result
+
+
+def encode_envelope(envelope: dict) -> tuple[str, int]:
+	estimate = 0
+	for _ in range(6):
+		envelope["budget"]["estimated_tokens"] = estimate
+		text = json.dumps(envelope, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+		updated = math.ceil((len(text) + 1) / 4)
+		if updated == estimate:
+			return text, estimate
+		estimate = updated
+	envelope["budget"]["estimated_tokens"] = estimate
+	text = json.dumps(envelope, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+	return text, math.ceil((len(text) + 1) / 4)
+
+
+def render_envelope(operation: str, parameters: dict, records: list[dict], matched: int,
+	warnings: list[dict], reasons: list[str], max_records: int, max_tokens: int,
+	result_metadata: dict | None = None, graph_sha256: str | None = None,
+	companion_sha256: dict[str, str] | None = None, total_is_exact: bool = True) -> str:
+	reason_set = set(reasons)
+	if len(records) > max_records:
+		reason_set.add("record-limit")
+	candidate_count = min(len(records), max_records)
+	raw_query = {"operation": operation, "parameters": parameters}
+	query = compact_value(raw_query, max_items=30, max_string=128)
+	severity_order = {"error": 0, "warning": 1, "info": 2}
+	warnings = sorted(warnings, key=lambda item: (
+		severity_order.get(str(item.get("severity")), 3), str(item.get("code")), str(item.get("message"))))
+	warnings_selected = [compact_value(item, max_items=10, max_string=160) for item in warnings]
+	raw_metadata = result_metadata or {}
+	metadata = compact_value(raw_metadata, max_items=20, max_string=128)
+	base_field_limited = query != raw_query or metadata != raw_metadata \
+		or any(compacted != original for compacted, original in zip(warnings_selected, warnings))
+	max_characters = max_tokens * 4 - 1
+	companion_sha256 = dict(sorted((companion_sha256 or {}).items()))
+	compacted_records: list[dict] = []
+	record_field_limited: list[bool] = []
+
+	def prepare(count: int) -> None:
+		while len(compacted_records) < count:
+			raw = records[len(compacted_records)]
+			compacted = compact_value(raw)
+			compacted_records.append(compacted)
+			record_field_limited.append(compacted != raw)
+
+	def build(selected: list[dict], token_limited: bool,
+		forced_field_limit: bool = False) -> dict:
+		selected_reasons = set(reason_set)
+		if token_limited:
+			selected_reasons.add("token-limit")
+		if base_field_limited or forced_field_limit \
+			or any(record_field_limited[:len(selected)]):
+			selected_reasons.add("field-limit")
+		return {
+			"schema_version": SCHEMA_VERSION,
+			"tool": TOOL,
+			"graph": {"fingerprint": {"algorithm": "sha256", "value": graph_sha256},
+				"companions": companion_sha256},
+			"query": query,
+			"result": {"matched": matched, "returned": len(selected), "records": selected,
+				"total_is_exact": total_is_exact,
+				"omitted": max(0, matched - len(selected)) if total_is_exact else None,
+				"metadata": metadata},
+			"truncated": bool(selected_reasons),
+			"truncation_reasons": sorted(selected_reasons),
+			"warnings": warnings_selected,
+			"budget": {"max_records": max_records, "max_tokens": max_tokens,
+				"estimation": "ceil(serialized ASCII characters / 4)", "estimated_tokens": 0},
+		}
+
+	def probe(count: int, token_limited: bool, replacement: dict | None = None) -> tuple[bool, str]:
+		prepare(count)
+		selected = compacted_records[:count]
+		forced_field_limit = False
+		if replacement is not None and selected:
+			selected[-1] = replacement
+			forced_field_limit = True
+		envelope = build(selected, token_limited, forced_field_limit)
+		text, estimated = encode_envelope(envelope)
+		return len(text) <= max_characters and estimated <= max_tokens, text
+
+	base_fits, empty_without_token_limit = probe(0, False)
+	token_base_fits, empty_with_token_limit = probe(0, True)
+	if not token_base_fits:
+		while len(warnings_selected) > 1 and not token_base_fits:
+			warnings_selected.pop()
+			base_field_limited = True
+			token_base_fits, empty_with_token_limit = probe(0, True)
+		if not token_base_fits:
+			query = compact_value(query, max_items=10, max_string=48)
+			metadata = compact_value(metadata, max_items=8, max_string=48)
+			base_field_limited = True
+			token_base_fits, empty_with_token_limit = probe(0, True)
+		if not token_base_fits and warnings_selected \
+			and warnings_selected[0].get("severity") != "error":
+			warnings_selected.clear()
+			base_field_limited = True
+			token_base_fits, empty_with_token_limit = probe(0, True)
+		if not token_base_fits and warnings_selected:
+			warnings_selected[:] = [compact_value(warnings_selected[0], max_items=4, max_string=24)]
+			base_field_limited = True
+			token_base_fits, empty_with_token_limit = probe(0, True)
+		if not token_base_fits:
+			metadata = {key: value for key, value in metadata.items() if key == "error"}
+			base_field_limited = True
+			token_base_fits, empty_with_token_limit = probe(0, True)
+		if not token_base_fits:
+			minimal_parameters = {key: value for key, value in query.get("parameters", {}).items()
+				if key == "batch_index"}
+			query = {"operation": query.get("operation", operation), "parameters": minimal_parameters}
+			base_field_limited = True
+			token_base_fits, empty_with_token_limit = probe(0, True)
+		if not token_base_fits:
+			raise QueryFailure("token-budget-too-small", "token budget cannot fit the response envelope")
+
+	if candidate_count == 0:
+		return empty_without_token_limit if base_fits else empty_with_token_limit
+
+	low = 0
+	high = 1
+	best_text = empty_with_token_limit
+	failure = candidate_count
+	while low < candidate_count:
+		count = min(high, candidate_count)
+		fits, text = probe(count, count < candidate_count)
+		if fits:
+			low = count
+			best_text = text
+			if count == candidate_count:
+				return text
+			high = min(candidate_count, count * 2)
+			continue
+		failure = count
+		break
+
+	left, right = low + 1, failure - 1
+	while left <= right:
+		middle = (left + right) // 2
+		fits, text = probe(middle, True)
+		if fits:
+			low = middle
+			best_text = text
+			left = middle + 1
+		else:
+			right = middle - 1
+
+	if low < candidate_count:
+		prepare(low + 1)
+		minimal = minimal_record(compacted_records[low])
+		if minimal != compacted_records[low]:
+			fits, text = probe(low + 1, True, minimal)
+			if fits:
+				return text
+	if low:
+		fits, text = probe(low, True)
+		if fits:
+			return text
+	return best_text
+
+
+def require_text(request: dict, field: str) -> str:
+	value = request.get(field)
+	if not isinstance(value, str) or not value.strip():
+		raise QueryFailure("invalid-query", f"{field} must be a non-empty string")
+	if len(value) > MAX_QUERY_LENGTH:
+		raise QueryFailure("invalid-query", f"{field} exceeds {MAX_QUERY_LENGTH} characters")
+	return value
+
+
+def choice(request: dict, field: str, default: str, allowed: set[str]) -> str:
+	value = request.get(field, default)
+	if not isinstance(value, str) or value not in allowed:
+		raise QueryFailure("invalid-query", f"{field} must be one of: {', '.join(sorted(allowed))}")
+	return value
+
+
+def bounded_int(request: dict, field: str, default: int, minimum: int, maximum: int) -> int:
+	value = request.get(field, default)
+	if not isinstance(value, int) or isinstance(value, bool) or not minimum <= value <= maximum:
+		raise QueryFailure("invalid-query", f"{field} must be an integer from {minimum} to {maximum}")
+	return value
+
+
+def string_list(request: dict, field: str) -> list[str]:
+	value = request.get(field, [])
+	if value is None:
+		return []
+	if not isinstance(value, list) or any(not isinstance(item, str) or not item for item in value):
+		raise QueryFailure("invalid-query", f"{field} must be an array of non-empty strings")
+	return sorted(set(value))
+
+
+def boolean(request: dict, field: str, default: bool = False) -> bool:
+	value = request.get(field, default)
+	if not isinstance(value, bool):
+		raise QueryFailure("invalid-query", f"{field} must be a boolean")
+	return value
+
+
+def summary(index: GraphIndex, companions: dict[str, dict | None]) -> tuple[list[dict], int, list[str], dict]:
+	activity_nodes = Counter(index.node_activity(node) for node in index.nodes.values())
+	activity_edges = Counter(index.edge_activity(edge) for edge in index.edges)
+	operational_nodes = [node for node in index.nodes.values() if index.node_operational(node)]
+	operational_edges = [edge for edge in index.edges if index.edge_operational(edge)]
+	records = [
+		{"record_type": "summary", "section": "graph",
+			"nodes": len(index.nodes), "operational_nodes": len(operational_nodes),
+			"edges": len(index.edges), "operational_edges": len(operational_edges),
+			"node_runtime_activity": dict(sorted(activity_nodes.items())),
+			"edge_runtime_activity": dict(sorted(activity_edges.items()))},
+		{"record_type": "summary", "section": "node_kinds",
+			"raw": dict(sorted(Counter(node.get("kind", "unknown") for node in index.nodes.values()).items())),
+			"operational": dict(sorted(Counter(node.get("kind", "unknown") for node in operational_nodes).items()))},
+		{"record_type": "summary", "section": "edge_kinds",
+			"raw": dict(sorted(Counter(edge["kind"] for edge in index.edges).items())),
+			"operational": dict(sorted(Counter(edge["kind"] for edge in operational_edges).items()))},
+		{"record_type": "summary", "section": "domains",
+			"raw": dict(sorted(Counter(str(node.get("domain", "unspecified"))
+				for node in index.nodes.values()).items())),
+			"operational": dict(sorted(Counter(str(node.get("domain", "unspecified"))
+				for node in operational_nodes).items()))},
+	]
+	coverage = companions.get("coverage")
+	if coverage is not None:
+		records.append({"record_type": "summary", "section": "coverage", "value": coverage})
+	completeness = companions.get("completeness")
+	if completeness is not None:
+		records.append({"record_type": "summary", "section": "completeness",
+			"value": {key: value for key, value in completeness.items()
+				if key != "source_components_without_entrypoints"},
+			"source_components_without_entrypoints": len(
+				completeness.get("source_components_without_entrypoints", []))})
+	packs = companions.get("query_packs")
+	if packs is not None:
+		records.append({"record_type": "summary", "section": "query_packs",
+			"sections": {key: len(value) if isinstance(value, (list, dict)) else 1
+				for key, value in sorted(packs.items()) if key != "schema_version"}})
+	return records, len(records), [], {}
+
+
+def node_details(index: GraphIndex, request: dict) -> tuple[list[dict], int, list[str], dict]:
+	ident = require_text(request, "id")
+	node = index.nodes.get(ident)
+	if node is None:
+		raise QueryFailure("node-not-found", f"graph node does not exist: {ident}")
+	incoming = index.incoming.get(ident, [])
+	outgoing = index.outgoing.get(ident, [])
+	record = {"record_type": "node", "node": node,
+		"runtime_activity": index.node_activity(node),
+		"edge_counts": {
+			"incoming": len(incoming), "outgoing": len(outgoing),
+			"operational_incoming": sum(index.edge_operational(edge) for edge in incoming),
+			"operational_outgoing": sum(index.edge_operational(edge) for edge in outgoing),
+			"incoming_by_kind": dict(sorted(Counter(edge["kind"] for edge in incoming).items())),
+			"outgoing_by_kind": dict(sorted(Counter(edge["kind"] for edge in outgoing).items())),
+		}}
+	return [record], 1, [], {}
+
+
+def search(index: GraphIndex, request: dict) -> tuple[list[dict], int, list[str], dict]:
+	term = require_text(request, "text").casefold()
+	scope = choice(request, "scope", "nodes", {"nodes", "edges", "all"})
+	kinds = set(string_list(request, "kinds"))
+	include_inactive = boolean(request, "include_inactive")
+	records = []
+	if scope in {"nodes", "all"}:
+		for ident, node in sorted(index.nodes.items()):
+			if not include_inactive and not index.node_operational(node):
+				continue
+			if kinds and node.get("kind") not in kinds:
+				continue
+			if term not in index.node_search_text[ident]:
+				continue
+			folded_id = ident.casefold()
+			metadata_fields = ("kind", "name", "owner", "file", "domain", "associated_type",
+				"runtime_alias", "config_trait", "entrypoint_kind")
+			if folded_id == term:
+				rank, reason = 0, "exact-node-id"
+			elif folded_id.startswith(term):
+				rank, reason = 1, "node-id-prefix"
+			elif term in folded_id:
+				rank, reason = 2, "node-id-substring"
+			elif any(isinstance(node.get(field), str) and node[field].casefold() == term
+				for field in metadata_fields):
+				rank, reason = 3, "exact-node-metadata"
+			else:
+				rank, reason = 6, "node-json-substring"
+			records.append({"record_type": "node", "runtime_activity": index.node_activity(node),
+				"match": {"rank": rank, "reason": reason}, "node": node})
+	if scope in {"edges", "all"}:
+		for edge in index.edges:
+			if not include_inactive and not index.edge_operational(edge):
+				continue
+			if kinds and edge["kind"] not in kinds:
+				continue
+			if term not in index.edge_search_text[json_key(edge)]:
+				continue
+			endpoints = (edge["source"].casefold(), edge["target"].casefold())
+			if term in endpoints:
+				rank, reason = 4, "exact-edge-endpoint"
+			elif any(value.startswith(term) or term in value for value in endpoints):
+				rank, reason = 5, "edge-endpoint-substring"
+			else:
+				rank, reason = 7, "edge-json-substring"
+			records.append({"record_type": "edge", "runtime_activity": index.edge_activity(edge),
+				"match": {"rank": rank, "reason": reason},
+				"evidence_sha256": index.evidence_fingerprint(edge), "edge": edge})
+	records.sort(key=lambda record: (record["match"]["rank"],
+		record.get("node", {}).get("id", ""), record.get("edge", {}).get("source", ""),
+		record.get("edge", {}).get("target", ""), json_key(record)))
+	return records, len(records), [], {"include_inactive": include_inactive,
+		"activity_policy": ACTIVITY_POLICY}
+
+
+def neighbors(index: GraphIndex, request: dict) -> tuple[list[dict], int, list[str], dict]:
+	ident = require_text(request, "id")
+	if ident not in index.nodes:
+		raise QueryFailure("node-not-found", f"graph node does not exist: {ident}")
+	direction = choice(request, "direction", "both", {"incoming", "outgoing", "both"})
+	depth = bounded_int(request, "depth", 1, 1, 6)
+	max_expansions = bounded_int(request, "max_expansions", 10_000, 1, 100_000)
+	kinds = set(string_list(request, "edge_kinds"))
+	include_inactive = boolean(request, "include_inactive")
+	records = []
+	seen_evidence = set()
+	discovered = {ident: 0}
+	queue = deque([ident])
+	expansions = 0
+	reasons = []
+	expansion_limited = False
+	while queue and not expansion_limited:
+		current = queue.popleft()
+		current_depth = discovered[current]
+		if current_depth >= depth:
+			continue
+		for neighbor, edge, traversal in path_transitions(index, current, direction, kinds, include_inactive):
+			fingerprint = index.evidence_fingerprint(edge)
+			if fingerprint in seen_evidence:
+				continue
+			if expansions >= max_expansions:
+				expansion_limited = True
+				break
+			seen_evidence.add(fingerprint)
+			expansions += 1
+			relation = "self" if neighbor == current else "outgoing" if traversal == "forward" else "incoming"
+			records.append({"record_type": "neighbor", "depth": current_depth + 1,
+				"from": current, "to": neighbor, "relation": relation,
+				"node": index.nodes[neighbor],
+				"node_runtime_activity": index.node_activity(index.nodes[neighbor]),
+				"edge_runtime_activity": index.edge_activity(edge),
+				"evidence_sha256": fingerprint, "edge": edge})
+			if neighbor not in discovered:
+				discovered[neighbor] = current_depth + 1
+				queue.append(neighbor)
+	if expansion_limited:
+		reasons.append("expansion-limit")
+	if not expansion_limited and any(
+		index.evidence_fingerprint(edge) not in seen_evidence
+		for frontier, frontier_depth in discovered.items() if frontier_depth == depth
+		for _, edge, _ in path_transitions(index, frontier, direction, kinds, include_inactive)
+	):
+		reasons.append("depth-limit")
+	records.sort(key=lambda record: (record["depth"], record["from"], record["to"],
+		record["relation"], json_key(record["edge"])))
+	return records, len(records), reasons, {"direction": direction, "depth": depth,
+		"include_inactive": include_inactive, "max_expansions": max_expansions,
+		"expansions": expansions, "nodes_reached": len(discovered), "search_complete": not reasons,
+		"activity_policy": ACTIVITY_POLICY}
+
+
+def path_transitions(index: GraphIndex, node: str, direction: str, kinds: set[str],
+	include_inactive: bool) -> list[tuple[str, dict, str]]:
+	result = []
+	if direction in {"outgoing", "both"}:
+		result.extend((edge["target"], edge, "forward") for edge in index.outgoing.get(node, []))
+	if direction in {"incoming", "both"}:
+		result.extend((edge["source"], edge, "reverse") for edge in index.incoming.get(node, []))
+	filtered = []
+	seen = set()
+	for neighbor, edge, traversal in result:
+		if kinds and edge["kind"] not in kinds:
+			continue
+		if not include_inactive and not index.edge_operational(edge):
+			continue
+		key = (neighbor, traversal, json_key(edge))
+		if key not in seen:
+			seen.add(key)
+			filtered.append((neighbor, edge, traversal))
+	return sorted(filtered, key=lambda item: (item[0], item[2], json_key(item[1])))
+
+
+def aggregated_path_transitions(index: GraphIndex, node: str, direction: str, kinds: set[str],
+	include_inactive: bool) -> list[tuple[str, list[tuple[dict, tuple[str, ...]]]]]:
+	groups: dict[str, dict[str, dict]] = defaultdict(dict)
+	traversals: dict[tuple[str, str], set[str]] = defaultdict(set)
+	for neighbor, edge, traversal in path_transitions(index, node, direction, kinds, include_inactive):
+		fingerprint = index.evidence_fingerprint(edge)
+		groups[neighbor][fingerprint] = edge
+		traversals[(neighbor, fingerprint)].add(traversal)
+	return [(neighbor, [(edges[fingerprint], tuple(sorted(traversals[(neighbor, fingerprint)])))
+		for fingerprint in sorted(edges)]) for neighbor, edges in sorted(groups.items())]
+
+
+def paths(index: GraphIndex, request: dict) -> tuple[list[dict], int, list[str], dict]:
+	source = require_text(request, "source")
+	target = require_text(request, "target")
+	if source not in index.nodes:
+		raise QueryFailure("node-not-found", f"graph node does not exist: {source}")
+	if target not in index.nodes:
+		raise QueryFailure("node-not-found", f"graph node does not exist: {target}")
+	direction = choice(request, "direction", "outgoing", {"incoming", "outgoing", "both"})
+	max_depth = bounded_int(request, "max_depth", 6, 0, 12)
+	max_paths = bounded_int(request, "max_paths", 10, 1, 1_000)
+	max_expansions = bounded_int(request, "max_expansions", 10_000, 1, 100_000)
+	kinds = set(string_list(request, "edge_kinds"))
+	include_inactive = boolean(request, "include_inactive")
+	distances = {source: 0}
+	predecessors: dict[str, list[tuple[str, list[tuple[dict, tuple[str, ...]]]]]] = defaultdict(list)
+	queue = deque([source])
+	expansions = 0
+	depth_truncated = False
+	expansion_limited = False
+	reasons = []
+	target_depth = 0 if source == target else None
+	while queue and not expansion_limited:
+		current = queue.popleft()
+		current_depth = distances[current]
+		if target_depth is not None and current_depth >= target_depth:
+			continue
+		transitions = aggregated_path_transitions(index, current, direction, kinds, include_inactive)
+		if current_depth >= max_depth:
+			depth_truncated = depth_truncated or any(neighbor not in distances
+				for neighbor, _ in transitions)
+			continue
+		for neighbor, evidence in transitions:
+			if expansions >= max_expansions:
+				expansion_limited = True
+				break
+			expansions += 1
+			if neighbor not in distances:
+				distances[neighbor] = current_depth + 1
+				queue.append(neighbor)
+				if neighbor == target:
+					target_depth = current_depth + 1
+			if distances.get(neighbor) == current_depth + 1:
+				predecessors[neighbor].append((current, evidence))
+	if expansion_limited:
+		reasons.append("expansion-limit")
+	if target_depth is None and depth_truncated:
+		reasons.append("depth-limit")
+	found = []
+	path_queue = deque([(target, [target], [])]) if target_depth is not None else deque()
+	reconstruction_limited = False
+	while path_queue and len(found) < max_paths and not reconstruction_limited:
+		current, reversed_nodes, reversed_steps = path_queue.popleft()
+		if current == source:
+			found.append({"record_type": "path", "length": len(reversed_steps),
+				"nodes": list(reversed(reversed_nodes)), "steps": list(reversed(reversed_steps))})
+			continue
+		for previous, evidence in predecessors.get(current, []):
+			if expansions >= max_expansions:
+				reconstruction_limited = True
+				break
+			expansions += 1
+			edges = [edge for edge, _ in evidence]
+			fingerprints = [index.evidence_fingerprint(edge) for edge in edges]
+			traversal_values = sorted({value for _, values in evidence for value in values})
+			edge_kinds = sorted({edge["kind"] for edge in edges})
+			activities = sorted({index.edge_activity(edge) for edge in edges})
+			step = {"from": previous, "to": current,
+				"traversal": traversal_values[0] if len(traversal_values) == 1 else "mixed",
+				"traversals": traversal_values,
+				"edge_kind": edge_kinds[0] if len(edge_kinds) == 1 else "mixed",
+				"edge_kinds": edge_kinds,
+				"edge_runtime_activity": activities[0] if len(activities) == 1 else "mixed",
+				"evidence_count": len(edges), "evidence_sha256": fingerprints[0],
+				"evidence_sha256s": fingerprints, "edge": edges[0],
+				"evidence_variants": [{"traversals": list(values),
+					"evidence_sha256": fingerprint, "edge": edge}
+					for (edge, values), fingerprint in zip(evidence, fingerprints)]}
+			path_queue.append((previous, [*reversed_nodes, previous], [*reversed_steps, step]))
+	if len(found) >= max_paths and path_queue:
+		reasons.append("path-limit")
+	if reconstruction_limited and "expansion-limit" not in reasons:
+		reasons.append("expansion-limit")
+	return found, len(found), reasons, {"direction": direction, "include_inactive": include_inactive,
+		"max_depth": max_depth, "max_paths": max_paths, "max_expansions": max_expansions,
+		"expansions": expansions, "nodes_reached": len(distances), "shortest_depth": target_depth,
+		"path_strategy": "all-shortest unique node paths; all parallel evidence grouped per topology hop",
+		"search_complete": not reasons,
+		"activity_policy": ACTIVITY_POLICY}
+
+
+def component_index(index: GraphIndex, payload: dict | None) -> GraphIndex | None:
+	if payload is None:
+		return None
+	if payload.get("schema_version") != 2:
+		raise QueryFailure("invalid-component-graph", "component-graph.json must use schema_version 2")
+	if payload.get("projection") != "execution":
+		raise QueryFailure("invalid-component-graph",
+			"component-graph.json must use the execution projection")
+	edges = payload.get("edges")
+	if not isinstance(edges, list):
+		raise QueryFailure("invalid-component-graph", "component-graph.json must contain an edge array")
+	if any(not isinstance(edge, dict) or any(
+		not isinstance(edge.get(field), str) or not edge[field]
+		for field in ("source", "target", "kind")) for edge in edges):
+		raise QueryFailure("invalid-component-graph",
+			"every component edge must have source, target, and kind strings")
+	node_ids = {edge.get(endpoint) for edge in edges if isinstance(edge, dict)
+		for endpoint in ("source", "target")}
+	missing = sorted((ident for ident in node_ids
+		if not isinstance(ident, str) or ident not in index.nodes), key=lambda value: str(value))
+	if missing:
+		raise QueryFailure("invalid-component-graph",
+			f"component graph contains nodes absent from the main graph: {missing[0]}")
+	return GraphIndex({"schema_version": 2,
+		"nodes": [index.nodes[ident] for ident in sorted(node_ids)], "edges": edges})
+
+
+def packs(companions: dict[str, dict | None], request: dict) -> tuple[list[dict], int, list[str], dict]:
+	payload = companions.get("query_packs")
+	if payload is None:
+		raise QueryFailure("query-packs-unavailable", "query-packs.json was not loaded")
+	section = request.get("section")
+	contains = request.get("contains")
+	if section is not None and (not isinstance(section, str) or not section):
+		raise QueryFailure("invalid-query", "section must be a non-empty string")
+	if contains is not None and (not isinstance(contains, str) or len(contains) > MAX_QUERY_LENGTH):
+		raise QueryFailure("invalid-query", f"contains must be a string up to {MAX_QUERY_LENGTH} characters")
+	if section is None:
+		records = [{"record_type": "query-pack", "section": key,
+			"type": "list" if isinstance(value, list) else "object" if isinstance(value, dict) else "scalar",
+			"count": len(value) if isinstance(value, (list, dict)) else 1}
+			for key, value in sorted(payload.items()) if key != "schema_version"]
+	else:
+		if section == "schema_version" or section not in payload:
+			raise QueryFailure("section-not-found", f"query-pack section does not exist: {section}")
+		value = payload[section]
+		if isinstance(value, list):
+			records = [{"record_type": "query-pack", "section": section, "index": index, "value": item}
+				for index, item in enumerate(value)]
+		elif isinstance(value, dict):
+			records = [{"record_type": "query-pack", "section": section, "key": key, "value": item}
+				for key, item in sorted(value.items())]
+		else:
+			records = [{"record_type": "query-pack", "section": section, "value": value}]
+	if contains:
+		needle = contains.casefold()
+		records = [record for record in records if needle in json_key(record).casefold()]
+	return records, len(records), [], {"section": section, "contains": contains}
+
+
+def execute(index: GraphIndex, companions: dict[str, dict | None], request: dict,
+	max_records: int, max_tokens: int, graph_sha256: str | None,
+	component_graph_index: GraphIndex | None = None, batch_index: int | None = None,
+	companion_sha256: dict[str, str] | None = None) -> str:
+	operation = request.get("operation")
+	if not isinstance(operation, str) or operation not in {
+		"summary", "node", "search", "neighbors", "paths", "packs"}:
+		raise QueryFailure("invalid-operation",
+			"operation must be one of: neighbors, node, packs, paths, search, summary")
+	def path_query() -> tuple[list[dict], int, list[str], dict]:
+		view = choice(request, "view", "raw", {"raw", "components"})
+		if view == "components" and component_graph_index is None:
+			raise QueryFailure("component-graph-unavailable",
+				"component path queries require component-graph.json")
+		result = paths(component_graph_index if view == "components" else index, request)
+		result[3]["view"] = view
+		return result
+
+	dispatch = {
+		"summary": lambda: summary(index, companions),
+		"node": lambda: node_details(index, request),
+		"search": lambda: search(index, request),
+		"neighbors": lambda: neighbors(index, request),
+		"paths": path_query,
+		"packs": lambda: packs(companions, request),
+	}
+	records, matched, reasons, metadata = dispatch[operation]()
+	parameters = {key: value for key, value in sorted(request.items()) if key != "operation"}
+	if batch_index is not None:
+		parameters["batch_index"] = batch_index
+	warnings = [*companion_warnings(companions, index), *activity_warnings(index)]
+	total_is_exact = not bool(set(reasons) & {"depth-limit", "expansion-limit", "path-limit"})
+	return render_envelope(operation, parameters, records, matched, warnings,
+		reasons, max_records, max_tokens, metadata, graph_sha256,
+		companion_sha256, total_is_exact)
+
+
+def error_response(operation: str, parameters: dict, error: QueryFailure,
+	companions: dict[str, dict | None], max_records: int, max_tokens: int,
+	graph_sha256: str | None = None, companion_sha256: dict[str, str] | None = None,
+	index: GraphIndex | None = None) -> str:
+	warnings = [*companion_warnings(companions, index), warning(error.code, "error", str(error))]
+	return render_envelope(operation, parameters, [], 0, warnings, [], max_records, max_tokens,
+		{"error": error.code}, graph_sha256, companion_sha256)
+
+
+def request_from_args(args: argparse.Namespace) -> dict:
+	request = {"operation": args.operation}
+	for field in ("id", "text", "scope", "direction", "view", "source", "target", "depth", "max_depth", "max_paths",
+		"max_expansions", "section", "contains"):
+		if hasattr(args, field) and getattr(args, field) is not None:
+			request[field] = getattr(args, field)
+	if hasattr(args, "kind") and args.kind:
+		request["kinds"] = args.kind
+	if hasattr(args, "edge_kind") and args.edge_kind:
+		request["edge_kinds"] = args.edge_kind
+	if getattr(args, "include_inactive", False):
+		request["include_inactive"] = True
+	return request
+
+
+def batch(index: GraphIndex, companions: dict[str, dict | None], args: argparse.Namespace,
+	graph_sha256: str | None, component_graph_index: GraphIndex | None,
+	companion_sha256: dict[str, str]) -> int:
+	failed = False
+	for line_number, raw in enumerate(sys.stdin, 1):
+		if not raw.strip():
+			continue
+		operation = "invalid"
+		parameters = {"batch_index": line_number}
+		request_records = args.max_records
+		request_tokens = args.max_tokens
+		try:
+			request = json.loads(raw)
+			if not isinstance(request, dict):
+				raise QueryFailure("invalid-batch-request", "each JSONL request must be an object")
+			candidate_records = request.get("max_records", args.max_records)
+			if isinstance(candidate_records, int) and not isinstance(candidate_records, bool) \
+				and 1 <= candidate_records <= args.max_records:
+				request_records = candidate_records
+			candidate_tokens = request.get("max_tokens", args.max_tokens)
+			if isinstance(candidate_tokens, int) and not isinstance(candidate_tokens, bool) \
+				and 256 <= candidate_tokens <= args.max_tokens:
+				request_tokens = candidate_tokens
+			request_records = bounded_int(request, "max_records", args.max_records, 1, args.max_records)
+			request_tokens = bounded_int(request, "max_tokens", args.max_tokens, 256, args.max_tokens)
+			operation_value = request.get("operation")
+			if not isinstance(operation_value, str):
+				raise QueryFailure("invalid-operation",
+					"operation must be one of: neighbors, node, packs, paths, search, summary")
+			operation = operation_value
+			print(execute(index, companions, request, request_records, request_tokens,
+				graph_sha256, component_graph_index, line_number, companion_sha256))
+		except (json.JSONDecodeError, QueryFailure, TypeError, KeyError, AttributeError, OverflowError) as error:
+			failed = True
+			if isinstance(error, QueryFailure):
+				failure = error
+			elif isinstance(error, json.JSONDecodeError):
+				failure = QueryFailure("invalid-batch-json",
+					f"invalid JSON on batch line {line_number}: {error}")
+			else:
+				failure = QueryFailure("invalid-batch-request",
+					f"invalid request on batch line {line_number}: {error}")
+			print(error_response(operation, parameters, failure, companions,
+				request_records, request_tokens, graph_sha256, companion_sha256, index))
+	return 2 if failed else 0
+
+
+def parser() -> argparse.ArgumentParser:
+	result = argparse.ArgumentParser(description="Deterministically query a Hydration runtime interaction graph")
+	result.add_argument("--graph", type=Path, required=True, help="interaction-graph.json")
+	result.add_argument("--coverage", type=Path, help="optional coverage.json; sibling is auto-loaded")
+	result.add_argument("--completeness", type=Path, help="optional completeness.json; sibling is auto-loaded")
+	result.add_argument("--query-packs", type=Path, help="optional query-packs.json; sibling is auto-loaded")
+	result.add_argument("--component-graph", type=Path,
+		help="optional component-graph.json; sibling is auto-loaded")
+	result.add_argument("--no-auto-companions", action="store_true", help="do not auto-load sibling companions")
+	result.add_argument("--max-records", type=int, default=DEFAULT_MAX_RECORDS)
+	result.add_argument("--max-tokens", type=int, default=DEFAULT_MAX_TOKENS,
+		help="approximate output token budget")
+	subparsers = result.add_subparsers(dest="operation", required=True)
+	subparsers.add_parser("summary", help="graph and companion coverage summary")
+	node_parser = subparsers.add_parser("node", help="full metadata and edge counts for one node")
+	node_parser.add_argument("id")
+	search_parser = subparsers.add_parser("search", help="search canonical node or edge JSON")
+	search_parser.add_argument("text")
+	search_parser.add_argument("--scope", choices=("nodes", "edges", "all"), default="nodes")
+	search_parser.add_argument("--kind", action="append", help="repeatable node or edge kind filter")
+	search_parser.add_argument("--include-inactive", action="store_true")
+	neighbor_parser = subparsers.add_parser("neighbors", help="bounded incoming and outgoing ego subgraph")
+	neighbor_parser.add_argument("id")
+	neighbor_parser.add_argument("--direction", choices=("incoming", "outgoing", "both"), default="both")
+	neighbor_parser.add_argument("--depth", type=int, default=1)
+	neighbor_parser.add_argument("--max-expansions", type=int, default=10_000)
+	neighbor_parser.add_argument("--edge-kind", action="append")
+	neighbor_parser.add_argument("--include-inactive", action="store_true")
+	path_parser = subparsers.add_parser("paths", help="bounded deterministic simple-path search")
+	path_parser.add_argument("source")
+	path_parser.add_argument("target")
+	path_parser.add_argument("--direction", choices=("incoming", "outgoing", "both"), default="outgoing")
+	path_parser.add_argument("--view", choices=("raw", "components"), default="raw")
+	path_parser.add_argument("--edge-kind", action="append")
+	path_parser.add_argument("--max-depth", type=int, default=6)
+	path_parser.add_argument("--max-paths", type=int, default=10)
+	path_parser.add_argument("--max-expansions", type=int, default=10_000)
+	path_parser.add_argument("--include-inactive", action="store_true")
+	packs_parser = subparsers.add_parser("packs", help="list or inspect query-pack sections")
+	packs_parser.add_argument("--section")
+	packs_parser.add_argument("--contains")
+	subparsers.add_parser("batch", help="read JSON query objects from stdin and emit JSONL envelopes")
+	return result
+
+
+def main() -> int:
+	args = parser().parse_args()
+	if not 1 <= args.max_records <= 10_000:
+		parser().error("--max-records must be from 1 to 10000")
+	if not 256 <= args.max_tokens <= 1_000_000:
+		parser().error("--max-tokens must be from 256 to 1000000")
+	companions: dict[str, dict | None] = {"coverage": None, "completeness": None,
+		"query_packs": None, "component_graph": None}
+	companion_sha256: dict[str, str] = {}
+	graph_sha256 = graph_fingerprint(args.graph)
+	component_graph_index = None
+	index = None
+	try:
+		payload = load_json(args.graph, dict, "graph")
+		index = GraphIndex(payload)
+		companions, companion_sha256 = load_companions(args)
+		component_graph_index = component_index(index, companions.get("component_graph"))
+	except QueryFailure as error:
+		print(error_response(args.operation, {}, error, companions, args.max_records, args.max_tokens,
+			graph_sha256, companion_sha256, index))
+		return 2
+	if args.operation == "batch":
+		return batch(index, companions, args, graph_sha256, component_graph_index, companion_sha256)
+	request = request_from_args(args)
+	try:
+		print(execute(index, companions, request, args.max_records, args.max_tokens,
+			graph_sha256, component_graph_index, companion_sha256=companion_sha256))
+		return 0
+	except QueryFailure as error:
+		print(error_response(args.operation, {key: value for key, value in request.items()
+			if key != "operation"}, error, companions, args.max_records, args.max_tokens,
+			graph_sha256, companion_sha256, index))
+		return 2
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/scripts/runtime-interaction-graph/runtime_interaction_graph.py
+++ b/scripts/runtime-interaction-graph/runtime_interaction_graph.py
@@ -2822,19 +2822,115 @@ def write_layer_svg(g: Graph, edges: list[dict], path: Path, title: str) -> None
 		f.write("</svg>\n")
 
 
+def interactive_graph_payload(g: Graph, components: list[dict]) -> dict:
+	projection_names = tuple(EDGE_PROJECTIONS)
+	projection_stats = {name: {"nodes": set(), "pairs": set(), "evidence_edges": 0,
+		"kinds": Counter()} for name in projection_names}
+	pairs = {}
+	node_projections: dict[str, set[str]] = defaultdict(set)
+	sample_fields = ("kind", "file", "line", "method", "semantic_source", "resolution",
+		"address", "selector", "semantics", "enforcement", "evidence_source", "evidence_target",
+		"semantic_evidence")
+	for edge in components:
+		projections = tuple(name for name in projection_names if edge["kind"] in EDGE_PROJECTIONS[name])
+		if not projections:
+			continue
+		key = (edge["source"], edge["target"])
+		pair = pairs.setdefault(key, {"source": edge["source"], "target": edge["target"],
+			"count": 0, "kind_counts": Counter(), "projection_counts": Counter(), "samples": {}})
+		pair["count"] += 1
+		pair["kind_counts"][edge["kind"]] += 1
+		if edge["kind"] not in pair["samples"]:
+			pair["samples"][edge["kind"]] = {field: edge[field] for field in sample_fields if field in edge}
+		for projection in projections:
+			pair["projection_counts"][projection] += 1
+			stats = projection_stats[projection]
+			stats["nodes"].update(key)
+			stats["pairs"].add(key)
+			stats["evidence_edges"] += 1
+			stats["kinds"][edge["kind"]] += 1
+			node_projections[edge["source"]].add(projection)
+			node_projections[edge["target"]].add(projection)
+
+	def activity(node: dict) -> str:
+		if node.get("runtime_active") is False:
+			return "inactive"
+		for field in ("owner", "function"):
+			dependency = node.get(field)
+			if isinstance(dependency, str) and g.nodes.get(dependency, {}).get("runtime_active") is False:
+				return "inactive"
+		return "active" if node.get("runtime_active") is True else "unclassified"
+
+	compact_nodes = []
+	for ident in sorted(node_projections):
+		node = g.nodes[ident]
+		label = node.get("semantic_label") or node.get("name") or node.get("runtime_alias")
+		if not label and isinstance(node.get("names"), list) and node["names"]:
+			label = node["names"][0]
+		compact = {"id": ident, "label": label or ident, "kind": node.get("kind", "unknown"),
+			"domain": node.get("domain", "unspecified"), "activity": activity(node),
+			"projections": sorted(node_projections[ident])}
+		for field in ("description", "semantic_description", "file", "source", "configured_by",
+			"address", "chain_address_id", "network", "runtime_alias", "entrypoint_kind"):
+			if field in node:
+				compact[field] = node[field]
+		for field in ("roles", "names", "semantic_domains"):
+			if isinstance(node.get(field), list):
+				compact[field] = node[field][:20]
+		compact_nodes.append(compact)
+
+	compact_edges = []
+	for key in sorted(pairs):
+		pair = pairs[key]
+		compact_edges.append({"source": pair["source"], "target": pair["target"],
+			"count": pair["count"], "kind_counts": dict(sorted(pair["kind_counts"].items())),
+			"projection_counts": dict(sorted(pair["projection_counts"].items())),
+			"samples": [pair["samples"][kind] for kind in sorted(pair["samples"])[:12]]})
+
+	scale = graph_scale_summary(g)
+	return {"schema_version": 1,
+		"summary": {"nodes": scale["totals"]["nodes"], "edges": scale["totals"]["edges"],
+			"components": scale["totals"]["components"], "entrypoints": scale["totals"]["entrypoints"],
+			"inventory_only_targets": scale["inventory_only_targets"],
+			"unresolved_targets": scale["unresolved_targets"]},
+		"projections": {name: {"nodes": len(stats["nodes"]), "pairs": len(stats["pairs"]),
+			"evidence_edges": stats["evidence_edges"], "kinds": sorted(stats["kinds"])}
+			for name, stats in projection_stats.items()},
+		"nodes": compact_nodes, "edges": compact_edges}
+
+
 def write_interactive_html(g: Graph, components: list[dict], output: Path) -> None:
-	nodes = {ident: dict(node) for ident, node in g.nodes.items()}
-	payload = json.dumps({"nodes": nodes, "edges": components}).replace("</", "<\\/")
-	html_text = """<!doctype html><meta charset="utf-8"><title>Hydration interaction graph</title>
-<style>body{font:14px system-ui;margin:24px;color:#172033}input,select{padding:8px;margin-right:8px}.overview{display:inline-block;margin:0 0 16px;padding:9px 12px;border:1px solid #dbe2ee;border-radius:8px;background:#f8fafc;color:#4338ca;text-decoration:none}.overview:hover{background:#eef2ff}table{border-collapse:collapse;width:100%;margin-top:16px}td,th{padding:6px;border-bottom:1px solid #ddd;text-align:left;vertical-align:top;word-break:break-word}code{font-size:12px}</style>
-<h1>Hydration interaction graph</h1><a class="overview" href="graph-scale.svg">open graph scale overview</a><br><input id="query" placeholder="filter nodes, edges, files"><select id="kind"><option value="">all edge kinds</option></select><select id="domain"><option value="">all domains</option></select><span id="count"></span>
-<table><thead><tr><th>source</th><th>edge</th><th>target</th><th>evidence</th></tr></thead><tbody id="rows"></tbody></table>
-<script>const graph=PAYLOAD;const q=document.querySelector('#query'),kind=document.querySelector('#kind'),domain=document.querySelector('#domain'),rows=document.querySelector('#rows'),count=document.querySelector('#count');
-for(const value of [...new Set(graph.edges.map(e=>e.kind))].sort())kind.add(new Option(value,value));
-for(const value of [...new Set(Object.values(graph.nodes).map(n=>n.domain).filter(Boolean))].sort())domain.add(new Option(value,value));
-function esc(value){const element=document.createElement('div');element.textContent=String(value);return element.innerHTML}
-function render(){const text=q.value.toLowerCase();const found=graph.edges.filter(e=>(!kind.value||e.kind===kind.value)&&(!domain.value||graph.nodes[e.source]?.domain===domain.value||graph.nodes[e.target]?.domain===domain.value)&&JSON.stringify([e,graph.nodes[e.source],graph.nodes[e.target]]).toLowerCase().includes(text));const foundNodes=text&&!kind.value?Object.values(graph.nodes).filter(n=>(!domain.value||n.domain===domain.value)&&JSON.stringify(n).toLowerCase().includes(text)):[];count.textContent=`${found.length} edges; ${foundNodes.length} matching nodes`;const nodeRows=foundNodes.slice(0,250).map(n=>`<tr><td><code>${esc(n.id)}</code></td><td>node:${esc(n.kind)}</td><td></td><td><code>${esc(JSON.stringify(n))}</code></td></tr>`);const edgeRows=found.slice(0,750).map(e=>{const evidence=Object.fromEntries(Object.entries(e).filter(([key])=>!['source','target','kind'].includes(key)));return `<tr><td><code>${esc(e.source)}</code></td><td>${esc(e.kind)}</td><td><code>${esc(e.target)}</code></td><td><code>${esc(JSON.stringify(evidence))}</code></td></tr>`});rows.innerHTML=[...nodeRows,...edgeRows].join('')}</script>
-<script>q.oninput=kind.onchange=domain.onchange=render;render()</script>""".replace("PAYLOAD", payload)
+	payload = json.dumps(interactive_graph_payload(g, components), sort_keys=True,
+		separators=(",", ":"), ensure_ascii=True)
+	payload = payload.replace("&", "\\u0026").replace("<", "\\u003c").replace(">", "\\u003e")
+	style = Path(__file__).with_name("graph_explorer.css").read_text()
+	script = Path(__file__).with_name("graph_explorer.js").read_text()
+	template = """<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Hydration runtime interaction explorer</title><style>__GRAPH_STYLE__</style></head>
+<body><header class="topbar"><div><p class="eyebrow">Hydration runtime</p><h1>Interaction explorer</h1>
+<p class="subtitle">Aggregated, evidence-backed relationships. Click any node or edge to inspect it.</p></div>
+<div class="headline-stats" aria-label="full graph scale"><div><strong id="full-node-count">—</strong><span>full nodes</span></div>
+<div><strong id="full-edge-count">—</strong><span>full edges</span></div><div><strong id="component-count">—</strong><span>components</span></div></div>
+<nav><a href="graph-scale.svg">scale overview</a><a href="interaction-graph.json">raw graph</a><a href="api/v1">API</a></nav></header>
+<main class="app"><section class="workspace" aria-label="interactive topology">
+<div class="toolbar"><label>projection<select id="projection"></select></label><label>domain<select id="domain"><option value="">all domains</option></select></label>
+<label>edge kind<select id="edge-kind"><option value="">all kinds</option></select></label>
+<label class="search-field">find node<input id="search" type="search" autocomplete="off" placeholder="omnipool, precompile, contract…" aria-controls="search-results"><span id="search-results" class="search-results"></span></label>
+<button id="fit" type="button">fit graph</button><button id="reset-selection" type="button">clear selection</button>
+<label class="check"><input id="labels" type="checkbox">more labels</label></div>
+<div class="projection-strip"><span id="projection-note"></span><strong id="relation-count"></strong></div>
+<div class="canvas-shell"><canvas id="graph-canvas" tabindex="0" role="img" aria-label="Interactive directed component graph. Use search or the inspector for an accessible node list."></canvas>
+<div id="legend" class="legend" aria-label="domain legend"></div><div class="canvas-hint">drag to pan · wheel to zoom · click to inspect</div></div>
+<p id="live-status" class="sr-only" aria-live="polite"></p></section>
+<aside id="inspector" class="inspector" aria-label="selection details"><div class="empty-inspector"><span>↗</span><h2>Select a node or relationship</h2><p>Neighbors, edge kinds, evidence samples, and bounded API metadata appear here.</p></div></aside></main>
+<noscript>This visualization requires JavaScript. The raw graph remains available through <a href="interaction-graph.json">interaction-graph.json</a>.</noscript>
+<script>const payload=__GRAPH_PAYLOAD__;</script><script>__GRAPH_SCRIPT__</script></body></html>
+"""
+	style_prefix, remainder = template.split("__GRAPH_STYLE__", 1)
+	payload_prefix, remainder = remainder.split("__GRAPH_PAYLOAD__", 1)
+	script_prefix, suffix = remainder.split("__GRAPH_SCRIPT__", 1)
+	html_text = style_prefix + style + payload_prefix + payload + script_prefix + script + suffix
 	(output / "interaction-graph.html").write_text(html_text)
 
 

--- a/scripts/runtime-interaction-graph/runtime_interaction_graph.py
+++ b/scripts/runtime-interaction-graph/runtime_interaction_graph.py
@@ -1,0 +1,3906 @@
+#!/usr/bin/env python3
+"""Build an audit-oriented FRAME/EVM interaction graph.
+
+The extractor is intentionally conservative: syntactic edges carry evidence and
+unresolved associated-type calls remain explicit nodes. Semantic call-graph data
+can later be merged without changing the output schema.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from collections import Counter, defaultdict, deque
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import mir_parser
+import runtime_inventory
+import semantic_inventory
+import analysis_provenance
+import collect_contracts
+import collect_mir
+import collect_rapx
+
+
+PALLET_CALL = re.compile(
+	r"((?:pallet_|orml_|cumulus_pallet_|frame_)[a-zA-Z0-9_]+)::Pallet(?:::<[^>]+>)?::([a-zA-Z0-9_]+)",
+)
+LOCAL_PALLET_CALL = re.compile(
+	r"\b(?:Self|Pallet)\s*::\s*(?:<[^>{};\n]+>\s*::\s*)?([a-z_][a-zA-Z0-9_]*)\s*\(",
+)
+ASSOCIATED_CALL = re.compile(
+	r"\b(T|R|Runtime)\s*::\s*([A-Z][A-Za-z0-9_]*)\s*::\s*([a-zA-Z0-9_]+)",
+)
+RUNTIME_CALL = re.compile(r"\b([A-Z][A-Za-z0-9_]*)::([a-zA-Z0-9_]+)\s*\(")
+FN = re.compile(r"(?:pub(?:\([^)]*\))?\s+)?fn\s+([a-zA-Z0-9_]+)\s*(?:<[^>{}]*>)?\s*\(")
+STORAGE = re.compile(r"\b([A-Z][A-Za-z0-9_]*)(?:::\s*<[^;\n]*?>)?::(get|insert|remove|take|put|mutate|try_mutate|append|clear|clear_prefix)\b")
+EXTERNAL = re.compile(r"(::call\b|\.call\s*\(|\.dispatch\s*\(|::dispatch\s*\(|::transfer\s*\(|::deposit\s*\(|::withdraw\s*\(|::mint_into\s*\(|::burn_from\s*\(|handle\.call\s*\(|Runner::call\b)")
+STORAGE_WRITES = {"insert", "remove", "take", "put", "mutate", "try_mutate", "append", "clear", "clear_prefix"}
+EVM_ENTRY = re.compile(r"(?:\bRunner::call\b|\bEVM::call\b|\bEvm::call\b|\bhandle\.call\s*\()")
+INTERNAL_EVM_EXECUTOR = re.compile(r"\bExecutor\s*::\s*<[^>]+>\s*::\s*(call|view)\s*\(")
+FRAME_DISPATCH = re.compile(r"(?:\btry_dispatch\s*\(|\.dispatch\s*\(|::dispatch\s*\()")
+XCM_SEND = re.compile(r"\b(?:send_xcm|send_xcm_on_behalf|transfer_assets|reserve_transfer_assets)\s*\(")
+XCM_ASSET = re.compile(r"::(?:deposit_asset|withdraw_asset|transfer_asset|check_in|check_out)\s*\(")
+PRECOMPILE_PUBLIC = re.compile(r'#\[precompile::public\("([^"]+)"\)\]')
+GENERATED_SELECTOR_ENUM = re.compile(
+	r"(?P<attributes>(?:\s*#\[[^\]]+\])+\s*)(?:pub(?:\([^)]*\))?\s+)?enum\s+"
+	r"(?P<name>[A-Z][A-Za-z0-9_]*)\s*\{",
+)
+SELECTOR_VARIANT = re.compile(r"\b([A-Z][A-Za-z0-9_]*)::([A-Z][A-Za-z0-9_]*)")
+SIMPLE_USE = re.compile(
+	r"\buse\s+((?:crate|self|super)(?:::[A-Za-z_][A-Za-z0-9_]*)+)"
+	r"(?:\s+as\s+([A-Za-z_][A-Za-z0-9_]*))?\s*;",
+)
+USE_STATEMENT = re.compile(r"(?ms)^[ \t]*(?:pub(?:\([^)]*\))?[ \t]+)?use[ \t]+(.+?);[ \t]*$")
+RUNTIME_CONFIG = re.compile(
+	r"impl\s+([a-z_][a-zA-Z0-9_]*(?:::[a-zA-Z_][a-zA-Z0-9_]*)*)::Config"
+	r"(?:\s*<([^>{}]+)>)?\s+for\s+Runtime\s*\{",
+)
+CONFIG_TRAIT = re.compile(r"(?:pub\s+)?trait\s+Config(?:\s*<[^>{}]+>)?(?:\s*:[^{]+)?\s*\{")
+RUNTIME_ALIAS = re.compile(
+	r"(?m)^[ \t]*([A-Z][A-Za-z0-9_]*)[ \t]*:(?!:)[ \t\r\n]*"
+	r"([a-z_][a-zA-Z0-9_]*(?:::[a-zA-Z_][a-zA-Z0-9_]*)*)"
+	r"(?:[ \t]*::[ \t]*<[^>{}\n]+>)?"
+	r"(?:[ \t\r\n]+(?:exclude_parts|use_parts)[ \t]*\{[^{}]*\})?"
+	r"[ \t\r\n]*=[ \t]*\d+[ \t]*,?",
+)
+HELPER_MODULE = re.compile(
+	r"(?:#\[cfg\([^\]]*(?:test|runtime-benchmarks)[^\]]*\)\]\s*)?"
+	r"(?:pub(?:\([^)]*\))?\s+)?mod\s+(?:tests?|mocks?|benchmarking|benchmarks|benchmark_helpers)\s*\{",
+)
+CFG_ATTRIBUTE = re.compile(r"#\s*\[\s*cfg\s*\((?P<expression>[^\]]+)\)\s*\]")
+ORIGIN_CHECKS = {"ensure_root": "root", "ensure_signed": "signed", "ensure_none": "none",
+	"ensure_signed_or_root": "signed-or-root"}
+LIFECYCLE_HOOKS = {"on_initialize", "on_finalize", "on_idle", "on_runtime_upgrade", "offchain_worker",
+	"on_poll", "integrity_test", "pre_upgrade", "post_upgrade"}
+SPECIAL_ENTRYPOINTS = {
+	"validate_unsigned": "unsigned-validation", "pre_dispatch": "unsigned-validation",
+	"create_inherent": "inherent", "check_inherent": "inherent", "is_inherent": "inherent",
+	"offchain_worker": "offchain-worker", "on_runtime_upgrade": "runtime-migration",
+	"pre_upgrade": "try-runtime", "post_upgrade": "try-runtime",
+}
+ASSET_METHODS = {
+	"transfer": "transfer", "transfer_keep_alive": "transfer", "deposit": "mint", "deposit_creating": "mint",
+	"mint_into": "mint", "issue": "issue", "withdraw": "withdraw", "burn_from": "burn", "burn": "burn",
+	"reserve": "reserve", "unreserve": "unreserve", "hold": "hold", "release": "release",
+	"repatriate_reserved": "repatriate", "set_lock": "lock", "remove_lock": "unlock",
+}
+STORAGE_SEMANTICS = {
+	("pallet:xyk", "TotalLiquidity"): ("pool-share-supply",),
+	("pallet:xyk", "ShareToken"): ("pool-share-identity",),
+	("pallet:stableswap", "Pools"): ("pool-configuration",),
+	("pallet:stableswap", "PoolSnapshots"): ("pool-reserves",),
+	("pallet:omnipool", "Assets"): ("pool-reserves", "pool-share-supply"),
+	("pallet:omnipool", "Positions"): ("pool-share-ownership",),
+	("pallet:circuit-breaker", "AssetLockdownState"): ("issuance-limit", "lock-or-hold"),
+	("precompile:call-permit", "NoncesStorage"): ("nonce-replay",),
+}
+
+EDGE_PROJECTIONS = {
+	"execution": {
+		"direct-call", "runtime-alias-call", "resolved-call", "rapx-call", "mir-call", "mir-component-call",
+		"mir-resolved-call", "enters-evm", "mir-enters-evm", "dispatches-frame", "mir-dispatches-frame",
+		"mir-external-call", "invokes-precompile", "sends-xcm", "receives-xcm", "moves-xcm-asset",
+		"enters-function", "callback-entry", "nested-dispatch", "executes-evm", "submits-ethereum-transaction",
+		"delivers-xcm", "invokes",
+	},
+	"callback": {"dynamic-call", "resolved-call", "callback-entry", "binding-resolves-to", "mir-dynamic-call",
+		"mir-resolved-call"},
+	"configuration": {"contains", "instantiates", "exposes-entrypoint", "config-binding", "binding-resolves-to", "runtime-config-read",
+		"runtime-config-type-reference", "weight-evaluation", "configured-as", "configured-by"},
+	"state": {"storage-access", "mir-storage-access", "reads-state", "writes-state", "owns-state",
+		"depends-on-state", "enforces-invariant", "guarded-by-invariant", "affects-invariant",
+		"owns", "reads", "writes", "enforces", "guards", "must-equal", "tracks", "derives-from",
+		"locks", "updates", "backs"},
+	"asset": {"asset-operation", "uses-asset-backend", "asset-kind-resolves-to", "defines-asset-kind", "exposed-as",
+		"issues-asset-kind", "routes-asset-to", "backed-by", "may-use-native-backend",
+		"may-be-protocol-controlled", "routes-to", "backs", "mints", "burns", "transfers-from",
+		"transfers-to", "derives-from", "updates"},
+	"authorization": {"authorizes-entry", "configured-origin", "origin-resolves-to"},
+	"evm-interface": {"dispatches-evm-selector", "encodes-evm-selector", "signature-hashes-to-selector",
+		"exposes-function", "selector-matches-contract-function"},
+	"deployment": {"uses-deployed-contract", "runtime-configures-contract", "proxy-implementation",
+		"bytecode-embeds-address", "exposes-function", "selector-matches-contract-function",
+		"deployment-aliases-contract", "deployment-step-produces-alias",
+		"deployment-step-references-address"},
+}
+
+COMPONENT_NODE_KINDS = {
+	"pallet", "frame", "precompile", "evm-adapter", "runtime-adapter", "runtime-pallet-instance",
+	"xcm-component", "execution-boundary", "asset-component", "runtime", "deployed-contract", "deployment-alias",
+	"deployment-step", "deployment-address-reference",
+}
+
+SEMANTIC_COMPONENTS = {
+	"component:balances": "pallet:balances",
+	"component:orml-tokens": "pallet:orml-tokens",
+	"component:erc20-currency": "component:evm:erc20_currency",
+	"component:stableswap": "pallet:stableswap",
+	"component:xyk": "pallet:xyk",
+	"component:omnipool": "pallet:omnipool",
+	"component:circuit-breaker": "pallet:circuit-breaker",
+}
+
+SEMANTIC_NODE_KINDS = {
+	"component": "semantic-component",
+	"configuration": "runtime-configuration",
+	"guard": "state-guard",
+	"invariant": "state-invariant",
+	"ledger": "asset-ledger",
+	"operation": "asset-operation",
+	"pool-state": "storage-model",
+	"router": "asset-router",
+}
+
+
+def line_of(text: str, offset: int) -> int:
+	return text.count("\n", 0, offset) + 1
+
+
+def is_storage_match(match: re.Match[str]) -> bool:
+	"""Exclude associated-type calls such as Currency::get from storage syntax."""
+	return "::<" in match.group(0).replace(" ", "") or match.group(1).endswith("Storage")
+
+
+def body_end(text: str, start: int) -> int | None:
+	opening = text.find("{", start)
+	if opening < 0:
+		return None
+	depth = 0
+	for i in range(opening, len(text)):
+		if text[i] == "{":
+			depth += 1
+		elif text[i] == "}":
+			depth -= 1
+			if depth == 0:
+				return i + 1
+	return None
+
+
+def function_body_end(text: str, start: int) -> int | None:
+	paren = 1
+	bracket = 0
+	angle = 0
+	i = start
+	while i < len(text):
+		if text.startswith("//", i):
+			i = text.find("\n", i + 2)
+			if i < 0:
+				return None
+			continue
+		if text.startswith("/*", i):
+			end = text.find("*/", i + 2)
+			if end < 0:
+				return None
+			i = end + 2
+			continue
+		char = text[i]
+		if char == '"':
+			i += 1
+			while i < len(text):
+				if text[i] == "\\":
+					i += 2
+					continue
+				if text[i] == '"':
+					i += 1
+					break
+				i += 1
+			continue
+		if char == "(":
+			paren += 1
+		elif char == ")":
+			paren = max(0, paren - 1)
+		elif char == "[":
+			bracket += 1
+		elif char == "]":
+			bracket = max(0, bracket - 1)
+		elif char == "<":
+			angle += 1
+		elif char == ">" and angle:
+			angle -= 1
+		elif char == ";" and not (paren or bracket or angle):
+			return None
+		elif char == "{" and not (paren or bracket or angle):
+			return body_end(text, i)
+		i += 1
+	return None
+
+
+def source_id(prefix: str, rel: str, name: str, occurrence: int) -> str:
+	suffix = f":{occurrence}" if occurrence > 1 else ""
+	return f"{prefix}:{rel}:{name}{suffix}"
+
+
+def component_id(crate: str) -> str:
+	name = crate.removeprefix("pallet_")
+	if name == "warehouse_liquidity_mining":
+		name = "liquidity_mining"
+	return f"pallet:{name.replace('_', '-')}"
+
+
+def configured_type_roots(value: str) -> list[str]:
+	value = re.sub(r"//[^\n]*|/\*.*?\*/", "", value, flags=re.S).strip()
+	if not value:
+		return []
+	if value.startswith("("):
+		depth = 0
+		closing = None
+		for offset, char in enumerate(value):
+			if char == "(":
+				depth += 1
+			elif char == ")":
+				depth -= 1
+				if depth == 0:
+					closing = offset
+					break
+		if closing == len(value) - 1:
+			body = value[1:-1]
+			parts = []
+			start = 0
+			paren = bracket = brace = angle = 0
+			for offset, char in enumerate(body):
+				if char == "(":
+					paren += 1
+				elif char == ")" and paren:
+					paren -= 1
+				elif char == "[":
+					bracket += 1
+				elif char == "]" and bracket:
+					bracket -= 1
+				elif char == "{":
+					brace += 1
+				elif char == "}" and brace:
+					brace -= 1
+				elif char == "<":
+					angle += 1
+				elif char == ">" and angle:
+					angle -= 1
+				elif char == "," and not (paren or bracket or brace or angle):
+					parts.append(body[start:offset])
+					start = offset + 1
+			parts.append(body[start:])
+			if len(parts) > 1:
+				return [root for part in parts for root in configured_type_roots(part)]
+			return configured_type_roots(body)
+	match = re.match(r"(?:::)?(?:[A-Za-z_][A-Za-z0-9_]*::)*[A-Za-z_][A-Za-z0-9_]*", value)
+	return [match.group(0)] if match else []
+
+
+def config_callback_targets(value: str, aliases: dict[str, str],
+	local_symbols: dict[str, set[str]]) -> list[str]:
+	targets = set()
+	for type_path in configured_type_roots(value):
+		parts = type_path.removeprefix("::").split("::")
+		first, symbol = parts[0], parts[-1]
+		if first in aliases:
+			targets.add(component_id(aliases[first]))
+		elif first == "warehouse_liquidity_mining" or first.startswith(
+			("pallet_", "orml_", "cumulus_pallet_", "frame_")
+		):
+			targets.add(component_id(first))
+		elif len(local_symbols.get(symbol, ())) == 1:
+			targets.add(next(iter(local_symbols[symbol])))
+	return sorted(targets)
+
+
+def scope_ranges(text: str) -> list[tuple[int, int, str]]:
+	ranges = []
+	pattern = re.compile(
+		r"(?m)^[ \t]*(?P<header>(?:(?:pub(?:\([^)]*\))?\s+)?mod\s+[a-zA-Z0-9_]+|"
+		r"(?:pub\s+)?trait\s+[A-Za-z0-9_]+[^;{]*|impl(?:<[^{}]*>)?[^;{]*))\s*\{",
+	)
+	for match in pattern.finditer(text):
+		end = body_end(text, match.end() - 1)
+		if end is not None:
+			ranges.append((match.start(), end, re.sub(r"\s+", " ", match.group("header")).strip()))
+	return ranges
+
+
+def function_source_id(text: str, match: re.Match[str], rel: str, scopes: list[tuple[int, int, str]],
+	prefix: str = "function") -> str:
+	opening = text.find("{", match.end())
+	signature = re.sub(r"\s+", " ", text[match.start():opening if opening >= 0 else match.end()]).strip()
+	enclosing = [header for start, end, header in scopes if start < match.start() < end]
+	identity = json.dumps({"signature": signature, "scope": enclosing}, sort_keys=True, separators=(",", ":"))
+	digest = hashlib.sha256(identity.encode()).hexdigest()[:12]
+	return f"{prefix}:{rel}:{match.group(1)}:{digest}"
+
+
+def impl_context(offset: int, scopes: list[tuple[int, int, str]]) -> str | None:
+	impls = [(end - start, header) for start, end, header in scopes
+		if start < offset < end and header.startswith("impl")]
+	return min(impls)[1] if impls else None
+
+
+def implemented_trait(header: str | None) -> str | None:
+	if not header or " for " not in header:
+		return None
+	prefix = header.split(" for ", 1)[0]
+	prefix = re.sub(r"^impl(?:<[^>]*>)?\s*", "", prefix)
+	return prefix.strip()
+
+
+def balanced_end(text: str, start: int, opening: str = "<", closing: str = ">") -> int | None:
+	if start >= len(text) or text[start] != opening:
+		return None
+	depth = 0
+	for offset in range(start, len(text)):
+		if text[offset] == opening:
+			depth += 1
+		elif text[offset] == closing:
+			depth -= 1
+			if depth == 0:
+				return offset + 1
+	return None
+
+
+def mask_rust_comments(text: str) -> str:
+	"""Replace Rust comments and literals while preserving byte offsets and line breaks."""
+	masked = list(text)
+
+	def clear(start: int, end: int) -> None:
+		for offset in range(start, min(end, len(masked))):
+			if masked[offset] != "\n":
+				masked[offset] = " "
+
+	position = 0
+	while position < len(text):
+		if text.startswith("//", position):
+			end = text.find("\n", position + 2)
+			end = len(text) if end < 0 else end
+			clear(position, end)
+			position = end
+			continue
+		if text.startswith("/*", position):
+			depth = 1
+			end = position + 2
+			while end < len(text) and depth:
+				if text.startswith("/*", end):
+					depth += 1
+					end += 2
+				elif text.startswith("*/", end):
+					depth -= 1
+					end += 2
+				else:
+					end += 1
+			clear(position, end)
+			position = end
+			continue
+		raw = re.match(r'(?:br|r)(?P<hashes>#{0,255})"', text[position:])
+		if raw and (position == 0 or not (text[position - 1].isalnum() or text[position - 1] == "_")):
+			terminator = '"' + raw.group("hashes")
+			end = text.find(terminator, position + raw.end())
+			end = len(text) if end < 0 else end + len(terminator)
+			clear(position, end)
+			position = end
+			continue
+		if text[position] == '"':
+			end = position + 1
+			while end < len(text):
+				if text[end] == "\\":
+					end += 2
+					continue
+				end += 1
+				if text[end - 1] == '"':
+					break
+			clear(position, end)
+			position = end
+			continue
+		if text[position] == "'":
+			end = None
+			if position + 2 < len(text) and text[position + 1] != "\\" \
+				and text[position + 2] == "'" and text[position + 1] not in {"\n", "\r", "'"}:
+				end = position + 3
+			elif text.startswith("'\\u{", position):
+				brace = text.find("}", position + 4)
+				if brace >= 0 and brace + 1 < len(text) and text[brace + 1] == "'":
+					end = brace + 2
+			elif text.startswith("'\\x", position) and position + 5 < len(text) \
+				and re.fullmatch(r"[0-9A-Fa-f]{2}", text[position + 3:position + 5]) \
+				and text[position + 5] == "'":
+				end = position + 6
+			elif position + 3 < len(text) and text[position + 1] == "\\" and text[position + 3] == "'":
+				end = position + 4
+			if end is not None:
+				clear(position, end)
+				position = end
+				continue
+		position += 1
+	return "".join(masked)
+
+
+def config_type_items(text: str, delimiter: str) -> list[dict[str, object]]:
+	"""Parse Config associated declarations or assignments without consuming nested GAT bounds."""
+	items = []
+	for match in re.finditer(r"\btype\s+([A-Z][A-Za-z0-9_]*)", text):
+		position = match.end()
+		while position < len(text) and text[position].isspace():
+			position += 1
+		generics = None
+		if position < len(text) and text[position] == "<":
+			end = balanced_end(text, position)
+			if end is None:
+				continue
+			generics = text[position:end]
+			position = end
+		while position < len(text) and text[position].isspace():
+			position += 1
+		if position >= len(text) or text[position] != delimiter:
+			continue
+		value_start = position + 1
+		paren = bracket = brace = angle = 0
+		end = None
+		for offset in range(value_start, len(text)):
+			char = text[offset]
+			if char == "(":
+				paren += 1
+			elif char == ")" and paren:
+				paren -= 1
+			elif char == "[":
+				bracket += 1
+			elif char == "]" and bracket:
+				bracket -= 1
+			elif char == "{":
+				brace += 1
+			elif char == "}" and brace:
+				brace -= 1
+			elif char == "<":
+				angle += 1
+			elif char == ">" and angle:
+				angle -= 1
+			elif char == ";" and not (paren or bracket or brace or angle):
+				end = offset
+				break
+		if end is None:
+			continue
+		items.append({"name": match.group(1), "generics": generics,
+			"value": text[value_start:end].strip(), "start": match.start(), "end": end + 1})
+	return items
+
+
+def associated_calls(text: str) -> list[dict[str, object]]:
+	"""Return associated calls while preserving an explicit `<T as Trait>` qualifier."""
+	calls = [{"start": match.start(), "subject": match.group(1), "trait_path": None,
+		"associated_type": match.group(2), "method": match.group(3)}
+		for match in ASSOCIATED_CALL.finditer(text)]
+	for prefix in re.finditer(r"<\s*([A-Za-z_][A-Za-z0-9_]*)\s+as\s+", text):
+		end = balanced_end(text, prefix.start())
+		if end is None:
+			continue
+		tail = re.match(
+			r"\s*::\s*([A-Z][A-Za-z0-9_]*)\s*::\s*([a-zA-Z0-9_]+)", text[end:])
+		if not tail:
+			continue
+		calls.append({"start": prefix.start(), "subject": prefix.group(1),
+			"trait_path": text[prefix.end():end - 1].strip(),
+			"associated_type": tail.group(1), "method": tail.group(2)})
+	return sorted(calls, key=lambda item: int(item["start"]))
+
+
+def config_projection(value: str) -> tuple[str, str, str | None, str] | None:
+	if not value.startswith("<"):
+		return None
+	end = balanced_end(value, 0)
+	if end is None:
+		return None
+	qualified = value[1:end - 1]
+	parts = re.match(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s+as\s+(.+?)\s*$", qualified)
+	if not parts:
+		return None
+	subject, trait = parts.groups()
+	config = trait.rfind("Config")
+	if config < 0:
+		return None
+	trait_path = trait[:config + len("Config")]
+	remainder = trait[config + len("Config"):]
+	if remainder and (not remainder.startswith("<") or balanced_end(remainder, 0) != len(remainder)):
+		return None
+	instance = remainder[1:-1].strip() if remainder else None
+	return subject, trait_path, instance, value[end:]
+
+
+def mir_associated_call(callee: str) -> dict[str, str | None] | None:
+	"""Return a Config projection only when it is the MIR call receiver."""
+	if callee.startswith("<<"):
+		outer_end = balanced_end(callee, 0)
+		if outer_end is not None:
+			method = re.fullmatch(r"::([A-Za-z_][A-Za-z0-9_]*)", callee[outer_end:])
+			projection = config_projection(callee[1:outer_end - 1])
+			if method and projection:
+				subject, trait_path, instance, remainder = projection
+				associated = re.match(r"^::([A-Z][A-Za-z0-9_]*)\s+as\s+", remainder)
+				if associated:
+					return {"subject": subject, "trait_path": trait_path,
+						"config_instance": instance,
+						"associated_type": associated.group(1), "method": method.group(1)}
+	projection = config_projection(callee)
+	if projection:
+		subject, trait_path, instance, remainder = projection
+		direct = re.fullmatch(
+			r"::([A-Z][A-Za-z0-9_]*)::([A-Za-z_][A-Za-z0-9_]*)", remainder)
+		if direct:
+			return {"subject": subject, "trait_path": trait_path,
+				"config_instance": instance,
+				"associated_type": direct.group(1), "method": direct.group(2)}
+	return None
+
+
+def config_associated_types(text: str) -> dict[str, str]:
+	result = {}
+	inactive_ranges = inactive_cfg_ranges(text)
+	masked = mask_rust_comments(text)
+	for match in CONFIG_TRAIT.finditer(masked):
+		end = body_end(masked, match.end() - 1)
+		if end is None:
+			continue
+		body = masked[match.end():end - 1]
+		for associated in config_type_items(body, ":"):
+			if any(start <= match.end() + int(associated["start"]) < stop for start, stop in inactive_ranges):
+				continue
+			result[str(associated["name"])] = re.sub(r"\s+", " ", str(associated["value"])).strip()
+	return result
+
+
+def split_top_level(value: str, delimiter: str = ",") -> list[str]:
+	parts = []
+	start = 0
+	paren = bracket = brace = angle = 0
+	for offset, char in enumerate(value):
+		if char == "(":
+			paren += 1
+		elif char == ")" and paren:
+			paren -= 1
+		elif char == "[":
+			bracket += 1
+		elif char == "]" and bracket:
+			bracket -= 1
+		elif char == "{":
+			brace += 1
+		elif char == "}" and brace:
+			brace -= 1
+		elif char == "<":
+			angle += 1
+		elif char == ">" and angle:
+			angle -= 1
+		elif char == delimiter and not (paren or bracket or brace or angle):
+			parts.append(value[start:offset].strip())
+			start = offset + 1
+	parts.append(value[start:].strip())
+	return [part for part in parts if part]
+
+
+def expand_use_tree(tree: str, prefix: str = "") -> list[str]:
+	tree = tree.strip()
+	opening = tree.find("{")
+	if opening < 0:
+		return ["::".join(part for part in (prefix, tree) if part)]
+	closing = balanced_end(tree, opening, "{", "}")
+	if closing is None:
+		return []
+	head = tree[:opening].strip().removesuffix("::")
+	base = "::".join(part for part in (prefix, head) if part)
+	result = []
+	for item in split_top_level(tree[opening + 1:closing - 1]):
+		if item == "self":
+			result.append(base)
+		elif re.fullmatch(r"self\s+as\s+[A-Za-z_][A-Za-z0-9_]*", item):
+			result.append(f"{base} {item.removeprefix('self ')}")
+		else:
+			result.extend(expand_use_tree(item, base))
+	return result
+
+
+def rust_use_bindings(text: str) -> dict[str, set[str]]:
+	bindings: dict[str, set[str]] = defaultdict(set)
+	inactive_ranges = inactive_cfg_ranges(text)
+	for statement in USE_STATEMENT.finditer(mask_rust_comments(text)):
+		if any(start <= statement.start() < end for start, end in inactive_ranges):
+			continue
+		for imported in expand_use_tree(statement.group(1)):
+			alias = re.search(r"\s+as\s+([A-Za-z_][A-Za-z0-9_]*)\s*$", imported)
+			path = re.sub(r"\s+as\s+[A-Za-z_][A-Za-z0-9_]*\s*$", "", imported).strip()
+			if not path or path.endswith("::*") or (alias and alias.group(1) == "_"):
+				continue
+			local = alias.group(1) if alias else path.rsplit("::", 1)[-1]
+			bindings[local].add(path)
+	return dict(bindings)
+
+
+def canonical_import_path(path: str, bindings: dict[str, set[str]]) -> str:
+	path = re.sub(r"\s+", "", path)
+	for _ in range(4):
+		parts = path.split("::")
+		targets = bindings.get(parts[0], set())
+		if len(targets) != 1:
+			break
+		replacement = next(iter(targets))
+		candidate = "::".join([replacement, *parts[1:]])
+		if candidate == path:
+			break
+		path = candidate
+	return path
+
+
+def canonical_config_crate(crate: str) -> str:
+	return "pallet_liquidity_mining" if crate == "warehouse_liquidity_mining" else crate
+
+
+def source_config_trait(src: str, relative: str) -> str | None:
+	_, module = rust_source_module(relative)
+	if relative.startswith("external/"):
+		crate = relative.split("/", 2)[1]
+	elif relative.startswith("pallets/"):
+		crate = f"pallet_{relative.split('/', 2)[1].replace('-', '_')}"
+	else:
+		return None
+	return "::".join([crate, *module, "Config"])
+
+
+def nearest_config_trait(candidate: str | None, declarations: dict[str, dict[str, str]]) -> str | None:
+	if not candidate or candidate in declarations:
+		return candidate
+	parts = candidate.split("::")[:-1]
+	matches = []
+	for trait in declarations:
+		trait_parts = trait.split("::")[:-1]
+		if len(trait_parts) <= len(parts) and parts[:len(trait_parts)] == trait_parts:
+			matches.append(trait)
+	return max(matches, key=lambda trait: len(trait.split("::")), default=None)
+
+
+def rust_type_aliases(text: str, bindings: dict[str, set[str]]) -> dict[str, set[str]]:
+	aliases: dict[str, set[str]] = defaultdict(set)
+	for match in re.finditer(
+		r"(?m)^[ \t]*(?:pub(?:\([^)]*\))?[ \t]+)?type[ \t]+([A-Z][A-Za-z0-9_]*)[ \t]*=[ \t]*([^;\n]+);",
+		mask_rust_comments(text),
+	):
+		aliases[match.group(1)].add(canonical_import_path(match.group(2).strip(), bindings))
+	return dict(aliases)
+
+
+def config_reference(raw: str, bindings: dict[str, set[str]], default_trait: str | None,
+	type_aliases: dict[str, set[str]] | None = None) -> tuple[str, str | None] | None:
+	raw = re.sub(r"\s+", "", raw)
+	config = raw.rfind("Config")
+	if config < 0:
+		return None
+	trait = raw[:config + len("Config")]
+	remainder = raw[config + len("Config"):]
+	instance = None
+	if remainder:
+		if not remainder.startswith("<") or balanced_end(remainder, 0) != len(remainder):
+			return None
+		instance = remainder[1:-1].strip()
+	if trait in {"Config", "crate::Config", "crate::pallet::Config", "self::Config", "super::Config"}:
+		targets = bindings.get("Config", set())
+		trait = next(iter(targets)) if len(targets) == 1 else default_trait
+	else:
+		trait = canonical_import_path(trait, bindings)
+	if not trait:
+		return None
+	if default_trait and re.fullmatch(r"(?:(?:self|super)::)+(?:pallet::)?Config", trait):
+		trait = default_trait
+	elif default_trait and trait in {"crate::Config", "crate::pallet::Config"}:
+		trait = f"{default_trait.split('::', 1)[0]}::Config"
+	if trait.startswith("pallet::") and default_trait:
+		trait = default_trait.rsplit("::", 1)[0] + trait.removeprefix("pallet")
+	if "::" in trait:
+		crate, remainder = trait.split("::", 1)
+		trait = f"{canonical_config_crate(crate)}::{remainder}"
+	if not trait.endswith("::Config") and trait != "Config":
+		return None
+	if instance and type_aliases:
+		targets = type_aliases.get(instance, set())
+		if len(targets) == 1:
+			instance = canonical_import_path(next(iter(targets)), bindings)
+	if instance and "::" in instance:
+		instance = instance.rsplit("::", 1)[-1]
+	if instance and not (re.fullmatch(r"I[0-9]*", instance) or re.fullmatch(r"Instance[0-9]+", instance)):
+		instance = None
+	return trait, instance
+
+
+def config_references(text: str, bindings: dict[str, set[str]], default_trait: str | None,
+	type_aliases: dict[str, set[str]] | None = None) -> set[tuple[str, str | None]]:
+	result = set()
+	for match in re.finditer(
+		r"(?<![A-Za-z0-9_])((?:[a-zA-Z_][a-zA-Z0-9_]*::)*Config(?:\s*<[^>{}]+>)?)", text
+	):
+		reference = config_reference(match.group(1), bindings, default_trait, type_aliases)
+		if reference:
+			result.add(reference)
+	return result
+
+
+def config_component(trait: str) -> str:
+	return component_id(trait.split("::", 1)[0])
+
+
+def config_owner(trait: str, current: str) -> str:
+	crate = trait.split("::", 1)[0]
+	if crate.startswith(("pallet_", "orml_", "frame_", "cumulus_pallet_")):
+		return component_id(crate)
+	return current
+
+
+def associated_identity(trait: str, instance: str | None, associated_type: str) -> str:
+	parts = trait.split("::")
+	component = config_component(trait)
+	modules = parts[1:-1]
+	qualifiers = [*modules, *([instance] if instance else [])]
+	qualified = f":{':'.join(qualifiers)}" if qualifiers else ""
+	return f"associated:{component}{qualified}:{associated_type}"
+
+
+def config_trait_components(text: str, current: str) -> set[str]:
+	components = set()
+	for crate in re.findall(r"\b([a-z_][a-zA-Z0-9_]*)::Config\b", text):
+		if crate in {"crate", "self", "pallet"}:
+			components.add(current)
+		elif crate.startswith(("pallet_", "orml_", "frame_", "cumulus_pallet_")):
+			components.add(component_id(crate))
+	return components
+
+
+def associated_config_owner(candidates: set[str], associated_type: str,
+	declarations: dict[str, dict[str, str]], parents: dict[str, set[str]]) -> str | None:
+	found = set()
+	queue = deque(sorted(candidates))
+	visited = set()
+	while queue:
+		component = queue.popleft()
+		if component in visited:
+			continue
+		visited.add(component)
+		if associated_type in declarations.get(component, {}):
+			found.add(component)
+		queue.extend(sorted(parents.get(component, set()) - visited))
+	return next(iter(found)) if len(found) == 1 else None
+
+
+def associated_config_references(candidates: set[tuple[str, str | None]], associated_type: str,
+	declarations: dict[str, dict[str, str]], parents: dict[str, set[str]]) -> set[tuple[str, str | None]]:
+	found = set()
+	queue = deque(sorted(candidates, key=lambda item: (item[0], item[1] or "")))
+	visited = set()
+	while queue:
+		trait, instance = queue.popleft()
+		if (trait, instance) in visited:
+			continue
+		visited.add((trait, instance))
+		if associated_type in declarations.get(trait, {}):
+			found.add((trait, instance))
+			continue
+		queue.extend((parent, None) for parent in sorted(parents.get(trait, set())))
+	return found
+
+
+def active_config_references(reference: tuple[str, str | None],
+	active: dict[str, set[str | None]]) -> list[tuple[str, str | None]]:
+	trait, instance = reference
+	instances = active.get(trait, set())
+	if instance in instances or not instances:
+		return [reference]
+	# Generic Config<I> source code applies to every concrete runtime instance of that Config trait.
+	if instance is not None and re.fullmatch(r"I[0-9]*", instance):
+		return [(trait, configured) for configured in sorted(instances, key=lambda item: item or "")]
+	if instance is not None:
+		return [reference]
+	if None not in instances:
+		return [(trait, configured) for configured in sorted(instances, key=lambda item: item or "")]
+	return [reference]
+
+
+def associated_role(name: str, bounds: str | None) -> str:
+	if name.endswith("WeightInfo") or name == "WeightInfo":
+		return "weight-provider"
+	if bounds and re.search(r"(?:^|[+:\s])(?:Get|GetByKey|TypedGet)\s*<", bounds):
+		return "config-value"
+	if name in {"RuntimeEvent", "RuntimeCall", "RuntimeOrigin", "AccountId", "AssetId", "Balance", "Amount",
+		"BlockNumber", "Hash", "Hasher", "Lookup", "Nonce"}:
+		return "config-type"
+	return "callback" if bounds else "unknown"
+
+
+def attribute_targets(text: str, pattern: re.Pattern[str]) -> dict[int, re.Match[str]]:
+	return {offset: attributes[-1] for offset, attributes in attribute_target_lists(text, pattern).items()}
+
+
+def attribute_target_lists(text: str, pattern: re.Pattern[str]) -> dict[int, list[re.Match[str]]]:
+	result: dict[int, list[re.Match[str]]] = defaultdict(list)
+	for attribute in pattern.finditer(text):
+		function = FN.search(text, attribute.end())
+		if function:
+			result[function.start()].append(attribute)
+	return dict(result)
+
+
+def rust_source_module(relative: str) -> tuple[str, tuple[str, ...]]:
+	if "/src/" in relative:
+		crate_scope, source = relative.split("/src/", 1)
+	elif relative.startswith("external/"):
+		parts = relative.split("/")
+		crate_scope, source = "/".join(parts[:2]), "/".join(parts[2:])
+	else:
+		crate_scope, source = relative.rsplit("/", 1) if "/" in relative else (relative, "lib.rs")
+	parts = source.split("/")
+	filename = parts.pop()
+	if filename not in {"lib.rs", "mod.rs"}:
+		parts.append(filename.removesuffix(".rs"))
+	return crate_scope, tuple(parts)
+
+
+def generated_selector_enums(text: str) -> dict[str, dict[str, str]]:
+	result = {}
+	for enum in GENERATED_SELECTOR_ENUM.finditer(text):
+		if "generate_function_selector" not in enum.group("attributes"):
+			continue
+		end = body_end(text, enum.end() - 1)
+		if end is None:
+			continue
+		variants = dict(re.findall(
+			r'([A-Z][A-Za-z0-9_]*)\s*=\s*"([^"]+\([^"\n]*\))"',
+			text[enum.start():end],
+		))
+		if variants:
+			result[enum.group("name")] = variants
+	return result
+
+
+def resolve_selector_import(relative: str, path: str) -> tuple[str, tuple[str, ...], str] | None:
+	crate_scope, current_module = rust_source_module(relative)
+	parts = path.split("::")
+	if parts[0] == "crate":
+		module = []
+		parts = parts[1:]
+	elif parts[0] == "self":
+		module = list(current_module)
+		parts = parts[1:]
+	elif parts[0] == "super":
+		module = list(current_module)
+		while parts and parts[0] == "super":
+			if not module:
+				return None
+			module.pop()
+			parts = parts[1:]
+	else:
+		return None
+	if not parts:
+		return None
+	return crate_scope, tuple([*module, *parts[:-1]]), parts[-1]
+
+
+def selector_type_bindings(text: str, relative: str,
+	definitions: dict[tuple[str, tuple[str, ...], str], dict[str, str] | None]) -> dict[str, dict[str, str]]:
+	crate_scope, module = rust_source_module(relative)
+	bindings = {
+		enum_name: variants
+		for (scope, enum_module, enum_name), variants in definitions.items()
+		if scope == crate_scope and enum_module == module and variants is not None
+	}
+	for imported in SIMPLE_USE.finditer(text):
+		target = resolve_selector_import(relative, imported.group(1))
+		variants = definitions.get(target) if target else None
+		if variants is not None:
+			bindings[imported.group(2) or target[2]] = variants
+	return bindings
+
+
+def macro_argument_ranges(text: str, names: tuple[str, ...]) -> list[tuple[int, int]]:
+	pattern = re.compile(rf"\b(?:{'|'.join(map(re.escape, names))})!\s*\(")
+	ranges = []
+	for match in pattern.finditer(text):
+		start = match.end() - 1
+		depth = 0
+		for offset in range(start, len(text)):
+			if text[offset] == "(":
+				depth += 1
+			elif text[offset] == ")":
+				depth -= 1
+				if depth == 0:
+					ranges.append((start, offset + 1))
+					break
+	return ranges
+
+
+def runtime_config_blocks(text: str) -> list[tuple[re.Match[str], str]]:
+	blocks = []
+	for match in RUNTIME_CONFIG.finditer(text):
+		end = body_end(text, match.end() - 1)
+		if end is not None:
+			blocks.append((match, text[match.end():end - 1]))
+	return blocks
+
+
+def helper_module_ranges(text: str) -> list[tuple[int, int]]:
+	ranges = []
+	for match in HELPER_MODULE.finditer(text):
+		end = body_end(text, match.end() - 1)
+		if end is not None:
+			ranges.append((match.start(), end))
+	return ranges
+
+
+def inactive_cfg_ranges(text: str) -> list[tuple[int, int]]:
+	"""Return item ranges enabled only in tests, benchmarks, or precompile testing builds."""
+	ranges = []
+	for attribute in CFG_ATTRIBUTE.finditer(text):
+		expression = re.sub(r"not\([^)]*\)", "", attribute.group("expression"))
+		if not (re.search(r'feature\s*=\s*"(?:runtime-benchmarks|testing)"', expression)
+			or re.search(r"\btest\b", expression)):
+			continue
+		brace = text.find("{", attribute.end())
+		semicolon = text.find(";", attribute.end())
+		if semicolon >= 0 and (brace < 0 or semicolon < brace):
+			end = semicolon + 1
+		elif brace >= 0:
+			end = body_end(text, brace)
+		else:
+			end = None
+		if end is not None:
+			ranges.append((attribute.start(), end))
+	return ranges
+
+
+def entrypoint_eligible(path: Path, offset: int, helper_ranges: list[tuple[int, int]]) -> bool:
+	if path.name == "weights.rs" or any(part in {"weights", "tests", "test", "mock", "mocks", "benchmarking",
+		"benchmarks"} for part in path.parts):
+		return False
+	return not any(start <= offset < end for start, end in helper_ranges)
+
+
+def source_excluded(path: Path) -> bool:
+	return path.name == "weights.rs" or "weights" in path.parts or "evm-utility" in path.parts or any(
+		part in {"tests", "test", "testing", "mock", "mocks", "benchmarking", "benchmarks"}
+		for part in path.parts
+	) or path.name.startswith(("test", "mock", "bench"))
+
+
+def owner(path: Path, root: Path) -> tuple[str, str]:
+	rel = path.relative_to(root).as_posix()
+	parts = rel.split("/")
+
+	def module_name(prefix: str) -> str:
+		module_parts = rel.removeprefix(prefix).strip("/").split("/")
+		filename = module_parts[-1]
+		if filename in {"lib.rs", "mod.rs"}:
+			if len(module_parts) == 1:
+				return filename.removesuffix(".rs")
+			module_parts = module_parts[:-1]
+		else:
+			module_parts[-1] = filename.removesuffix(".rs")
+		return "/".join(module_parts)
+
+	if parts[0] == "pallets" and len(parts) > 1:
+		return f"pallet:{parts[1]}", "frame"
+	if parts[0] == "precompiles" and len(parts) > 1:
+		return f"precompile:{parts[1]}", "precompile"
+	if rel.startswith("runtime/hydradx/src/evm/precompiles/"):
+		return f"precompile:runtime:{module_name('runtime/hydradx/src/evm/precompiles/')}", "precompile"
+	if rel.startswith("runtime/hydradx/src/evm/"):
+		return f"component:evm:{module_name('runtime/hydradx/src/evm/')}", "evm-adapter"
+	if rel == "runtime/hydradx/src/lib.rs":
+		return "runtime:hydradx", "runtime"
+	if rel.startswith("runtime/hydradx/src/"):
+		return f"component:runtime:{module_name('runtime/hydradx/src/')}", "runtime-adapter"
+	if rel.startswith("runtime/adapters/src/"):
+		return f"component:runtime-adapters:{module_name('runtime/adapters/src/')}", "runtime-adapter"
+	return f"component:{parts[0]}", "rust"
+
+
+class Graph:
+	def __init__(self) -> None:
+		self.nodes: dict[str, dict] = {}
+		self.edges: list[dict] = []
+		self._edge_keys: set[str] = set()
+
+	def node(self, ident: str, kind: str, **data: object) -> None:
+		node = self.nodes.setdefault(ident, {"id": ident, "kind": kind})
+		if node["kind"] == "unresolved-reference" and kind != "unresolved-reference":
+			node["kind"] = kind
+			node.pop("placeholder", None)
+		elif node["kind"] != kind:
+			roles = set(node.get("roles", [])) | {node["kind"], kind}
+			node["roles"] = sorted(roles)
+			if kind in {"pallet", "precompile", "function", "entrypoint", "deployed-contract"}:
+				node["kind"] = kind
+		node.update(data)
+
+	def edge(self, source: str, target: str, kind: str, **data: object) -> None:
+		if source not in self.nodes:
+			self.node(source, "unresolved-reference", placeholder=True)
+		if target not in self.nodes:
+			self.node(target, "unresolved-reference", placeholder=True)
+		edge = {"source": source, "target": target, "kind": kind, **data}
+		key = json.dumps(edge, sort_keys=True, separators=(",", ":"), default=str)
+		if key in self._edge_keys:
+			return
+		self._edge_keys.add(key)
+		self.edges.append(edge)
+
+	def reindex_edges(self) -> None:
+		unique = []
+		self._edge_keys = set()
+		for edge in self.edges:
+			key = json.dumps(edge, sort_keys=True, separators=(",", ":"), default=str)
+			if key in self._edge_keys:
+				continue
+			self._edge_keys.add(key)
+			unique.append(edge)
+		self.edges = unique
+
+
+def add_entrypoint(g: Graph, function: str, entrypoint_kind: str, qualifier: str | None = None,
+	**data: object) -> str:
+	qualified_kind = f"{entrypoint_kind}:{qualifier}" if qualifier else entrypoint_kind
+	ident = f"entrypoint:{qualified_kind}:{function}"
+	g.node(ident, "entrypoint", entrypoint_kind=entrypoint_kind, owner=g.nodes[function].get("owner"), **data)
+	g.edge(ident, function, "enters-function")
+	return ident
+
+
+def ensure_evm_selector(g: Graph, signature: str, selector: str | None = None) -> tuple[str, str]:
+	computed = f"0x{collect_contracts.keccak256(signature.encode())[:4].hex()}"
+	if selector is not None and selector.lower() != computed:
+		raise ValueError(f"selector does not match canonical EVM signature: {signature}")
+	signature_id = f"evm-signature:{signature}"
+	selector_id = f"evm-selector:{computed}"
+	signatures = sorted(set(g.nodes.get(selector_id, {}).get("signatures", [])) | {signature})
+	g.node(signature_id, "evm-signature", domain="evm", signature=signature)
+	g.node(selector_id, "evm-selector", domain="evm", selector=computed, signatures=signatures,
+		selector_collision=len(signatures) > 1)
+	g.edge(signature_id, selector_id, "signature-hashes-to-selector")
+	return signature_id, selector_id
+
+
+def add_precompile_selector_entrypoints(g: Graph, function: str, selectors: list[tuple[str, int]],
+	file: str) -> list[str]:
+	entrypoints = []
+	for signature, line in selectors:
+		_, selector_node = ensure_evm_selector(g, signature)
+		selector = g.nodes[selector_node]["selector"]
+		entrypoint = add_entrypoint(g, function, "precompile-selector", qualifier=selector,
+			signature=signature, selector=selector)
+		g.edge(entrypoint, selector_node, "dispatches-evm-selector", signature=signature, file=file, line=line)
+		entrypoints.append(entrypoint)
+	return entrypoints
+
+
+def add_state_semantics(g: Graph) -> None:
+	storage_ids = sorted({edge["target"] for edge in g.edges if edge["kind"] in {"storage-access", "mir-storage-access"}
+		and edge["target"].startswith("storage:")})
+	for storage_id in storage_ids:
+		name = storage_id.rsplit(":", 1)[-1]
+		owner_id = g.nodes.get(storage_id, {}).get("owner") or storage_id.removeprefix("storage:").rsplit(":", 1)[0]
+		g.node(storage_id, "storage", storage_name=name, owner=owner_id)
+		for invariant in STORAGE_SEMANTICS.get((owner_id, name), ()):
+			ident = f"invariant:{owner_id}:{invariant}"
+			g.node(ident, "state-invariant", domain="state", invariant=invariant, owner=owner_id,
+				classification="explicit-storage-inventory")
+			g.edge(storage_id, ident, "affects-invariant", evidence="explicit-storage-inventory")
+
+
+def merge_semantic_inventory(g: Graph, root: Path) -> dict | None:
+	path = root / "scripts/runtime-interaction-graph/semantic-inventory.json"
+	if not path.is_file():
+		return None
+	inventory = semantic_inventory.load_inventory(root, path)
+	for node in inventory["nodes"]:
+		ident = SEMANTIC_COMPONENTS.get(node["id"], node["id"])
+		kind = g.nodes.get(ident, {}).get("kind", SEMANTIC_NODE_KINDS[node["kind"]])
+		metadata = {
+			"semantic_kind": node["kind"],
+			"semantic_domains": sorted(set(g.nodes.get(ident, {}).get("semantic_domains", [])) | {node["domain"]}),
+			"semantic_label": node["label"],
+			"semantic_description": node["description"],
+			"semantic_evidence": node["evidence"],
+			"semantic_source": node["semantic_source"],
+		}
+		if node["id"] != ident:
+			metadata["semantic_inventory_id"] = node["id"]
+		g.node(ident, kind, **metadata)
+	for edge in inventory["edges"]:
+		g.edge(SEMANTIC_COMPONENTS.get(edge["source"], edge["source"]),
+			SEMANTIC_COMPONENTS.get(edge["target"], edge["target"]), edge["kind"],
+			semantics=edge["semantics"], enforcement=edge["enforcement"],
+			semantic_source=edge["semantic_source"], semantic_evidence=edge["evidence"])
+	g.node("semantic-analysis:explicit-inventory", "semantic-coverage", tool="explicit-inventory",
+		schema_version=inventory["schema_version"], **inventory["coverage"])
+	return inventory
+
+
+def node_runtime_active(g: Graph, node: dict) -> bool:
+	if node.get("runtime_active") is False:
+		return False
+	owner = node.get("owner")
+	if owner and g.nodes.get(owner, {}).get("runtime_active") is False:
+		return False
+	function = node.get("function")
+	return not function or g.nodes.get(function, {}).get("runtime_active") is not False
+
+
+def edge_runtime_active(g: Graph, edge: dict) -> bool:
+	return all(node_runtime_active(g, g.nodes.get(endpoint, {}))
+		for endpoint in (edge["source"], edge["target"]))
+
+
+def projected_edges(g: Graph, projection: str, component_level: bool = False,
+	active_only: bool | None = None) -> list[dict]:
+	allowed = EDGE_PROJECTIONS[projection]
+	edges = component_edges(g) if component_level else g.edges
+	if active_only is None:
+		active_only = projection in {"execution", "callback"}
+	return [edge for edge in edges if edge["kind"] in allowed
+		and (not active_only or edge_runtime_active(g, edge))]
+
+
+def prioritize_gaps(g: Graph, components: list[dict]) -> list[dict]:
+	function_entrypoints: dict[str, set[str]] = defaultdict(set)
+	for edge in g.edges:
+		if edge["kind"] == "enters-function":
+			function_entrypoints[edge["target"]].add(edge["source"])
+	covered = {edge["target"] for edge in g.edges if edge["kind"] == "test-covers-component"}
+	covered.update(entrypoint for edge in g.edges if edge["kind"] == "test-covers-entrypoint"
+		for entrypoint in function_entrypoints[edge["target"]])
+	privileged_functions = {edge["target"] for edge in g.edges if edge["kind"] == "authorizes-entry"
+		and edge["source"] in {"origin:root", "origin:signed-or-root"}}
+	privileged = set().union(*(function_entrypoints[target] for target in privileged_functions)) \
+		if privileged_functions else set()
+	asset_nodes = {edge["source"] for edge in g.edges if edge["kind"] in {"asset-operation", "issues-asset-kind"}}
+	boundary_nodes = {edge["source"] for edge in components if edge["target"].startswith("boundary:")}
+	result = []
+	for node in g.nodes.values():
+		if node["kind"] not in {"entrypoint", "pallet", "precompile", "evm-adapter", "xcm-component"}:
+			continue
+		if node.get("runtime_active") is False:
+			continue
+		ident = node["id"]
+		if ident in covered:
+			continue
+		score = 1
+		reasons = ["no-static-integration-test-link"]
+		if ident in privileged:
+			score += 5; reasons.append("privileged")
+		if ident in asset_nodes or node.get("owner") in asset_nodes:
+			score += 4; reasons.append("asset-impact")
+		if ident in boundary_nodes or node.get("owner") in boundary_nodes:
+			score += 4; reasons.append("execution-boundary")
+		if node.get("owner") and g.nodes.get(node["owner"], {}).get("domain") in {"precompile", "evm-adapter", "xcm"}:
+			score += 3; reasons.append("cross-domain")
+		result.append({"id": ident, "score": score, "reasons": reasons, "kind": node["kind"]})
+	return sorted(result, key=lambda item: (-item["score"], item["id"]))
+
+
+def component_edges(g: Graph) -> list[dict]:
+	"""Collapse function-level calls into evidence-bearing component edges."""
+	owners = {node["id"]: node.get("owner") for node in g.nodes.values() if node.get("owner")}
+	result = []
+	seen = set()
+	for edge in g.edges:
+		if not edge_runtime_active(g, edge):
+			continue
+		source = owners.get(edge["source"], edge["source"])
+		target = owners.get(edge["target"], edge["target"])
+		if not source or source == target or edge["kind"] not in {
+			"direct-call", "runtime-alias-call", "dynamic-call", "resolved-call", "may-resolve-to",
+			"binding-resolves-to", "enters-evm", "dispatches-frame", "asset-kind-resolves-to",
+			"defines-asset-kind", "exposed-as", "may-use-native-backend", "may-be-protocol-controlled",
+			"invokes-precompile", "uses-asset-backend", "issues-asset-kind",
+			"rapx-call", "mir-enters-evm", "mir-dispatches-frame", "mir-external-call",
+			"sends-xcm", "receives-xcm", "moves-xcm-asset", "enters-function", "callback-entry",
+			"uses-deployed-contract",
+			"proxy-implementation", "bytecode-embeds-address", "runtime-configures-contract",
+			"deployment-aliases-contract", "deployment-step-produces-alias",
+			"deployment-step-references-address",
+			"encodes-evm-selector", "dispatches-evm-selector", "signature-hashes-to-selector",
+			"selector-matches-contract-function",
+			"authorizes-entry",
+			"asset-operation", "affects-invariant",
+			"mir-component-call", "mir-dynamic-call", "mir-resolved-call",
+			"storage-access",
+			"runtime-config-read",
+			"runtime-config-type-reference", "weight-evaluation", "configured-as", "instantiates",
+			"declares-associated-type", "executes-evm", "submits-ethereum-transaction", "delivers-xcm",
+			"nested-dispatch", "mir-call", "owns-state", "depends-on-state", "reads-state", "writes-state",
+			"enforces-invariant", "guarded-by-invariant", "routes-asset-to", "backed-by", "configured-origin",
+			"origin-resolves-to",
+			"exposes-entrypoint",
+			"contains", "config-binding",
+			"owns", "reads", "writes", "enforces", "guards", "must-equal", "tracks", "derives-from",
+			"locks", "updates", "backs", "routes-to", "mints", "burns", "transfers-from",
+			"transfers-to", "configured-by", "invokes",
+		}:
+			continue
+		collapsed = {**edge, "source": source, "target": target}
+		if source != edge["source"]:
+			collapsed["evidence_source"] = edge["source"]
+		if target != edge["target"]:
+			collapsed["evidence_target"] = edge["target"]
+		key = json.dumps(collapsed, sort_keys=True, separators=(",", ":"))
+		if key in seen:
+			continue
+		seen.add(key)
+		result.append(collapsed)
+	return sorted(result, key=lambda edge: (edge["source"], edge["target"], edge["kind"],
+		edge.get("line") or 0, json.dumps(edge, sort_keys=True, separators=(",", ":"))))
+
+
+def enrich_resolutions(g: Graph) -> None:
+	bindings: dict[str, list[dict]] = defaultdict(list)
+	for edge in g.edges:
+		if edge["kind"] == "binding-resolves-to":
+			bindings[edge["source"]].append(edge)
+	for associated, edges in bindings.items():
+		node = g.nodes[associated]
+		node["unresolved"] = False
+		resolutions = {edge.get("resolution", "runtime-config") for edge in edges}
+		node["resolution"] = next(iter(resolutions)) if len(resolutions) == 1 else "mixed-runtime-resolution"
+		node["resolved_targets"] = sorted({edge["target"] for edge in edges})
+	for edge in list(g.edges):
+		if edge["kind"] != "dynamic-call":
+			continue
+		for binding in bindings.get(edge["target"], []):
+			g.edge(edge["source"], binding["target"], "resolved-call", method=edge.get("method"),
+				file=edge.get("file"), line=edge.get("line"),
+				resolution=binding.get("resolution", "runtime-config"),
+				associated_type=edge["target"], binding_file=binding.get("file"))
+
+
+def enrich_unique_type_resolutions(g: Graph) -> None:
+	"""Retained as a compatibility no-op; short associated names are not globally resolvable."""
+
+
+def enrich_callback_entrypoints(g: Graph) -> None:
+	functions: dict[tuple[str, str], list[str]] = defaultdict(list)
+	for node in g.nodes.values():
+		if node["kind"] == "function" and node.get("entrypoint_eligible", True):
+			functions[(node.get("owner"), node["name"])].append(node["id"])
+	for edge in list(g.edges):
+		if edge["kind"] != "resolved-call" or not edge.get("method"):
+			continue
+		associated = g.nodes.get(edge.get("associated_type"), {})
+		bounds = associated.get("trait_bounds", "")
+		trait_names = set(re.findall(r"\b([A-Z][A-Za-z0-9_]*)\s*(?:<|\+|$)", bounds))
+		candidates = functions[(edge["target"], edge["method"])]
+		qualified = [function for function in candidates if any(
+			trait in (g.nodes[function].get("implemented_trait") or "") for trait in trait_names)]
+		for function in qualified:
+			entrypoint = add_entrypoint(g, function, "runtime-callback", method=edge["method"],
+				associated_type=edge.get("associated_type"), resolution="trait-qualified")
+			g.edge(edge["source"], entrypoint, "callback-entry", method=edge["method"],
+				associated_type=edge.get("associated_type"), resolution="trait-qualified")
+
+
+def config_is_active(trait: str, instance: str | None,
+	active_configs: dict[str, set[str | None]]) -> bool:
+	instances = active_configs.get(trait, set())
+	if instance is None or re.fullmatch(r"I[0-9]*", instance or ""):
+		return bool(instances)
+	return instance in instances
+
+
+def migration_source(path: str | None) -> bool:
+	if not path:
+		return False
+	parts = path.lower().split("/")
+	return any(part in {"migration", "migrations"} or part.startswith("migration.")
+		or part.startswith("migrations.") for part in parts)
+
+
+def enrich_migration_calls(g: Graph) -> None:
+	functions: dict[tuple[str, str], list[str]] = defaultdict(list)
+	for node in g.nodes.values():
+		if node.get("kind") == "function" and migration_source(node.get("file")):
+			functions[(node["file"], node["name"])].append(node["id"])
+	for node in list(g.nodes.values()):
+		if node.get("kind") != "function" or not migration_source(node.get("file")):
+			continue
+		for call in node.get("local_pallet_calls", []):
+			candidates = functions.get((node["file"], call["method"]), [])
+			if len(candidates) == 1:
+				g.edge(node["id"], candidates[0], "direct-call", method=call["method"],
+					file=node["file"], line=call["line"], resolution="source-local-migration")
+
+
+def propagate_runtime_activity(g: Graph) -> None:
+	changed = True
+	while changed:
+		changed = False
+		for node in g.nodes.values():
+			if node.get("runtime_active") is False:
+				continue
+			dependencies = []
+			if node.get("function"):
+				dependencies.append(node["function"])
+			if node.get("instance") and isinstance(node.get("instance"), str) \
+				and node["instance"].startswith("mir-instance:"):
+				dependencies.append(node["instance"])
+			if any(g.nodes.get(dependency, {}).get("runtime_active") is False for dependency in dependencies):
+				node.update({"runtime_active": False, "runtime_activity": "inventory-only",
+					"runtime_activity_reason": "inactive-source-function"})
+				changed = True
+		for edge in g.edges:
+			if edge["kind"] != "enters-function":
+				continue
+			if g.nodes.get(edge["target"], {}).get("runtime_active") is False \
+				and g.nodes.get(edge["source"], {}).get("runtime_active") is not False:
+				g.nodes[edge["source"]].update({"runtime_active": False,
+					"runtime_activity": "inventory-only", "runtime_activity_reason": "inactive-entrypoint"})
+				changed = True
+
+
+def classify_runtime_activity(g: Graph, runtime_components: set[str],
+	active_configs: dict[str, set[str | None]], inventory_complete: bool,
+	known_config_traits: set[str] | None = None) -> None:
+	for component in runtime_components:
+		if component in g.nodes:
+			g.nodes[component].update({"runtime_active": True, "runtime_instantiated": True})
+	configured_migrations = {edge["target"] for edge in g.edges if edge["kind"] == "enters-function"
+		and g.nodes.get(edge["source"], {}).get("entrypoint_kind") in {"runtime-migration", "try-runtime"}}
+	active_migration_functions = set(configured_migrations)
+	changed = True
+	while changed:
+		changed = False
+		for edge in g.edges:
+			if edge["kind"] != "direct-call" or edge["source"] not in active_migration_functions:
+				continue
+			target = g.nodes.get(edge["target"], {})
+			if target.get("kind") != "function" or not migration_source(target.get("file")) \
+				or edge["target"] in active_migration_functions:
+				continue
+			active_migration_functions.add(edge["target"])
+			changed = True
+	for node in g.nodes.values():
+		if node.get("kind") != "function":
+			continue
+		if migration_source(node.get("file")):
+			active = node["id"] in active_migration_functions
+			node.update({"runtime_active": active,
+				"runtime_activity": "active" if active else "inventory-only",
+				"runtime_activity_reason": "configured-migration" if active else "migration-not-configured"})
+			continue
+		requirements = [(item.get("trait"), item.get("instance"))
+			for item in node.get("required_config_traits", []) if item.get("trait")
+			and (known_config_traits is None or item.get("trait") in known_config_traits)]
+		inactive_requirements = [(trait, instance) for trait, instance in requirements
+			if not config_is_active(trait, instance, active_configs)]
+		if not inactive_requirements:
+			continue
+		owner_active = node.get("owner") in runtime_components
+		if inventory_complete:
+			node.update({"runtime_active": False, "runtime_activity": "inventory-only",
+				"runtime_activity_reason": "config-trait-not-implemented" if owner_active
+				else "component-not-instantiated", "inactive_config_traits": [
+					{"trait": trait, "instance": instance} for trait, instance in inactive_requirements]})
+	used_associated = {edge["target"] for edge in g.edges
+		if edge["kind"] in {"dynamic-call", "mir-dynamic-call", "configured-origin"}}
+	inactive_components = set()
+	for node in g.nodes.values():
+		if node.get("kind") != "associated-type" or node["id"] not in used_associated:
+			continue
+		trait = node.get("config_trait")
+		instance = node.get("config_instance")
+		if trait and not config_is_active(trait, instance, active_configs) and inventory_complete:
+			owner_active = node.get("owner") in runtime_components
+			node.update({"runtime_active": False, "runtime_activity": "inventory-only",
+				"runtime_activity_reason": "config-trait-not-implemented" if owner_active
+				else "component-not-instantiated"})
+			if not owner_active and node.get("owner"):
+				inactive_components.add(node["owner"])
+			continue
+		incoming = [edge for edge in g.edges if edge["target"] == node["id"]
+			and edge["kind"] in {"dynamic-call", "mir-dynamic-call", "configured-origin"}]
+		if incoming and all(g.nodes.get(edge["source"], {}).get("runtime_active") is False
+			for edge in incoming):
+			node.update({"runtime_active": False, "runtime_activity": "inventory-only",
+				"runtime_activity_reason": "migration-not-configured"})
+	for component in inactive_components:
+		if component in g.nodes:
+			g.nodes[component].update({"runtime_active": False, "runtime_instantiated": False,
+				"runtime_activity": "inventory-only", "runtime_activity_reason": "component-not-instantiated"})
+	propagate_runtime_activity(g)
+
+
+def classify_unresolved(g: Graph) -> None:
+	propagate_runtime_activity(g)
+	bindings_by_node: dict[str, set[str]] = defaultdict(set)
+	used_associated = {edge["target"] for edge in g.edges
+		if edge["kind"] in {"dynamic-call", "mir-dynamic-call", "configured-origin"}}
+	for edge in g.edges:
+		if edge["kind"] == "binding-resolves-to":
+			bindings_by_node[edge["source"]].add(edge["target"])
+	for node in g.nodes.values():
+		if node["kind"] != "associated-type" or not node.get("unresolved"):
+			continue
+		if node.get("runtime_active") is False:
+			node.update({"unresolved": False, "resolution": "inventory-only", "candidate_targets": [],
+				"ambiguity_reason": node.get("runtime_activity_reason", "inventory-only")})
+			continue
+		if node["id"] not in used_associated and not bindings_by_node[node["id"]]:
+			node.update({"unresolved": False, "resolution": "declaration-only", "candidate_targets": []})
+			continue
+		targets = bindings_by_node[node["id"]]
+		node["ambiguity_reason"] = "multiple-runtime-targets" if len(targets) > 1 else "no-runtime-binding"
+		node["candidate_targets"] = sorted(targets)
+
+
+def normalize_config_value_calls(g: Graph) -> None:
+	incoming: dict[str, list[dict]] = defaultdict(list)
+	for edge in g.edges:
+		if edge["kind"] in {"dynamic-call", "mir-dynamic-call"}:
+			incoming[edge["target"]].append(edge)
+	for target, edges in incoming.items():
+		node = g.nodes.get(target, {})
+		role = node.get("associated_role")
+		if role not in {"config-value", "config-type", "weight-provider"}:
+			continue
+		kind = {"config-value": "runtime-config-value", "config-type": "runtime-config-type",
+			"weight-provider": "runtime-weight-provider"}[role]
+		node.update({"kind": kind, "unresolved": False, "resolution": "trait-bound-classification"})
+		for edge in edges:
+			edge["kind"] = {"config-value": "runtime-config-read", "config-type": "runtime-config-type-reference",
+				"weight-provider": "weight-evaluation"}[role]
+	# Declaration-only types are classified only when their Config trait provides enough evidence.
+	for node in g.nodes.values():
+		role = node.get("associated_role")
+		if node.get("kind") != "associated-type" or node["id"] in incoming \
+			or role not in {"config-value", "config-type", "weight-provider"}:
+			continue
+		node.update({"kind": {"config-value": "runtime-config-value", "config-type": "runtime-config-type",
+			"weight-provider": "runtime-weight-provider"}[role], "unresolved": False,
+			"resolution": "trait-bound-classification"})
+	g.reindex_edges()
+
+
+def enrich_configured_origins(g: Graph) -> None:
+	bindings: dict[str, set[str]] = defaultdict(set)
+	for edge in g.edges:
+		if edge["kind"] == "binding-resolves-to":
+			bindings[edge["source"]].add(edge["target"])
+	for edge in list(g.edges):
+		if edge["kind"] != "configured-origin":
+			continue
+		for target in bindings[edge["target"]]:
+			g.edge(edge["source"], target, "origin-resolves-to", associated_type=edge["target"],
+				resolution="runtime-config")
+
+
+def add_configured_migrations(g: Graph, root: Path) -> None:
+	path = root / "runtime/hydradx/src/migrations/mod.rs"
+	if not path.is_file():
+		return
+	text = path.read_text(errors="replace")
+	symbols = set(re.findall(r"\b([A-Z][A-Za-z0-9_]*(?:Migration|Migrations|Version)[A-Za-z0-9_]*)\b", text))
+	for function in list(g.nodes.values()):
+		if function.get("kind") != "function" or function.get("name") not in {
+			"on_runtime_upgrade", "pre_upgrade", "post_upgrade"}:
+			continue
+		header = function.get("impl_header") or ""
+		if not any(symbol in header for symbol in symbols):
+			continue
+		kind = "runtime-migration" if function["name"] == "on_runtime_upgrade" else "try-runtime"
+		add_entrypoint(g, function["id"], kind, method=function["name"], configured_by=path.relative_to(root).as_posix())
+
+
+def enrich_runtime_instances(g: Graph, entries: list[dict]) -> None:
+	instances: dict[str, list[tuple[str, dict]]] = defaultdict(list)
+	for entry in entries:
+		instances[component_id(entry["crate"])].append((f"runtime-instance:{entry['alias']}", entry))
+	for entrypoint in [node for node in g.nodes.values() if node.get("kind") == "entrypoint"]:
+		for instance, entry in instances[entrypoint.get("owner")]:
+			if entrypoint.get("entrypoint_kind") == "extrinsic" and "Call" in entry["excluded_parts"]:
+				continue
+			g.edge(instance, entrypoint["id"], "exposes-entrypoint", runtime_alias=entry["alias"],
+				instance=entry["instance"], pallet_index=entry["index"])
+
+
+def merge_integration_tests(g: Graph, root: Path, aliases: dict[str, str]) -> None:
+	functions: dict[tuple[str, str], list[str]] = defaultdict(list)
+	entrypoint_functions = {edge["target"] for edge in g.edges if edge["kind"] == "enters-function"}
+	for node in g.nodes.values():
+		if node["kind"] == "function" and node["id"] in entrypoint_functions:
+			functions[(node.get("owner"), node["name"])].append(node["id"])
+	for path in sorted((root / "integration-tests/src").rglob("*.rs")):
+		text = path.read_text(errors="replace")
+		rel = path.relative_to(root).as_posix()
+		scopes = scope_ranges(text)
+		test_targets = attribute_targets(text, re.compile(r"#\[(?:tokio::)?test\]"))
+		definitions = {}
+		for match in FN.finditer(text):
+			end = function_body_end(text, match.end())
+			if not end:
+				continue
+			definitions.setdefault(match.group(1), (match, text[match.start():end]))
+		for match, body in definitions.values():
+			if match.start() not in test_targets:
+				continue
+			ident = function_source_id(text, match, rel, scopes, "integration-test")
+			assertions = len(re.findall(r"\b(?:assert|assert_eq|assert_ne|assert_ok|assert_noop|assert_err|assert_storage_noop)!", body))
+			dispatch_assertions = len(re.findall(r"\b(?:assert_ok|assert_noop|assert_err)!\s*\(", body))
+			confidence = "mixed-call-site" if dispatch_assertions else ("assertion-present" if assertions else "reference")
+			g.node(ident, "integration-test", file=rel, line=line_of(text, match.start()), name=match.group(1),
+				assertion_count=assertions, dispatch_assertion_count=dispatch_assertions, confidence=confidence)
+			segments = [(body, "test-body")]
+			seen_helpers = set()
+			queue = deque(re.findall(r"\b([a-z_][a-zA-Z0-9_]*)\s*\(", body))
+			while queue and len(seen_helpers) < 50:
+				helper = queue.popleft()
+				if helper in seen_helpers or helper not in definitions or helper == match.group(1):
+					continue
+				seen_helpers.add(helper)
+				helper_body = definitions[helper][1]
+				segments.append((helper_body, "local-helper"))
+				queue.extend(re.findall(r"\b([a-z_][a-zA-Z0-9_]*)\s*\(", helper_body))
+			combined = "\n".join(segment for segment, _ in segments)
+			components = set()
+			for alias, crate in aliases.items():
+				if re.search(rf"\b{alias}\b", combined):
+					components.add(component_id(crate))
+			for crate in re.findall(r"\b((?:pallet|orml|cumulus_pallet)_[a-zA-Z0-9_]+)\b", combined):
+				components.add(component_id(crate))
+			stem = path.stem.replace("_", "-")
+			if f"pallet:{stem}" in g.nodes:
+				components.add(f"pallet:{stem}")
+			if re.search(r"\b(?:EVM|Evm|eth_|H160|Precompile)\b", combined):
+				components.add("boundary:evm-execution")
+			if re.search(r"\b(?:Xcm|XCM|xcm|Location|VersionedAssets)\b", combined):
+				components.add("boundary:xcm-outbound")
+			for component in sorted(components):
+				g.edge(ident, component, "test-covers-component", evidence="source-reference", confidence="reference")
+			for segment, segment_source in segments:
+				dispatch_ranges = macro_argument_ranges(segment, ("assert_ok", "assert_noop", "assert_err"))
+				for call in re.finditer(r"\b([A-Z][A-Za-z0-9_]*)::([a-zA-Z0-9_]+)\s*\(", segment):
+					alias, method = call.groups()
+					crate = aliases.get(alias)
+					if not crate:
+						continue
+					asserted = any(start <= call.start() < end for start, end in dispatch_ranges)
+					call_confidence = "direct-dispatch-assertion" if asserted else (
+						"helper-propagated" if segment_source == "local-helper" else "source-call")
+					for function in functions[(component_id(crate), method)]:
+						g.edge(ident, function, "test-covers-entrypoint", evidence=segment_source,
+							confidence=call_confidence, asserted=asserted)
+
+
+def semantic_source_prefix(owner: str) -> str | None:
+	if owner == "runtime:hydradx":
+		return "runtime/hydradx/src/"
+	if owner.startswith("pallet:"):
+		return f"pallets/{owner.removeprefix('pallet:')}/src/"
+	if owner.startswith("precompile:"):
+		return f"precompiles/{owner.removeprefix('precompile:')}/src/"
+	return None
+
+
+def semantic_package_function(node: dict, owner: str) -> bool:
+	prefix = semantic_source_prefix(owner)
+	if node.get("kind") != "function":
+		return False
+	file = node.get("file") or ""
+	return file.startswith(prefix) if prefix and file else node.get("owner") == owner
+
+
+def resolve_semantic_symbol(g: Graph, candidates: list[str], symbol: str, owner: str) -> str | None:
+	if len(candidates) == 1:
+		return candidates[0]
+	prefix = semantic_source_prefix(owner)
+	if not prefix:
+		return None
+	qualified = []
+	for candidate in candidates:
+		file = g.nodes[candidate].get("file") or ""
+		if not file.startswith(prefix):
+			continue
+		module = file.removeprefix(prefix).removesuffix(".rs")
+		module = module.removesuffix("/mod")
+		if module == "lib":
+			module = ""
+		module = module.replace("/", "::")
+		if module and re.search(rf"(?:^|[<\s]){re.escape(module)}::", symbol):
+			qualified.append(candidate)
+	return qualified[0] if len(qualified) == 1 else None
+
+
+def merge_rapx(g: Graph, path: Path, owner: str) -> int:
+	functions: dict[str, list[str]] = defaultdict(list)
+	for node in g.nodes.values():
+		if semantic_package_function(node, owner):
+			functions[node["name"]].append(node["id"])
+	current = None
+	added = 0
+	for line in path.read_text(errors="replace").splitlines():
+		caller = re.match(r"^  (.+) calls:$", line)
+		if caller:
+			symbol = caller.group(1)
+			name = symbol.split("::")[-1].split("{")[0]
+			current = resolve_semantic_symbol(g, functions.get(name, []), symbol, owner)
+			continue
+		callee = re.match(r"^    -> (.+)$", line)
+		if not current or not callee:
+			continue
+		target_name = callee.group(1)
+		method = target_name.split("::")[-1].split("{")[0]
+		local_call = target_name.startswith("<impl pallet::Pallet") or target_name.startswith("pallet::Pallet")
+		target = resolve_semantic_symbol(g, functions.get(method, []), target_name, owner) if local_call else None
+		if not target:
+			pallet = re.match(r"(pallet_[a-zA-Z0-9_]+)::Pallet", target_name)
+			if pallet:
+				target = f"pallet:{pallet.group(1).removeprefix('pallet_').replace('_', '-')}"
+			elif "hydradx_traits::evm::EVM::call" in target_name:
+				target = "boundary:evm-execution"
+		if target and target != current:
+			g.edge(current, target, "rapx-call", method=method, semantic_source="rapx",
+				rapx_output=path.name)
+			added += 1
+	return added
+
+
+def semantic_tool_inputs(tool: str) -> dict:
+	scripts = Path(__file__).parent
+	paths = [scripts / ("collect_mir.py" if tool == "rustc-mir" else "collect_rapx.py"),
+		scripts / "analysis_provenance.py"]
+	if tool == "rustc-mir":
+		paths.append(scripts / "collect_rapx.py")
+	return analysis_provenance.tool_input_fingerprint(paths)
+
+
+def semantic_artifact_path(manifest_path: Path, value: object, context: str) -> Path:
+	if not isinstance(value, str) or not value:
+		raise ValueError(f"{context} must be a non-empty relative path")
+	relative = Path(value)
+	if relative.is_absolute():
+		raise ValueError(f"{context} must stay inside the manifest directory")
+	parent = manifest_path.parent.resolve()
+	path = (parent / relative).resolve()
+	try:
+		path.relative_to(parent)
+	except ValueError as error:
+		raise ValueError(f"{context} must stay inside the manifest directory") from error
+	return path
+
+
+def valid_sha256(value: object) -> bool:
+	return isinstance(value, str) and bool(re.fullmatch(r"[0-9a-f]{64}", value))
+
+
+def validate_semantic_manifest(manifest: dict, path: Path, tool: str, root: Path | None = None) -> None:
+	if manifest.get("schema_version") != 2 or manifest.get("tool") != tool:
+		raise ValueError(f"{tool} manifest must use schema_version 2")
+	collector_module = collect_mir if tool == "rustc-mir" else collect_rapx
+	collector = Path(__file__).with_name("collect_mir.py" if tool == "rustc-mir" else "collect_rapx.py")
+	if manifest.get("toolchain") != collector_module.TOOLCHAIN:
+		raise ValueError(f"{tool} manifest toolchain is invalid")
+	timeout = manifest.get("timeout_seconds")
+	if not isinstance(timeout, int) or isinstance(timeout, bool) or timeout <= 0:
+		raise ValueError(f"{tool} manifest timeout is invalid")
+	packages = manifest.get("packages")
+	requested = manifest.get("requested_packages")
+	if not isinstance(packages, list) or not isinstance(requested, list) \
+		or any(not isinstance(package, str) or not package for package in requested) \
+		or len(requested) != len(set(requested)) or any(not isinstance(package, dict) for package in packages):
+		raise ValueError(f"{tool} manifest package inventory is invalid")
+	package_names = [package.get("package") for package in packages]
+	if any(not isinstance(package, str) or not package for package in package_names) \
+		or len(package_names) != len(set(package_names)) or sorted(package_names) != sorted(requested):
+		raise ValueError(f"{tool} manifest package inventory is incomplete")
+	provenance = manifest.get("provenance", {})
+	source_count = provenance.get("source_inputs", {}).get("file_count")
+	tool_inputs = provenance.get("tool_inputs")
+	if not valid_sha256(provenance.get("source_inputs", {}).get("sha256")) \
+		or not isinstance(source_count, int) or isinstance(source_count, bool) or source_count < 0 \
+		or not valid_sha256(provenance.get("collector_sha256")) \
+		or provenance.get("toolchain") != collector_module.TOOLCHAIN \
+		or not analysis_provenance.valid_tool_input_fingerprint(tool_inputs):
+		raise ValueError(f"{tool} manifest has no verified source provenance")
+	if tool_inputs["files"].get(collector.name) != provenance["collector_sha256"]:
+		raise ValueError(f"{tool} manifest collector is not bound to its tooling fingerprint")
+	if root is not None:
+		current_sources = analysis_provenance.tree_fingerprint(root)
+		if provenance["source_inputs"] != current_sources:
+			raise ValueError(f"{tool} manifest source fingerprint is stale")
+		if provenance["collector_sha256"] != analysis_provenance.file_sha256(collector):
+			raise ValueError(f"{tool} manifest collector fingerprint is stale")
+		if tool_inputs != semantic_tool_inputs(tool):
+			raise ValueError(f"{tool} manifest tooling fingerprint is stale")
+	workspace = None
+	if root is not None and requested:
+		workspace = {package["package"]: package for package in collect_rapx.workspace_packages(root)}
+		if any(package not in workspace for package in requested):
+			raise ValueError(f"{tool} manifest requests an unknown workspace package")
+	requested_analyses = None
+	if tool == "rapx":
+		requested_analyses = manifest.get("requested_analyses")
+		if not isinstance(requested_analyses, list) or not requested_analyses \
+			or len(requested_analyses) != len(set(requested_analyses)) \
+			or any(analysis not in {"callgraph", "mir", "dataflow"} for analysis in requested_analyses):
+			raise ValueError("rapx manifest requested analysis inventory is invalid")
+	for package in packages:
+		if not isinstance(package.get("owner"), str) or not package["owner"] \
+			or not isinstance(package.get("manifest"), str) or not package["manifest"]:
+			raise ValueError(f"{tool} package metadata is invalid: {package.get('package')!r}")
+		package_metadata = {key: package[key] for key in ("package", "owner", "manifest")}
+		manifest_relative = Path(package["manifest"])
+		if manifest_relative.is_absolute() or ".." in manifest_relative.parts:
+			raise ValueError(f"{tool} package manifest path is invalid: {package['package']}")
+		if workspace is not None and workspace[package["package"]] != package_metadata:
+			raise ValueError(f"{tool} package metadata does not match the workspace: {package['package']}")
+		if tool == "rapx":
+			analyses = package.get("analyses")
+			if not isinstance(analyses, dict) or set(analyses) != set(requested_analyses):
+				raise ValueError(f"rapx package analysis inventory is incomplete: {package['package']}")
+			artifacts = [(f"{package['package']}.{name}", name, analysis, "path")
+				for name, analysis in analyses.items()]
+			statuses = {"ok", "failed", "timeout", "invalid-output"}
+		else:
+			artifacts = [(package["package"], None, package, "artifact")]
+			statuses = {"ok", "failed", "timeout"}
+		for context, analysis_name, artifact, path_field in artifacts:
+			if not isinstance(artifact, dict) or artifact.get("status") not in statuses:
+				raise ValueError(f"{tool} artifact status is invalid: {context}")
+			expected_command = (collect_rapx.analysis_command(package_metadata, analysis_name, timeout)
+				if analysis_name is not None else collect_mir.mir_command(package_metadata))
+			if artifact.get("command") != expected_command:
+				raise ValueError(f"{tool} artifact command is invalid: {context}")
+			fingerprint_context = ({**package_metadata, "analysis": analysis_name}
+				if analysis_name is not None else package_metadata)
+			expected_fingerprint = analysis_provenance.command_fingerprint(
+				provenance, fingerprint_context, expected_command)
+			if artifact.get("input_fingerprint") != expected_fingerprint:
+				raise ValueError(f"{tool} artifact input fingerprint is invalid: {context}")
+			semantic_artifact_path(path, artifact.get(path_field), f"{context}.{path_field}")
+			if artifact.get("log") is not None:
+				semantic_artifact_path(path, artifact["log"], f"{context}.log")
+			if artifact["status"] != "ok":
+				continue
+			artifact_path = semantic_artifact_path(path, artifact.get(path_field), f"{context}.{path_field}")
+			if not artifact_path.is_file() or not valid_sha256(artifact.get("artifact_sha256")) \
+				or hashlib.sha256(artifact_path.read_bytes()).hexdigest() != artifact["artifact_sha256"]:
+				raise ValueError(f"{tool} artifact is missing or stale: {artifact.get(path_field)}")
+
+
+def merge_rapx_manifest(g: Graph, path: Path, root: Path | None = None) -> int:
+	manifest = json.loads(path.read_text())
+	validate_semantic_manifest(manifest, path, "rapx", root)
+	added = 0
+	coverage = []
+	for package in manifest.get("packages", []):
+		analysis = package.get("analyses", {}).get("callgraph", {})
+		coverage.append({"package": package["package"], "owner": package["owner"],
+			"callgraph": analysis.get("status", "missing"),
+			"mir": package.get("analyses", {}).get("mir", {}).get("status", "not-requested"),
+			"dataflow": package.get("analyses", {}).get("dataflow", {}).get("status", "not-requested")})
+		if analysis.get("status") != "ok":
+			continue
+		added += merge_rapx(g, path.parent / analysis["path"], package["owner"])
+	g.node("semantic-analysis:rapx-coverage", "semantic-coverage", tool="rapx",
+		manifest=path.name, manifest_sha256=analysis_provenance.file_sha256(path), packages=coverage,
+		callgraph_success=sum(item["callgraph"] == "ok" for item in coverage), total_packages=len(coverage))
+	return added
+
+
+def mir_operation(line: str) -> str | None:
+	item = mir_parser.operation(line)
+	return item["kind"] if item else None
+
+
+def mir_order_flags(blocks: dict[int, dict]) -> tuple[bool, bool]:
+	normalized = {block: {**data, "normal_successors": data.get("normal_successors", data.get("successors", []))}
+		for block, data in blocks.items()}
+	return mir_parser.order_flags(normalized)
+
+
+def merge_rustc_mir(g: Graph, path: Path, owner: str) -> int:
+	def in_package(node: dict) -> bool:
+		return semantic_package_function(node, owner)
+
+	def trait_matches(target: str, trait_path: str, function_owner: str) -> bool:
+		target_node = g.nodes.get(target, {})
+		target_trait = target_node.get("config_trait")
+		if not target_trait:
+			return False
+		trait_path = re.sub(r"\s+", "", trait_path)
+		if trait_path in {"Config", "pallet::Config", "crate::Config", "crate::pallet::Config",
+			"self::Config", "super::Config", "super::pallet::Config"}:
+			return config_component(target_trait) == function_owner
+		crate, separator, remainder = trait_path.partition("::")
+		canonical = f"{canonical_config_crate(crate)}::{remainder}" if separator else trait_path
+		return target_trait == canonical
+
+	def instance_matches(target: str, raw_instance: str | None, fallback: bool = False) -> bool:
+		target_node = g.nodes.get(target, {})
+		target_instance = target_node.get("config_instance")
+		if raw_instance is None:
+			return target_instance is None
+		instance = re.sub(r"\s+", "", raw_instance).rsplit("::", 1)[-1]
+		if re.fullmatch(r"I[0-9]*", instance):
+			return target_node.get("runtime_instance") is not None
+		if re.fullmatch(r"Instance[0-9]+", instance):
+			return target_instance == instance
+		return not fallback
+
+	functions: dict[str, list[str]] = defaultdict(list)
+	for node in g.nodes.values():
+		if in_package(node):
+			functions[node["name"]].append(node["id"])
+	instances = mir_parser.parse(path.read_text(errors="replace"))
+	added = 0
+	matched_functions = set()
+	matched_instances = 0
+	for instance in instances:
+		candidates = functions.get(instance["name"], [])
+		if instance.get("source_file"):
+			candidates = [candidate for candidate in candidates
+				if g.nodes[candidate].get("file") == instance["source_file"]]
+		if instance.get("impl_line") is not None and candidates:
+			following = [candidate for candidate in candidates
+				if g.nodes[candidate].get("line", 0) >= instance["impl_line"]]
+			if following:
+				candidates = [min(following,
+					key=lambda candidate: g.nodes[candidate].get("line", 0) - instance["impl_line"])]
+		if len(candidates) != 1:
+			continue
+		function = candidates[0]
+		function_owner = g.nodes[function].get("owner") or owner
+		source_associated_targets: dict[tuple[str, str | None], set[str]] = defaultdict(set)
+		for source_edge in g.edges:
+			if source_edge["source"] != function or source_edge["kind"] not in {
+				"dynamic-call", "runtime-config-read", "runtime-config-type-reference", "weight-evaluation",
+			}:
+				continue
+			target_node = g.nodes.get(source_edge["target"], {})
+			associated_type = target_node.get("associated_type")
+			if associated_type:
+				source_associated_targets[(associated_type, source_edge.get("method"))].add(source_edge["target"])
+		function_blocks = instance["blocks"]
+		operations = [{"block": block, **operation} for block, data in sorted(function_blocks.items())
+			for operation in data["operations"]]
+		if not operations:
+			continue
+		matched_functions.add(function)
+		matched_instances += 1
+		before, after = mir_parser.order_flags(function_blocks)
+		unwind_before, unwind_after = mir_parser.order_flags(function_blocks, "unwind_successors")
+		g.nodes[function].setdefault("mir_operations", []).extend(
+			[{**operation, "instance": instance["id"]} for operation in operations if operation["kind"] != "call"])
+		g.nodes[function]["mir_write_before_external"] = \
+			g.nodes[function].get("mir_write_before_external", False) or before
+		g.nodes[function]["mir_write_after_external"] = \
+			g.nodes[function].get("mir_write_after_external", False) or after
+		g.nodes[function]["mir_unwind_write_before_external"] = \
+			g.nodes[function].get("mir_unwind_write_before_external", False) or unwind_before
+		g.nodes[function]["mir_unwind_write_after_external"] = \
+			g.nodes[function].get("mir_unwind_write_after_external", False) or unwind_after
+		g.nodes[function]["mir_source"] = path.name
+		instance_node = f"mir-instance:{owner}:{instance['id']}"
+		g.node(instance_node, "mir-instance", owner=function_owner, function=function, symbol=instance["symbol"],
+			source_file=instance.get("source_file"), impl_line=instance.get("impl_line"), semantic_source="rustc-mir")
+		g.edge(function, instance_node, "has-mir-instance", semantic_source="rustc-mir")
+		operation_nodes: dict[int, list[str]] = defaultdict(list)
+		for block, data in sorted(function_blocks.items()):
+			for index, operation in enumerate(data["operations"]):
+				callee = operation.get("callee") or ""
+				component_match = re.search(
+					r"\b((?:pallet_|orml_|cumulus_pallet_|frame_)[A-Za-z0-9_]+)::Pallet", callee)
+				associated_call = mir_associated_call(callee)
+				method = associated_call["method"] if associated_call \
+					else (callee.rsplit("::", 1)[-1].split("<", 1)[0] if callee else None)
+				associated_targets = set()
+				if associated_call:
+					associated_type = str(associated_call["associated_type"])
+					candidates_by_type = source_associated_targets.get((associated_type, method), set()) \
+						or source_associated_targets.get((associated_type, None), set())
+					associated_targets = {target for target in candidates_by_type
+						if trait_matches(target, str(associated_call["trait_path"]), function_owner)
+						and instance_matches(target, associated_call["config_instance"])}
+					if not associated_targets:
+						associated_targets = {node["id"] for node in g.nodes.values()
+							if node.get("associated_type") == associated_type
+							and node.get("runtime_instance") is not None
+							and trait_matches(node["id"], str(associated_call["trait_path"]), function_owner)
+							and instance_matches(node["id"], associated_call["config_instance"], fallback=True)
+							and node.get("runtime_active") is not False}
+				local_target = None
+				if operation["kind"] == "call" and method and (callee.startswith(("pallet::", "<impl", "Self::"))):
+					local_candidates = functions.get(method, [])
+					local_target = local_candidates[0] if len(local_candidates) == 1 else None
+				relevant_call = operation["kind"] != "call" or component_match or associated_targets or local_target
+				if not relevant_call:
+					continue
+				ident = f"mir-operation:{instance_node}:{block}:{index}"
+				operation_nodes[block].append(ident)
+				g.node(ident, "mir-operation", owner=function_owner, function=function, instance=instance_node, block=block,
+					operation_index=index, operation=operation["kind"], statement=operation["statement"],
+					callee=operation.get("callee"), semantic_source="rustc-mir")
+				g.edge(instance_node, ident, "mir-contains-operation", block=block, operation_index=index)
+				if operation["kind"] == "evm-call":
+					g.edge(ident, "boundary:evm-execution", "mir-enters-evm", semantic_source="rustc-mir")
+				elif operation["kind"] == "frame-dispatch":
+					g.edge(ident, "boundary:frame-dispatch", "mir-dispatches-frame", semantic_source="rustc-mir")
+				elif operation["kind"] == "external-call":
+					g.edge(ident, "boundary:external-execution", "mir-external-call", semantic_source="rustc-mir")
+				elif operation["kind"].startswith("storage-"):
+					storage = re.search(r"_GeneratedPrefixForStorage([A-Za-z0-9_]+)", operation["statement"])
+					if storage:
+						target = f"storage:{function_owner}:{storage.group(1)}"
+						g.node(target, "storage", owner=function_owner)
+						g.edge(ident, target, "mir-storage-access", operation=operation["kind"],
+							semantic_source="rustc-mir")
+				if local_target:
+					g.edge(ident, local_target, "mir-call", method=method, semantic_source="rustc-mir")
+				if component_match:
+					target = component_id(component_match.group(1))
+					if target != function_owner:
+						g.edge(ident, target, "mir-component-call", method=method, semantic_source="rustc-mir")
+				if associated_targets:
+					for target in sorted(associated_targets):
+						target_node = g.nodes[target]
+						edge_metadata = {"method": method, "semantic_source": "rustc-mir"}
+						if target_node.get("config_trait") is not None:
+							edge_metadata.update({"config_trait": target_node["config_trait"],
+								"config_instance": target_node.get("config_instance")})
+						g.edge(ident, target, "mir-dynamic-call", **edge_metadata)
+						for resolved in g.nodes[target].get("resolved_targets", []):
+							g.edge(ident, resolved, "mir-resolved-call", semantic_source="rustc-mir",
+								associated_type=target)
+			for left, right in zip(operation_nodes[block], operation_nodes[block][1:]):
+				g.edge(left, right, "mir-control-flow", semantic_source="rustc-mir")
+		for block, identifiers in operation_nodes.items():
+			if not identifiers:
+				continue
+			for successor_kind, edge_kind in (("normal_successors", "mir-control-flow"),
+				("unwind_successors", "mir-unwind-flow")):
+				queue = deque(function_blocks[block].get(successor_kind, []))
+				seen_blocks = set()
+				found = False
+				while queue:
+					target_block = queue.popleft()
+					if target_block in seen_blocks or target_block not in function_blocks:
+						continue
+					seen_blocks.add(target_block)
+					if operation_nodes.get(target_block):
+						g.edge(identifiers[-1], operation_nodes[target_block][0], edge_kind,
+							semantic_source="rustc-mir")
+						found = True
+					else:
+						queue.extend(function_blocks[target_block].get(successor_kind, []))
+				if successor_kind == "unwind_successors" and function_blocks[block].get(successor_kind) and not found:
+					unwind_exit = f"mir-unwind-exit:{instance_node}"
+					g.node(unwind_exit, "mir-unwind-exit", owner=function_owner,
+						function=function, instance=instance_node)
+					g.edge(identifiers[-1], unwind_exit, "mir-unwind-flow", semantic_source="rustc-mir")
+		added += sum(len(identifiers) for identifiers in operation_nodes.values())
+	source_functions = {node["id"] for node in g.nodes.values() if in_package(node)
+		and not (node.get("file") or "").endswith("weights.rs")}
+	g.node(f"semantic-analysis:rustc-mir:{owner}", "semantic-coverage", tool="rustc-mir",
+		owner=owner, artifact=path.name, artifact_sha256=analysis_provenance.file_sha256(path),
+		matched_functions=len(matched_functions),
+		matched_instances=matched_instances, source_functions_total=len(source_functions),
+		source_function_coverage=(len(matched_functions) / len(source_functions)) if source_functions else None,
+		operation_count=added)
+	return added
+
+
+def merge_rustc_mir_manifest(g: Graph, path: Path, root: Path | None = None) -> int:
+	manifest = json.loads(path.read_text())
+	validate_semantic_manifest(manifest, path, "rustc-mir", root)
+	added = 0
+	for package in manifest.get("packages", []):
+		if package.get("status") == "ok":
+			added += merge_rustc_mir(g, path.parent / package["artifact"], package["owner"])
+	g.node("semantic-analysis:rustc-mir-workspace", "semantic-coverage", tool="rustc-mir-workspace",
+		manifest=path.name, manifest_sha256=analysis_provenance.file_sha256(path),
+		packages=manifest.get("packages", []),
+		success=sum(package.get("status") == "ok" for package in manifest.get("packages", [])),
+		total=len(manifest.get("packages", [])))
+	classify_unresolved(g)
+	return added
+
+
+def merge_contracts(g: Graph, path: Path) -> int:
+	payload = json.loads(path.read_text())
+	schema_version = payload.get("schema_version", 1)
+	if not isinstance(schema_version, int) or isinstance(schema_version, bool) or schema_version not in {1, 2}:
+		raise ValueError(f"unsupported contract manifest schema_version: {schema_version!r}")
+	if schema_version == 1:
+		observations = {(item["project"], item["network"], item["address"].lower()): item
+			for item in payload.get("observations", [])}
+		merged: dict[tuple[str, str, str], dict] = {}
+		for contract in payload.get("contracts", []):
+			key = (contract["project"], contract["network"], contract["address"].lower())
+			entry = merged.setdefault(key,
+				{"names": set(), "artifacts": set(), "signatures": set(), "records": []})
+			entry["names"].add(contract["name"])
+			entry["artifacts"].add(contract["artifact"])
+			entry["signatures"].update(contract.get("abi_signatures", []))
+			entry["records"].append({key: value for key, value in contract.items()
+				if key not in {"abi_signatures", "artifact", "name", "project", "network", "address"}})
+		contracts_by_address: dict[str, list[str]] = defaultdict(list)
+		for project, network, address in merged:
+			contracts_by_address[address].append(f"deployed-contract:{project}:{network}:{address}")
+		for (project, network, address), entry in sorted(merged.items()):
+			ident = f"deployed-contract:{project}:{network}:{address}"
+			observation_data = {key: value
+				for key, value in observations.get((project, network, address), {}).items()
+				if key not in {"project", "network", "address"}}
+			g.node(ident, "deployed-contract", domain="evm-contract", project=project, network=network,
+				address=address, names=sorted(entry["names"]), artifacts=sorted(entry["artifacts"]),
+				deployment_records=entry["records"], **observation_data)
+			for signature in sorted(entry["signatures"]):
+				function = f"contract-function:{project}:{network}:{address}:{signature}"
+				g.node(function, "contract-function", owner=ident, signature=signature)
+				g.edge(ident, function, "exposes-function")
+				_, selector_node = ensure_evm_selector(g, signature)
+				g.edge(selector_node, function, "selector-matches-contract-function")
+			names = " ".join(entry["names"]).lower()
+			if any(value in names for value in ("pool-proxy", "pooladdressesprovider", "aaveoracle")):
+				g.edge("component:evm:aave_trade_executor", ident, "uses-deployed-contract")
+			if any(value in names for value in ("gho", "hollar", "flashminter")):
+				g.edge("pallet:hsm", ident, "uses-deployed-contract")
+			if "gigahdx" in network or "giga" in names:
+				g.edge("pallet:gigahdx", ident, "uses-deployed-contract")
+			if project == "whm" and any(value in names for value in ("emitter", "basejump", "router")):
+				g.edge("component:xcm:router", ident, "uses-deployed-contract")
+			if project == "whm" and any(value in names for value in ("transactor", "landing", "receiver")):
+				g.edge("component:xcm:asset-transactor", ident, "uses-deployed-contract")
+			observation = observations.get((project, network, address), {})
+			if observation.get("implementation"):
+				implementation_address = observation["implementation"].lower()
+				implementation_targets = contracts_by_address.get(implementation_address)
+				implementation = (implementation_targets or
+					[f"evm-address:{network}:{implementation_address}"])[0]
+				g.node(implementation, "deployed-contract" if implementation_targets else "evm-address",
+					domain="evm-contract", network=network, address=implementation_address)
+				g.edge(ident, implementation, "proxy-implementation", semantic_source="eip-1967")
+			for target_address in observation.get("embedded_addresses", []):
+				target = f"evm-address:{network}:{target_address.lower()}"
+				g.node(target, "evm-address", domain="evm-contract", network=network,
+					address=target_address.lower())
+				g.edge(ident, target, "bytecode-embeds-address", semantic_source="deployed-bytecode")
+		for configuration in payload.get("runtime_configurations", []):
+			address = configuration["address"].lower()
+			targets = contracts_by_address.get(address) or [f"evm-address:hydration:{address}"]
+			for target in targets:
+				g.node(target, g.nodes.get(target, {}).get("kind", "evm-address"),
+					domain="evm-contract", address=address)
+				g.edge(configuration["component"], target, "runtime-configures-contract",
+					storage=configuration["storage"], asset_id=configuration.get("asset_id"),
+					block_hash=payload.get("substrate_snapshot", {}).get("block_hash"))
+		g.node("semantic-analysis:contract-deployments", "semantic-coverage", tool="deployment-artifacts",
+			manifest=path.name, manifest_sha256=analysis_provenance.file_sha256(path),
+			contracts=len(merged), records=len(payload.get("contracts", [])))
+		return len(merged)
+
+	address_pattern = re.compile(r"^0x[0-9a-fA-F]{40}$")
+
+	def normalized_address(value: object) -> str:
+		if not isinstance(value, str) or not address_pattern.fullmatch(value):
+			raise ValueError(f"invalid EVM address in schema-v2 contract manifest: {value!r}")
+		return value.lower()
+
+	def canonical_address(value: object = None, chain_id: object = None,
+		address: object = None) -> tuple[int, str, str]:
+		if value is not None:
+			match = re.fullmatch(r"eip155:([0-9]+):(0x[0-9a-fA-F]{40})", str(value))
+			if not match or int(match.group(1)) < 1:
+				raise ValueError(f"invalid canonical chain address in schema-v2 contract manifest: {value!r}")
+			parsed_chain = int(match.group(1))
+			parsed_address = normalized_address(match.group(2))
+			if chain_id is not None and (not isinstance(chain_id, int) or isinstance(chain_id, bool)
+				or chain_id != parsed_chain):
+				raise ValueError(f"chain id does not match canonical chain address: {value!r}")
+			if address is not None and normalized_address(address) != parsed_address:
+				raise ValueError(f"address does not match canonical chain address: {value!r}")
+			return parsed_chain, parsed_address, f"eip155:{parsed_chain}:{parsed_address}"
+		if not isinstance(chain_id, int) or isinstance(chain_id, bool) or chain_id < 1:
+			raise ValueError(f"invalid EVM chain id in schema-v2 contract manifest: {chain_id!r}")
+		parsed_address = normalized_address(address)
+		return chain_id, parsed_address, f"eip155:{chain_id}:{parsed_address}"
+
+	aliases: dict[tuple[str, str, str], dict] = {}
+	canonical_selectors: dict[str, set[str]] = defaultdict(set)
+	for contract in payload.get("contracts", []):
+		address = normalized_address(contract.get("address"))
+		project = contract.get("project")
+		network = contract.get("network")
+		if not isinstance(project, str) or not project or not isinstance(network, str) or not network:
+			raise ValueError(f"invalid deployment alias identity: {contract!r}")
+		key = (project, network, address)
+		entry = aliases.setdefault(key, {"names": set(), "artifacts": set(), "functions": defaultdict(set),
+			"records": []})
+		if isinstance(contract.get("name"), str):
+			entry["names"].add(contract["name"])
+		if isinstance(contract.get("artifact"), str):
+			entry["artifacts"].add(contract["artifact"])
+		for function in contract.get("abi_functions", []):
+			if not isinstance(function, dict) or not isinstance(function.get("signature"), str):
+				raise ValueError(f"invalid canonical ABI function: {function!r}")
+			selector = function.get("selector")
+			if not isinstance(selector, str) or not re.fullmatch(r"0x[0-9a-fA-F]{8}", selector):
+				raise ValueError(f"invalid canonical ABI selector: {function!r}")
+			selector = selector.lower()
+			entry["functions"][function["signature"]].add(selector)
+			canonical_selectors[function["signature"]].add(selector)
+		for signature in contract.get("abi_signatures", []):
+			if isinstance(signature, str):
+				entry["functions"].setdefault(signature, set())
+		entry["records"].append({key: value for key, value in contract.items() if key not in {
+			"abi_functions", "abi_signatures", "artifact", "name", "project", "network", "address"}})
+	conflicting_selectors = {signature: sorted(selectors) for signature, selectors in canonical_selectors.items()
+		if len(selectors) != 1}
+	if conflicting_selectors:
+		raise ValueError(f"canonical ABI signatures have conflicting selectors: {conflicting_selectors!r}")
+
+	physical_observations: dict[str, list[dict]] = defaultdict(list)
+	alias_physical: dict[tuple[str, str, str], str] = {}
+	for observation in payload.get("observations", []):
+		chain_id, address, chain_address = canonical_address(observation.get("chain_address_id"),
+			observation.get("chain_id"), observation.get("address"))
+		physical_observations[chain_address].append(observation)
+		project = observation.get("project")
+		network = observation.get("network")
+		if isinstance(project, str) and isinstance(network, str):
+			key = (project, network, address)
+			previous = alias_physical.setdefault(key, chain_address)
+			if previous != chain_address:
+				raise ValueError(f"deployment alias resolves to multiple chain addresses: {key!r}")
+	chains_by_network: dict[str, set[int]] = defaultdict(set)
+	for chain in payload.get("chains", []):
+		chain_id = chain.get("evm_chain_id")
+		networks = chain.get("deployment_networks")
+		if (not isinstance(chain_id, int) or isinstance(chain_id, bool) or chain_id < 1 or
+			not isinstance(networks, list) or any(not isinstance(network, str) or not network for network in networks)):
+			raise ValueError(f"invalid chain descriptor in schema-v2 contract manifest: {chain!r}")
+		for network in networks:
+			chains_by_network[network].add(chain_id)
+	for key in aliases:
+		if key in alias_physical or len(chains_by_network[key[1]]) != 1:
+			continue
+		_, _, chain_address = canonical_address(chain_id=next(iter(chains_by_network[key[1]])), address=key[2])
+		alias_physical[key] = chain_address
+		physical_observations.setdefault(chain_address, [])
+
+	physical_ids = {chain_address: f"deployed-contract:{chain_address}"
+		for chain_address in physical_observations}
+	aliases_by_physical: dict[str, list[tuple[str, str, str]]] = defaultdict(list)
+	for key, chain_address in alias_physical.items():
+		if key in aliases:
+			aliases_by_physical[chain_address].append(key)
+
+	for chain_address, observations in sorted(physical_observations.items()):
+		chain_id, address, _ = canonical_address(chain_address)
+		alias_keys = sorted(aliases_by_physical.get(chain_address, []))
+		alias_entries = [aliases[key] for key in alias_keys]
+		sorted_observations = sorted(observations, key=lambda item: json.dumps(item, sort_keys=True))
+		observation_data = {}
+		observation_conflicts = {}
+		observation_keys = sorted({key for observation in observations for key in observation} - {
+			"project", "network", "chain_id", "address", "chain_address_id"})
+		for key in observation_keys:
+			values = {json.dumps(observation.get(key), sort_keys=True): observation.get(key)
+				for observation in observations}
+			if len(values) == 1:
+				observation_data[key] = next(iter(values.values()))
+			else:
+				observation_conflicts[key] = [values[encoded] for encoded in sorted(values)]
+		alias_ids = [f"deployment-alias:{project}:{network}:{alias_address}"
+			for project, network, alias_address in alias_keys]
+		projects = sorted({key[0] for key in alias_keys})
+		networks = sorted({key[1] for key in alias_keys})
+		g.node(physical_ids[chain_address], "deployed-contract", domain="evm-contract",
+			chain_id=chain_id, chain_address_id=chain_address, address=address,
+			onchain_observed=bool(observations),
+			project=",".join(projects) or None, network=",".join(networks) or None,
+			projects=projects, networks=networks,
+			names=sorted({name for entry in alias_entries for name in entry["names"]}),
+			artifacts=sorted({artifact for entry in alias_entries for artifact in entry["artifacts"]}),
+			deployment_aliases=alias_ids,
+			observations=sorted_observations,
+			observation_conflicts=observation_conflicts,
+			**observation_data)
+
+	def ensure_physical_address(chain_address: str) -> str:
+		chain_id, address, canonical = canonical_address(chain_address)
+		if canonical in physical_ids:
+			return physical_ids[canonical]
+		ident = f"evm-address:{canonical}"
+		g.node(ident, g.nodes.get(ident, {}).get("kind", "evm-address"), domain="evm-contract",
+			chain_id=chain_id, chain_address_id=canonical, address=address)
+		return ident
+
+	for (project, network, address), entry in sorted(aliases.items()):
+		alias = f"deployment-alias:{project}:{network}:{address}"
+		chain_address = alias_physical.get((project, network, address))
+		functions = []
+		for signature, selectors in sorted(entry["functions"].items()):
+			function = {"signature": signature}
+			if len(selectors) == 1:
+				function["selector"] = next(iter(selectors))
+			elif selectors:
+				function["selectors"] = sorted(selectors)
+			functions.append(function)
+		g.node(alias, "deployment-alias", domain="evm-contract", project=project, network=network,
+			address=address, chain_address_id=chain_address, names=sorted(entry["names"]),
+			artifacts=sorted(entry["artifacts"]), abi_functions=functions,
+			deployment_records=sorted(entry["records"], key=lambda item: json.dumps(item, sort_keys=True)))
+		for record in entry["records"]:
+			step_name = record.get("migration_step")
+			if not isinstance(step_name, str) or not step_name:
+				continue
+			step = f"deployment-step:{project}:{network}:{step_name}"
+			g.node(step, "deployment-step", domain="evm-contract", project=project, network=network,
+				migration_step=step_name)
+			g.edge(step, alias, "deployment-step-produces-alias", field=record.get("field"),
+				deployment_role=record.get("deployment_role"), artifact_sha256=record.get("artifact_sha256"))
+		if chain_address:
+			g.edge(alias, physical_ids[chain_address], "deployment-aliases-contract",
+				semantic_source="deployment-artifact")
+		target = physical_ids[chain_address] if chain_address else alias
+		names = " ".join(entry["names"]).lower()
+		evidence = {"deployment_alias": alias}
+		if any(value in names for value in ("pool-proxy", "pooladdressesprovider", "aaveoracle")):
+			g.edge("component:evm:aave_trade_executor", target, "uses-deployed-contract", **evidence)
+		if any(value in names for value in ("gho", "hollar", "flashminter")):
+			g.edge("pallet:hsm", target, "uses-deployed-contract", **evidence)
+		if "gigahdx" in network or "giga" in names:
+			g.edge("pallet:gigahdx", target, "uses-deployed-contract", **evidence)
+		if project == "whm" and any(value in names for value in ("emitter", "basejump", "router")):
+			g.edge("component:xcm:router", target, "uses-deployed-contract", **evidence)
+		if project == "whm" and any(value in names for value in ("transactor", "landing", "receiver")):
+			g.edge("component:xcm:asset-transactor", target, "uses-deployed-contract", **evidence)
+
+	references: dict[tuple[str, str, str], list[dict]] = defaultdict(list)
+	for reference in payload.get("address_references", []):
+		if not isinstance(reference, dict):
+			raise ValueError(f"invalid deployment address reference: {reference!r}")
+		project = reference.get("project")
+		network = reference.get("network")
+		role = reference.get("role")
+		field = reference.get("field")
+		step_name = reference.get("migration_step")
+		if any(not isinstance(value, str) or not value for value in (project, network, role, field, step_name)):
+			raise ValueError(f"invalid deployment address reference: {reference!r}")
+		address = normalized_address(reference.get("address"))
+		references[(project, network, address)].append(reference)
+	for (project, network, address), records in sorted(references.items()):
+		reference_id = f"deployment-address-reference:{project}:{network}:{address}"
+		candidate_chain_address = None
+		if len(chains_by_network[network]) == 1:
+			candidate_chain_id = next(iter(chains_by_network[network]))
+			candidate_chain_address = f"eip155:{candidate_chain_id}:{address}"
+		g.node(reference_id, "deployment-address-reference", domain="evm-contract", project=project,
+			network=network, address=address, candidate_chain_address_id=candidate_chain_address,
+			roles=sorted({record["role"] for record in records}),
+			reference_records=sorted(records, key=lambda item: json.dumps(item, sort_keys=True)),
+			onchain_observed=False)
+		for record in records:
+			step_name = record["migration_step"]
+			step = f"deployment-step:{project}:{network}:{step_name}"
+			g.node(step, "deployment-step", domain="evm-contract", project=project, network=network,
+				migration_step=step_name)
+			g.edge(step, reference_id, "deployment-step-references-address", role=record["role"],
+				field=record["field"], artifact=record.get("artifact"),
+				artifact_sha256=record.get("artifact_sha256"))
+
+	for chain_address, ident in sorted(physical_ids.items()):
+		chain_id, _, _ = canonical_address(chain_address)
+		functions: dict[str, dict[str, set[str]]] = defaultdict(lambda: {"selectors": set(), "aliases": set()})
+		for key in aliases_by_physical.get(chain_address, []):
+			alias = f"deployment-alias:{key[0]}:{key[1]}:{key[2]}"
+			for signature, selectors in aliases[key]["functions"].items():
+				functions[signature]["selectors"].update(selectors)
+				functions[signature]["aliases"].add(alias)
+		for signature, function_data in sorted(functions.items()):
+			function = f"contract-function:{chain_address}:{signature}"
+			selectors = sorted(function_data["selectors"])
+			node_data = {"owner": ident, "domain": "evm-contract", "chain_id": chain_id,
+				"chain_address_id": chain_address, "signature": signature,
+				"deployment_aliases": sorted(function_data["aliases"])}
+			if len(selectors) == 1:
+				node_data["selector"] = selectors[0]
+			elif selectors:
+				node_data["selector_conflicts"] = selectors
+			g.node(function, "contract-function", **node_data)
+			g.edge(ident, function, "exposes-function")
+			_, selector_node = ensure_evm_selector(g, signature, selectors[0] if len(selectors) == 1 else None)
+			g.edge(selector_node, function, "selector-matches-contract-function")
+
+	for chain_address, observations in sorted(physical_observations.items()):
+		chain_id, _, _ = canonical_address(chain_address)
+		source = physical_ids[chain_address]
+		for observation in observations:
+			implementation = observation.get("implementation")
+			implementation_chain_address = observation.get("implementation_chain_address_id")
+			if implementation_chain_address:
+				implementation_chain, implementation_address, implementation_chain_address = canonical_address(
+					implementation_chain_address, address=implementation)
+				if implementation_chain != chain_id:
+					raise ValueError("proxy implementation must be on the same chain as its proxy")
+			elif implementation:
+				_, implementation_address, implementation_chain_address = canonical_address(
+					chain_id=chain_id, address=implementation)
+			else:
+				implementation_address = None
+			if implementation_address:
+				target = ensure_physical_address(implementation_chain_address)
+				g.edge(source, target, "proxy-implementation", semantic_source="eip-1967")
+			for embedded_address in observation.get("embedded_addresses", []):
+				_, _, embedded_chain_address = canonical_address(chain_id=chain_id, address=embedded_address)
+				target = ensure_physical_address(embedded_chain_address)
+				g.edge(source, target, "bytecode-embeds-address", semantic_source="deployed-bytecode")
+
+	default_chain_id = payload.get("rpc_snapshot", {}).get("chain_id")
+	for configuration in payload.get("runtime_configurations", []):
+		configuration_chain_id = configuration.get("chain_id")
+		if configuration_chain_id is None and not configuration.get("chain_address_id"):
+			configuration_chain_id = default_chain_id
+		chain_id, address, chain_address = canonical_address(configuration.get("chain_address_id"),
+			configuration_chain_id, configuration.get("address"))
+		target = ensure_physical_address(chain_address)
+		g.edge(configuration["component"], target, "runtime-configures-contract",
+			storage=configuration["storage"], asset_id=configuration.get("asset_id"), chain_id=chain_id,
+			chain_address_id=chain_address,
+			block_hash=payload.get("substrate_snapshot", {}).get("block_hash"))
+
+	g.node("semantic-analysis:contract-deployments", "semantic-coverage", tool="deployment-artifacts",
+		manifest=path.name, manifest_sha256=analysis_provenance.file_sha256(path), schema_version=2,
+		contracts=len(physical_ids), aliases=len(aliases),
+		records=len(payload.get("contracts", [])), address_references=len(payload.get("address_references", [])),
+		runtime_configurations=len(payload.get("runtime_configurations", [])),
+		asset_registry_erc20_configurations=sum(
+			configuration.get("component") == "pallet:asset-registry"
+			and configuration.get("storage") == "assetRegistry.assetLocations"
+			and configuration.get("asset_type") == "erc20"
+			for configuration in payload.get("runtime_configurations", [])),
+		chain_context=payload.get("chain_context"),
+		rpc_snapshot=payload.get("rpc_snapshot"), substrate_snapshot=payload.get("substrate_snapshot"),
+		collection_provenance=payload.get("collection_provenance"),
+		enrichment_provenance=payload.get("enrichment_provenance"),
+		runtime_collection_provenance=payload.get("runtime_collection_provenance"),
+		runtime_query_coverage=payload.get("runtime_collection_provenance", {}).get("query_coverage"))
+	return len(physical_ids)
+
+
+def bounded_paths_with_metadata(edges: list[dict], targets: set[str], max_depth: int = 5,
+	limit: int = 50) -> tuple[list[list[str]], dict]:
+	adj: dict[str, set[str]] = defaultdict(set)
+	for edge in edges:
+		adj[edge["source"]].add(edge["target"])
+	starts = sorted({node for node in adj
+		if node.startswith(("pallet:", "runtime:", "precompile:", "component:evm:"))}
+		| {"boundary:evm-execution"})
+	paths = []
+	limit_truncated = []
+	depth_truncated = []
+	for start in starts:
+		queue = deque([(start, [start])])
+		found_for_start = 0
+		while queue and found_for_start < limit:
+			node, path = queue.popleft()
+			if node in targets and len(path) > 1:
+				paths.append(path)
+				found_for_start += 1
+				continue
+			if len(path) - 1 >= max_depth:
+				if adj[node]:
+					depth_truncated.append(start)
+				continue
+			for target in sorted(adj[node]):
+				if target not in path:
+					queue.append((target, path + [target]))
+		if queue and found_for_start >= limit:
+			limit_truncated.append(start)
+	metadata = {
+		"max_depth": max_depth,
+		"per_start_limit": limit,
+		"start_count": len(starts),
+		"limit_truncated_starts": sorted(set(limit_truncated)),
+		"depth_truncated_starts": sorted(set(depth_truncated)),
+	}
+	return sorted(paths, key=lambda path: (len(path), path)), metadata
+
+
+def bounded_paths(edges: list[dict], targets: set[str], max_depth: int = 5, limit: int = 50) -> list[list[str]]:
+	return bounded_paths_with_metadata(edges, targets, max_depth, limit)[0]
+
+
+def overview_selection(g: Graph, components: list[dict]) -> tuple[set[str], list[dict]]:
+	components = [edge for edge in components if edge["kind"] != "may-resolve-to"]
+	interesting = {"boundary:evm-execution", "boundary:frame-dispatch"}
+	interesting.update(node["id"] for node in g.nodes.values() if node["kind"] in {"asset-kind", "asset-backend"})
+	interesting.add("pallet:asset-registry")
+	interesting.update(edge["target"] for edge in components
+		if edge["source"] == "pallet:route-executor" and (edge.get("associated_type") or "").endswith(":AMM"))
+	interesting.update(edge["source"] for edge in components
+		if edge["target"] in {"boundary:evm-execution", "boundary:frame-dispatch"})
+	for cycle in strongly_connected(components):
+		interesting.update(cycle)
+	selected = {}
+	for edge in components:
+		if edge["source"] in interesting and edge["target"] in interesting:
+			selected.setdefault((edge["source"], edge["target"], edge["kind"]), edge)
+	return interesting, list(selected.values())
+
+
+def write_overview_dot(g: Graph, components: list[dict], output: Path) -> Path:
+	interesting, selected = overview_selection(g, components)
+	path = output / "audit-overview.dot"
+	colors = {"frame": "#dbeafe", "evm": "#fee2e2", "precompile": "#fef3c7", "asset": "#dcfce7",
+		"runtime": "#ede9fe", "evm-adapter": "#fce7f3"}
+	with path.open("w") as f:
+		f.write("digraph audit_overview {\n  rankdir=LR;\n  graph [bgcolor=\"transparent\", pad=\"0.2\"];\n")
+		f.write("  node [shape=box, style=\"rounded,filled\", fontname=\"sans-serif\", fontsize=10];\n")
+		for ident in sorted(interesting):
+			node = g.nodes.get(ident, {})
+			color = colors.get(node.get("domain"), "#f3f4f6")
+			label = ident.replace("associated:pallet:", "callback:").replace("asset-backend:", "backend:")
+			f.write(f'  "{ident}" [label="{label}", fillcolor="{color}"];\n')
+		for edge in selected:
+			f.write(f'  "{edge["source"]}" -> "{edge["target"]}" [label="{edge["kind"]}"];\n')
+		f.write("}\n")
+	return path
+
+
+def write_overview_svg(g: Graph, components: list[dict], output: Path) -> Path:
+	nodes, edges = overview_selection(g, components)
+	columns: dict[str, list[str]] = defaultdict(list)
+	for ident in sorted(nodes):
+		node = g.nodes.get(ident, {})
+		if node.get("kind") == "asset-backend":
+			column = "backend"
+		elif node.get("kind") == "asset-kind":
+			column = "asset"
+		elif ident.startswith("boundary:"):
+			column = "boundary"
+		elif node.get("domain") in {"precompile", "evm-adapter"}:
+			column = "evm"
+		else:
+			column = "frame"
+		columns[column].append(ident)
+	x_positions = {"frame": 40, "evm": 390, "boundary": 740, "asset": 1050, "backend": 1340}
+	positions = {}
+	for column, identifiers in columns.items():
+		for index, ident in enumerate(identifiers):
+			positions[ident] = (x_positions[column], 60 + index * 48)
+	height = max((y for _, y in positions.values()), default=600) + 80
+	colors = {"frame": "#dbeafe", "evm": "#fee2e2", "precompile": "#fef3c7", "asset": "#dcfce7",
+		"runtime": "#ede9fe", "evm-adapter": "#fce7f3"}
+	path = output / "audit-overview.svg"
+	with path.open("w") as f:
+		f.write(f'<svg xmlns="http://www.w3.org/2000/svg" width="1660" height="{height}" viewBox="0 0 1660 {height}">\n')
+		f.write('<defs><marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" fill="#64748b"/></marker></defs>\n')
+		f.write('<rect width="100%" height="100%" fill="#ffffff"/><text x="40" y="28" font-family="sans-serif" font-size="18" font-weight="bold">Hydration runtime audit overview</text>\n')
+		for edge in edges:
+			sx, sy = positions[edge["source"]]
+			tx, ty = positions[edge["target"]]
+			f.write(f'<path d="M {sx + 280} {sy + 15} C {(sx + tx) / 2:.0f} {sy + 15}, {(sx + tx) / 2:.0f} {ty + 15}, {tx} {ty + 15}" fill="none" stroke="#94a3b8" stroke-width="1.2" marker-end="url(#arrow)"><title>{html.escape(edge["kind"])}</title></path>\n')
+		for ident in sorted(nodes):
+			x, y = positions[ident]
+			node = g.nodes.get(ident, {})
+			color = colors.get(node.get("domain"), "#f3f4f6")
+			label = ident.replace("associated:pallet:", "callback:").replace("asset-backend:", "backend:")
+			f.write(f'<g><title>{html.escape(ident)}</title><rect x="{x}" y="{y}" width="280" height="30" rx="6" fill="{color}" stroke="#64748b"/><text x="{x + 8}" y="{y + 20}" font-family="monospace" font-size="11">{html.escape(label)}</text></g>\n')
+		f.write("</svg>\n")
+	return path
+
+
+def graph_scale_summary(g: Graph) -> dict[str, object]:
+	nodes = list(g.nodes.values())
+	edges = list(g.edges)
+
+	def node_activity(node: dict) -> str:
+		if node.get("runtime_active") is False:
+			return "inactive"
+		for relation in ("owner", "function"):
+			dependency = node.get(relation)
+			if isinstance(dependency, str) and g.nodes.get(dependency, {}).get("runtime_active") is False:
+				return "inactive"
+		return "active" if node.get("runtime_active") is True else "unclassified"
+
+	node_activity_by_id = {node["id"]: node_activity(node) for node in nodes}
+
+	def edge_activity(edge: dict) -> str:
+		statuses = {node_activity_by_id[edge[endpoint]] for endpoint in ("source", "target")}
+		if "inactive" in statuses:
+			return "inactive"
+		return "active" if statuses == {"active"} else "unclassified"
+
+	edge_activity_by_id = {id(edge): edge_activity(edge) for edge in edges}
+
+	def activity_counts(items: list[dict], statuses: dict, identity) -> dict[str, int]:
+		counts = Counter(statuses[identity(item)] for item in items)
+		return {"raw": len(items), "operational": counts["active"] + counts["unclassified"],
+			"active": counts["active"], "unclassified": counts["unclassified"],
+			"inactive": counts["inactive"]}
+
+	def distribution(items: list[dict], statuses: dict, identity, key) -> list[dict]:
+		raw = Counter(str(key(item) or "unclassified") for item in items)
+		activity = {status: Counter(str(key(item) or "unclassified") for item in items
+			if statuses[identity(item)] == status) for status in ("active", "unclassified", "inactive")}
+		return [{"name": name, "raw": raw[name],
+			"operational": activity["active"][name] + activity["unclassified"][name],
+			"active": activity["active"][name], "unclassified": activity["unclassified"][name],
+			"inactive": activity["inactive"][name]}
+			for name in sorted(raw, key=lambda name: (-raw[name], name))]
+
+	component_nodes = [node for node in nodes if node["kind"] in COMPONENT_NODE_KINDS]
+	entrypoints = [node for node in nodes if node["kind"] == "entrypoint"]
+	inventory_targets = [node for node in nodes if node.get("runtime_active") is False
+		and (node.get("kind") == "associated-type" or "associated-type" in (node.get("roles") or []))]
+
+	def evidence(edge: dict) -> str:
+		kind = edge["kind"]
+		source = edge.get("semantic_source")
+		if source == "rustc-mir" or kind.startswith("mir-"):
+			return "rustc MIR"
+		if source == "rapx" or kind == "rapx-call":
+			return "RAPx"
+		if source == "explicit-inventory":
+			return "semantic inventory"
+		deployment_kinds = {
+			"uses-deployed-contract", "runtime-configures-contract", "proxy-implementation",
+			"bytecode-embeds-address", "deployment-aliases-contract", "deployment-step-produces-alias",
+			"deployment-step-references-address", "selector-matches-contract-function",
+		}
+		deployment_nodes = {"deployed-contract", "deployment-alias", "deployment-step",
+			"deployment-address-reference", "contract-function"}
+		if source in {"deployment-artifact", "eip-1967", "deployed-bytecode"} or kind in deployment_kinds \
+			or any(g.nodes.get(edge[endpoint], {}).get("kind") in deployment_nodes
+				for endpoint in ("source", "target")):
+			return "deployment / chain"
+		return "source scan"
+
+	evidence_order = ["source scan", "rustc MIR", "RAPx", "semantic inventory", "deployment / chain"]
+	evidence_raw = Counter(evidence(edge) for edge in edges)
+	evidence_activity = {status: Counter(evidence(edge) for edge in edges
+		if edge_activity_by_id[id(edge)] == status) for status in ("active", "unclassified", "inactive")}
+
+	def effective_domain(node: dict) -> str:
+		if node.get("domain"):
+			return str(node["domain"])
+		for relation in ("owner", "function"):
+			related = g.nodes.get(node.get(relation), {})
+			if related.get("domain"):
+				return str(related["domain"])
+		return "unclassified"
+
+	return {
+		"totals": {
+			"nodes": activity_counts(nodes, node_activity_by_id, lambda node: node["id"]),
+			"edges": activity_counts(edges, edge_activity_by_id, id),
+			"components": activity_counts(component_nodes, node_activity_by_id, lambda node: node["id"]),
+			"entrypoints": activity_counts(entrypoints, node_activity_by_id, lambda node: node["id"]),
+		},
+		"inventory_only_targets": len(inventory_targets),
+		"unresolved_targets": sum(bool(node.get("unresolved")) for node in nodes),
+		"domains": distribution(nodes, node_activity_by_id, lambda node: node["id"], effective_domain),
+		"node_kinds": distribution(nodes, node_activity_by_id, lambda node: node["id"],
+			lambda node: node["kind"]),
+		"edge_kinds": distribution(edges, edge_activity_by_id, id, lambda edge: edge["kind"]),
+		"evidence": [{"name": name, "raw": evidence_raw[name],
+			"operational": evidence_activity["active"][name] + evidence_activity["unclassified"][name],
+			"active": evidence_activity["active"][name],
+			"unclassified": evidence_activity["unclassified"][name],
+			"inactive": evidence_activity["inactive"][name]}
+			for name in evidence_order],
+	}
+
+
+def write_graph_scale_svg(g: Graph, output: Path) -> Path:
+	summary = graph_scale_summary(g)
+	totals = summary["totals"]
+	width, height = 1600, 1200
+	path = output / "graph-scale.svg"
+	lines = [
+		f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" '
+		f'viewBox="0 0 {width} {height}" role="img" aria-labelledby="title" aria-describedby="description">',
+		'<title id="title">Hydration runtime interaction graph scale</title>',
+		'<desc id="description">Raw graph totals with explicit active, unclassified, inactive, operational, and evidence provenance counts.</desc>',
+		'''<defs>
+			<filter id="shadow" x="-10%" y="-10%" width="120%" height="130%"><feDropShadow dx="0" dy="5" stdDeviation="8" flood-color="#172033" flood-opacity=".08"/></filter>
+		</defs>
+		<style>
+			.title{font:700 32px Inter,system-ui,sans-serif;fill:#172033}.subtitle{font:15px Inter,system-ui,sans-serif;fill:#475569}
+			.eyebrow{font:700 11px Inter,system-ui,sans-serif;letter-spacing:1.5px;fill:#64748b}.metric{font:700 36px Inter,system-ui,sans-serif;fill:#172033}
+			.metric-detail{font:12px Inter,system-ui,sans-serif;fill:#475569}.panel-title{font:700 17px Inter,system-ui,sans-serif;fill:#172033}
+			.label{font:13px Inter,system-ui,sans-serif;fill:#334155}.count{font:12px ui-monospace,SFMono-Regular,monospace;fill:#475569}
+			.chip{font:700 12px Inter,system-ui,sans-serif;fill:#334155}.legend{font:12px Inter,system-ui,sans-serif;fill:#475569}
+		</style>''',
+		'<rect width="1600" height="1200" fill="#f5f7fb"/>',
+		'<text class="title" x="48" y="53">Hydration runtime interaction graph</text>',
+		'<text class="subtitle" x="48" y="82">Executive scale overview · raw inventory, operational records, and explicit activity evidence</text>',
+	]
+
+	chips = [("inventory-only targets", summary["inventory_only_targets"], 1050, 190),
+		("unresolved targets", summary["unresolved_targets"], 1260, 190)]
+	for label, value, x, chip_width in chips:
+		lines.extend([
+			f'<rect x="{x}" y="37" width="{chip_width}" height="38" rx="19" fill="#ffffff" stroke="#dbe2ee"/>',
+			f'<text class="chip" x="{x + 16}" y="61">{html.escape(label)} · {value:,}</text>',
+		])
+
+	card_colors = ["#6366f1", "#0ea5e9", "#22c55e", "#f59e0b"]
+	for index, key in enumerate(("nodes", "edges", "components", "entrypoints")):
+		metric = totals[key]
+		x = 48 + index * 380
+		percentage = (metric["operational"] / metric["raw"] * 100) if metric["raw"] else 0
+		lines.extend([
+			f'<g filter="url(#shadow)"><rect x="{x}" y="110" width="364" height="120" rx="18" fill="#ffffff"/>',
+			f'<rect x="{x}" y="110" width="364" height="5" rx="2.5" fill="{card_colors[index]}"/></g>',
+			f'<text class="eyebrow" x="{x + 22}" y="143">RAW {key.upper()}</text>',
+			f'<text class="metric" x="{x + 22}" y="181">{metric["raw"]:,}</text>',
+			f'<text class="metric-detail" x="{x + 22}" y="204">{metric["operational"]:,} operational · {percentage:.1f}%</text>',
+			f'<text class="metric-detail" x="{x + 22}" y="221">{metric["active"]:,} active · {metric["unclassified"]:,} unclassified</text>',
+		])
+
+	lines.extend([
+		'<g filter="url(#shadow)"><rect x="48" y="255" width="1504" height="185" rx="18" fill="#ffffff"/></g>',
+		'<text class="panel-title" x="72" y="290">Runtime activity</text>',
+		'<rect x="1110" y="275" width="12" height="12" rx="3" fill="#4f46e5"/><text class="legend" x="1130" y="286">explicit active</text>',
+		'<rect x="1245" y="275" width="12" height="12" rx="3" fill="#0ea5e9"/><text class="legend" x="1265" y="286">unclassified</text>',
+		'<rect x="1380" y="275" width="12" height="12" rx="3" fill="#cbd5e1"/><text class="legend" x="1400" y="286">inactive</text>',
+	])
+	for index, key in enumerate(("nodes", "edges")):
+		metric = totals[key]
+		y = 326 + index * 60
+		bar_width = 1210
+		active_width = bar_width * metric["active"] / metric["raw"] if metric["raw"] else 0
+		operational_width = bar_width * metric["operational"] / metric["raw"] if metric["raw"] else 0
+		lines.extend([
+			f'<text class="label" x="72" y="{y + 18}">{key}</text>',
+			f'<rect x="174" y="{y}" width="{bar_width}" height="24" rx="12" fill="#cbd5e1"/>',
+			f'<rect x="174" y="{y}" width="{operational_width:.2f}" height="24" rx="12" fill="#0ea5e9"/>',
+			f'<rect x="174" y="{y}" width="{active_width:.2f}" height="24" rx="12" fill="#4f46e5"/>',
+			f'<text class="count" text-anchor="end" x="1528" y="{y + 18}">{metric["operational"]:,} / {metric["raw"]:,} operational</text>',
+		])
+
+	def compact(items: list[dict], limit: int = 8) -> list[dict]:
+		if len(items) <= limit:
+			return items
+		return items[:limit - 1] + [{"name": f"other ({len(items) - limit + 1} more)",
+			"raw": sum(item["raw"] for item in items[limit - 1:]),
+			"operational": sum(item["operational"] for item in items[limit - 1:]),
+			"active": sum(item["active"] for item in items[limit - 1:]),
+			"unclassified": sum(item["unclassified"] for item in items[limit - 1:]),
+			"inactive": sum(item["inactive"] for item in items[limit - 1:])}]
+
+	def display_label(value: str) -> str:
+		value = value.replace("_", " ")
+		return value if len(value) <= 25 else value[:24] + "…"
+
+	panels = [("Top domains", summary["domains"]), ("Top node kinds", summary["node_kinds"]),
+		("Top edge kinds", summary["edge_kinds"])]
+	for panel_index, (title, items) in enumerate(panels):
+		x = 48 + panel_index * 504
+		panel_items = compact(items)
+		maximum = max((item["raw"] for item in panel_items), default=1)
+		lines.extend([
+			f'<g filter="url(#shadow)"><rect x="{x}" y="465" width="480" height="440" rx="18" fill="#ffffff"/></g>',
+			f'<text class="panel-title" x="{x + 20}" y="500">{title}</text>',
+			f'<text class="legend" text-anchor="end" x="{x + 458}" y="500">operational / raw</text>',
+		])
+		for row, item in enumerate(panel_items):
+			y = 526 + row * 45
+			raw_width = 235 * item["raw"] / maximum
+			active_width = 235 * item["active"] / maximum
+			operational_width = 235 * item["operational"] / maximum
+			label = display_label(item["name"])
+			lines.extend([
+				f'<g><title>{html.escape(item["name"])}</title><text class="label" x="{x + 20}" y="{y + 15}">{html.escape(label)}</text>',
+				f'<text class="count" text-anchor="end" x="{x + 458}" y="{y + 15}">{item["operational"]:,} / {item["raw"]:,}</text>',
+				f'<rect x="{x + 20}" y="{y + 24}" width="235" height="8" rx="4" fill="#edf1f7"/>',
+				f'<rect x="{x + 20}" y="{y + 24}" width="{raw_width:.2f}" height="8" rx="4" fill="#cbd5e1"/>',
+				f'<rect x="{x + 20}" y="{y + 24}" width="{operational_width:.2f}" height="8" rx="4" fill="#0ea5e9"/>',
+				f'<rect x="{x + 20}" y="{y + 24}" width="{active_width:.2f}" height="8" rx="4" fill="#4f46e5"/>',
+				'</g>',
+			])
+
+	evidence = summary["evidence"]
+	evidence_total = sum(item["raw"] for item in evidence)
+	evidence_colors = ["#6366f1", "#0ea5e9", "#a855f7", "#f59e0b", "#22c55e"]
+	lines.extend([
+		'<g filter="url(#shadow)"><rect x="48" y="930" width="1504" height="210" rx="18" fill="#ffffff"/></g>',
+		'<text class="panel-title" x="72" y="967">Edge evidence provenance</text>',
+		'<text class="legend" x="72" y="990">mutually exclusive evidence classes · segment width is proportional to raw edge count</text>',
+		'<rect x="72" y="1012" width="1456" height="28" rx="14" fill="#edf1f7"/>',
+	])
+	offset = 72.0
+	for color, item in zip(evidence_colors, evidence):
+		segment_width = 1456 * item["raw"] / evidence_total if evidence_total else 0
+		lines.append(f'<rect x="{offset:.2f}" y="1012" width="{segment_width:.2f}" height="28" fill="{color}"/>')
+		offset += segment_width
+	for index, (color, item) in enumerate(zip(evidence_colors, evidence)):
+		x = 76 + index * 292
+		lines.extend([
+			f'<rect x="{x}" y="1063" width="12" height="12" rx="3" fill="{color}"/>',
+			f'<text class="label" x="{x + 20}" y="1074">{html.escape(item["name"])}</text>',
+			f'<text class="count" x="{x + 20}" y="1097">{item["raw"]:,} raw · {item["operational"]:,} operational</text>',
+			f'<text class="count" x="{x + 20}" y="1117">{item["active"]:,} active · {item["unclassified"]:,} unclassified</text>',
+		])
+	lines.extend([
+		'<text class="legend" x="48" y="1174">Deterministic aggregate view · exact records and evidence remain in interaction-graph.json</text>',
+		'</svg>',
+	])
+	path.write_text("\n".join(lines) + "\n")
+	return path
+
+
+def write_focus_svg(nodes: list[str], path: Path, title: str, cyclic: bool = False) -> None:
+	width = max(700, len(nodes) * 260)
+	with path.open("w") as f:
+		f.write(f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="150" viewBox="0 0 {width} 150">\n')
+		f.write('<defs><marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" fill="#64748b"/></marker></defs><rect width="100%" height="100%" fill="#fff"/>\n')
+		f.write(f'<text x="24" y="26" font-family="sans-serif" font-size="16" font-weight="bold">{html.escape(title)}</text>\n')
+		for index, node in enumerate(nodes):
+			x = 24 + index * 250
+			f.write(f'<rect x="{x}" y="60" width="210" height="34" rx="6" fill="#e2e8f0" stroke="#64748b"/><text x="{x + 8}" y="81" font-family="monospace" font-size="10">{html.escape(node)}</text>\n')
+			if index + 1 < len(nodes):
+				f.write(f'<line x1="{x + 210}" y1="77" x2="{x + 246}" y2="77" stroke="#64748b" marker-end="url(#arrow)"/>\n')
+		if cyclic and len(nodes) > 1:
+			end = 24 + (len(nodes) - 1) * 250
+			f.write(f'<path d="M {end + 105} 96 C {end + 105} 135, 129 135, 129 96" fill="none" stroke="#dc2626" marker-end="url(#arrow)"/>\n')
+		f.write("</svg>\n")
+
+
+def write_router_svg(components: list[dict], path: Path) -> None:
+	targets = sorted({edge["target"] for edge in components
+		if edge["source"] == "pallet:route-executor" and (edge.get("associated_type") or "").endswith(":AMM")
+		and edge["target"].startswith(("pallet:", "component:evm:"))})
+	height = max(300, 80 + len(targets) * 52)
+	with path.open("w") as f:
+		f.write(f'<svg xmlns="http://www.w3.org/2000/svg" width="760" height="{height}" viewBox="0 0 760 {height}">\n')
+		f.write('<defs><marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" fill="#64748b"/></marker></defs><rect width="100%" height="100%" fill="#fff"/>\n')
+		f.write('<text x="24" y="28" font-family="sans-serif" font-size="16" font-weight="bold">Router AMM backends</text>\n')
+		f.write(f'<rect x="30" y="{height / 2 - 18}" width="230" height="36" rx="6" fill="#dbeafe" stroke="#64748b"/><text x="40" y="{height / 2 + 5}" font-family="monospace" font-size="11">pallet:route-executor</text>\n')
+		for index, target in enumerate(targets):
+			y = 55 + index * 52
+			color = "#fce7f3" if target.startswith("component:evm:") else "#dcfce7"
+			f.write(f'<path d="M 260 {height / 2} C 350 {height / 2}, 350 {y + 18}, 455 {y + 18}" fill="none" stroke="#64748b" marker-end="url(#arrow)"/>\n')
+			f.write(f'<rect x="460" y="{y}" width="270" height="36" rx="6" fill="{color}" stroke="#64748b"/><text x="470" y="{y + 23}" font-family="monospace" font-size="11">{html.escape(target)}</text>\n')
+		f.write("</svg>\n")
+
+
+def write_layer_svg(g: Graph, edges: list[dict], path: Path, title: str) -> None:
+	nodes = sorted({edge[key] for edge in edges for key in ("source", "target")})
+	columns: dict[str, list[str]] = defaultdict(list)
+	for ident in nodes:
+		node = g.nodes.get(ident, {})
+		if ident.startswith("asset-kind:"):
+			column = "kind"
+		elif ident.startswith("asset-backend:"):
+			column = "backend"
+		elif ident.startswith("boundary:"):
+			column = "boundary"
+		elif ident.startswith("precompile:") or node.get("domain") in {"evm-adapter", "evm-contract"}:
+			column = "evm"
+		else:
+			column = "frame"
+		columns[column].append(ident)
+	order = [column for column in ("frame", "evm", "boundary", "kind", "backend") if columns[column]]
+	x_positions = {column: 30 + index * 330 for index, column in enumerate(order)}
+	positions = {(ident): (x_positions[column], 60 + index * 48)
+		for column in order for index, ident in enumerate(columns[column])}
+	width = max(720, len(order) * 330 + 30)
+	height = max((y for _, y in positions.values()), default=60) + 70
+	with path.open("w") as f:
+		f.write(f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">\n')
+		f.write('<defs><marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" fill="#64748b"/></marker></defs><rect width="100%" height="100%" fill="#fff"/>\n')
+		f.write(f'<text x="24" y="28" font-family="sans-serif" font-size="16" font-weight="bold">{html.escape(title)}</text>\n')
+		for edge in edges:
+			sx, sy = positions[edge["source"]]
+			tx, ty = positions[edge["target"]]
+			f.write(f'<path d="M {sx + 280} {sy + 15} C {(sx + tx + 280) / 2:.0f} {sy + 15}, {(sx + tx + 280) / 2:.0f} {ty + 15}, {tx} {ty + 15}" fill="none" stroke="#94a3b8" marker-end="url(#arrow)"><title>{html.escape(edge["kind"])}</title></path>\n')
+		for ident in nodes:
+			x, y = positions[ident]
+			f.write(f'<rect x="{x}" y="{y}" width="280" height="30" rx="6" fill="#e2e8f0" stroke="#64748b"/><text x="{x + 8}" y="{y + 20}" font-family="monospace" font-size="10">{html.escape(ident)}</text>\n')
+		f.write("</svg>\n")
+
+
+def write_interactive_html(g: Graph, components: list[dict], output: Path) -> None:
+	nodes = {ident: dict(node) for ident, node in g.nodes.items()}
+	payload = json.dumps({"nodes": nodes, "edges": components}).replace("</", "<\\/")
+	html_text = """<!doctype html><meta charset="utf-8"><title>Hydration interaction graph</title>
+<style>body{font:14px system-ui;margin:24px;color:#172033}input,select{padding:8px;margin-right:8px}.overview{display:inline-block;margin:0 0 16px;padding:9px 12px;border:1px solid #dbe2ee;border-radius:8px;background:#f8fafc;color:#4338ca;text-decoration:none}.overview:hover{background:#eef2ff}table{border-collapse:collapse;width:100%;margin-top:16px}td,th{padding:6px;border-bottom:1px solid #ddd;text-align:left;vertical-align:top;word-break:break-word}code{font-size:12px}</style>
+<h1>Hydration interaction graph</h1><a class="overview" href="graph-scale.svg">open graph scale overview</a><br><input id="query" placeholder="filter nodes, edges, files"><select id="kind"><option value="">all edge kinds</option></select><select id="domain"><option value="">all domains</option></select><span id="count"></span>
+<table><thead><tr><th>source</th><th>edge</th><th>target</th><th>evidence</th></tr></thead><tbody id="rows"></tbody></table>
+<script>const graph=PAYLOAD;const q=document.querySelector('#query'),kind=document.querySelector('#kind'),domain=document.querySelector('#domain'),rows=document.querySelector('#rows'),count=document.querySelector('#count');
+for(const value of [...new Set(graph.edges.map(e=>e.kind))].sort())kind.add(new Option(value,value));
+for(const value of [...new Set(Object.values(graph.nodes).map(n=>n.domain).filter(Boolean))].sort())domain.add(new Option(value,value));
+function esc(value){const element=document.createElement('div');element.textContent=String(value);return element.innerHTML}
+function render(){const text=q.value.toLowerCase();const found=graph.edges.filter(e=>(!kind.value||e.kind===kind.value)&&(!domain.value||graph.nodes[e.source]?.domain===domain.value||graph.nodes[e.target]?.domain===domain.value)&&JSON.stringify([e,graph.nodes[e.source],graph.nodes[e.target]]).toLowerCase().includes(text));const foundNodes=text&&!kind.value?Object.values(graph.nodes).filter(n=>(!domain.value||n.domain===domain.value)&&JSON.stringify(n).toLowerCase().includes(text)):[];count.textContent=`${found.length} edges; ${foundNodes.length} matching nodes`;const nodeRows=foundNodes.slice(0,250).map(n=>`<tr><td><code>${esc(n.id)}</code></td><td>node:${esc(n.kind)}</td><td></td><td><code>${esc(JSON.stringify(n))}</code></td></tr>`);const edgeRows=found.slice(0,750).map(e=>{const evidence=Object.fromEntries(Object.entries(e).filter(([key])=>!['source','target','kind'].includes(key)));return `<tr><td><code>${esc(e.source)}</code></td><td>${esc(e.kind)}</td><td><code>${esc(e.target)}</code></td><td><code>${esc(JSON.stringify(evidence))}</code></td></tr>`});rows.innerHTML=[...nodeRows,...edgeRows].join('')}</script>
+<script>q.oninput=kind.onchange=domain.onchange=render;render()</script>""".replace("PAYLOAD", payload)
+	(output / "interaction-graph.html").write_text(html_text)
+
+
+def query_packs(g: Graph, components: list[dict], projections: dict[str, list[dict]],
+	cycles: list[list[str]], paths: list[list[str]], path_search: dict, dangerous: list[dict]) -> dict:
+	operational = {name: [edge for edge in edges if edge_runtime_active(g, edge)]
+		for name, edges in projections.items()}
+	adj: dict[str, set[str]] = defaultdict(set)
+	for edge in operational["execution"]:
+		adj[edge["source"]].add(edge["target"])
+	traces = []
+	trace_limit = 10
+	trace_depth = 8
+	trace_limit_truncated = []
+	trace_depth_truncated = []
+	starts = sorted(node["id"] for node in g.nodes.values() if node["kind"] == "entrypoint")
+	for start in starts:
+		queue = deque([(start, [start])])
+		found_for_start = 0
+		while queue and found_for_start < trace_limit:
+			node, trace = queue.popleft()
+			if len(trace) > 1 and node.startswith("boundary:"):
+				traces.append(trace)
+				found_for_start += 1
+				continue
+			if len(trace) >= trace_depth:
+				if adj[node]:
+					trace_depth_truncated.append(start)
+				continue
+			for target in sorted(adj[node]):
+				if target not in trace:
+					queue.append((target, trace + [target]))
+		if queue and found_for_start >= trace_limit:
+			trace_limit_truncated.append(start)
+	return {
+		"schema_version": 1,
+		"component_cycles": cycles,
+		"cross_domain_paths": paths,
+		"path_search": path_search,
+		"state_external_ordering": [item for item in dangerous if "state-write" in item["rule"]
+			and (not item.get("function")
+				or node_runtime_active(g, g.nodes.get(item["function"], {})))],
+		"privileged_entries": [edge for edge in operational["authorization"]
+			if edge["kind"] == "authorizes-entry"],
+		"lifecycle_entrypoints": [node for node in g.nodes.values()
+			if node.get("entrypoint_kind") in {"runtime-hook", "runtime-callback"}
+			and node_runtime_active(g, node)],
+		"token_backend_edges": operational["asset"],
+		"runtime_contract_edges": operational["deployment"],
+		"state_invariant_edges": [edge for edge in operational["state"] if edge["kind"] in {
+			"affects-invariant", "enforces-invariant", "guarded-by-invariant", "enforces", "guards",
+			"must-equal"}],
+		"prioritized_test_gaps": prioritize_gaps(g, components),
+		"entrypoint_execution_traces": traces,
+		"entrypoint_trace_search": {"max_depth": trace_depth, "per_entrypoint_limit": trace_limit,
+			"limit_truncated_entrypoints": sorted(set(trace_limit_truncated)),
+			"depth_truncated_entrypoints": sorted(set(trace_depth_truncated))},
+	}
+
+
+def dangerous_interactions(g: Graph, cycles: list[list[str]], paths: list[list[str]]) -> list[dict]:
+	result = []
+	for path in paths:
+		if "boundary:evm-execution" in path and "boundary:frame-dispatch" in path:
+			result.append({"rule": "evm-precompile-frame-dispatch", "severity": "high", "path": path})
+		if path[0] == "pallet:route-executor" and "boundary:evm-execution" in path and len(path) <= 4:
+			result.append({"rule": "polymorphic-router-reaches-evm", "severity": "high", "path": path})
+	for cycle in cycles:
+		if any("evm" in node or "precompile" in node for node in cycle):
+			result.append({"rule": "cross-domain-component-cycle", "severity": "high", "path": cycle})
+	for node in g.nodes.values():
+		if node["kind"] != "function":
+			continue
+		if node.get("mir_write_before_external") and node.get("mir_write_after_external"):
+			result.append({"rule": "mir-state-write-around-external-call", "severity": "high",
+				"function": node["id"], "operations": node["mir_operations"]})
+			continue
+		operations = node.get("operations", [])
+		calls = [index for index, operation in enumerate(operations) if operation["kind"] == "external-call"]
+		writes = [index for index, operation in enumerate(operations) if operation["kind"] == "storage-write"]
+		if calls and any(write < calls[0] for write in writes) and any(write > calls[0] for write in writes):
+			result.append({"rule": "state-write-around-external-call", "severity": "high",
+				"function": node["id"], "operations": operations})
+		if node.get("lifecycle") and calls and not node.get("transactional"):
+			result.append({"rule": "lifecycle-external-call-without-explicit-transaction", "severity": "review",
+				"function": node["id"], "operations": operations})
+	return result
+
+
+def historical_property_status(g: Graph, components: list[dict]) -> dict[str, bool]:
+	edges = {(edge["source"], edge["target"], edge["kind"]) for edge in components}
+	router_targets = {edge["target"] for edge in components
+		if edge["source"] == "pallet:route-executor" and edge["kind"] == "resolved-call"}
+	call_permit = [node for node in g.nodes.values() if node["kind"] == "audit-candidate"
+		and "precompiles/call-permit/src/lib.rs" in node["id"]]
+	return {
+		"call-permit-nonce-write-before-subcall": len(call_permit) == 1
+			and bool(call_permit[0].get("storage_before")) and not call_permit[0].get("storage_after"),
+		"router-resolves-all-amm-backends": {
+			"pallet:omnipool", "pallet:stableswap", "pallet:xyk", "pallet:lbp", "pallet:hsm",
+			"component:evm:aave_trade_executor",
+		}.issubset(router_targets),
+		"asset-kinds-cover-native-tokens-pool-shares-and-erc20": {
+			("pallet:balances", "asset-backend:balances", "uses-asset-backend"),
+			("pallet:orml-tokens", "asset-backend:tokens", "uses-asset-backend"),
+			("component:evm:erc20_currency", "asset-backend:erc20", "uses-asset-backend"),
+			("pallet:stableswap", "asset-kind:StableSwap", "issues-asset-kind"),
+		}.issubset(edges),
+		"xcm-connects-message-and-asset-boundaries": {
+			("component:xcm:router", "boundary:xcm-outbound", "sends-xcm"),
+			("boundary:xcm-inbound", "component:xcm:executor", "receives-xcm"),
+			("component:xcm:asset-transactor", "asset-backend:xcm", "uses-asset-backend"),
+		}.issubset(edges),
+	}
+
+
+def resolved_component_edges(g: Graph, edges: list[dict]) -> list[dict]:
+	result = []
+	for edge in edges:
+		if edge["kind"] == "dynamic-call" and not g.nodes.get(edge["target"], {}).get("unresolved", True):
+			continue
+		if edge["kind"] == "binding-resolves-to" and not g.nodes.get(edge["source"], {}).get("unresolved", True):
+			continue
+		result.append(edge)
+	return result
+
+
+def strongly_connected(edges: list[dict]) -> list[list[str]]:
+	adj: dict[str, set[str]] = defaultdict(set)
+	for edge in edges:
+		adj[edge["source"]].add(edge["target"])
+	index = 0
+	stack: list[str] = []
+	on_stack: set[str] = set()
+	indices: dict[str, int] = {}
+	low: dict[str, int] = {}
+	groups: list[list[str]] = []
+
+	def visit(node: str) -> None:
+		nonlocal index
+		indices[node] = low[node] = index
+		index += 1
+		stack.append(node)
+		on_stack.add(node)
+		for target in adj[node]:
+			if target not in indices:
+				visit(target)
+				low[node] = min(low[node], low[target])
+			elif target in on_stack:
+				low[node] = min(low[node], indices[target])
+		if low[node] == indices[node]:
+			group = []
+			while True:
+				item = stack.pop()
+				on_stack.remove(item)
+				group.append(item)
+				if item == node:
+					break
+			if len(group) > 1:
+				groups.append(sorted(group))
+
+	for node in sorted(adj):
+		if node not in indices:
+			visit(node)
+	return sorted(groups, key=lambda x: (-len(x), x))
+
+
+def runtime_aliases(text: str) -> dict[str, str]:
+	aliases = {}
+	for alias, crate in RUNTIME_ALIAS.findall(text):
+		aliases[alias] = crate.split("::")[0]
+	return aliases
+
+
+def scan(root: Path) -> Graph:
+	g = Graph()
+	asset_backends = {
+		"balances": "Native pallet_balances currency",
+		"tokens": "ORML Tokens currency",
+		"erc20": "Arbitrary EVM ERC-20 contract",
+		"mapped-erc20": "ERC-20 facade over a native asset",
+		"xcm": "XCM-minted or reserve-backed asset",
+		"pool-share": "AMM liquidity share asset",
+		"protocol-minted": "Protocol-controlled synthetic asset",
+		"unknown": "Dynamically selected asset backend",
+	}
+	for backend, description in asset_backends.items():
+		g.node(f"asset-backend:{backend}", "asset-backend", domain="asset", description=description)
+	asset_kinds = {
+		"Token": ("tokens", "Asset registry token; execution is selected by the runtime currency adapter"),
+		"XYK": ("pool-share", "XYK liquidity share registered by AssetRegistry"),
+		"StableSwap": ("pool-share", "StableSwap liquidity share registered by AssetRegistry"),
+		"Bond": ("protocol-minted", "Bond asset registered by AssetRegistry"),
+		"External": ("xcm", "Externally reserved or XCM-controlled asset"),
+		"Erc20": ("erc20", "Bound external ERC-20 contract"),
+	}
+	for kind, (backend, description) in asset_kinds.items():
+		ident = f"asset-kind:{kind}"
+		g.node(ident, "asset-kind", domain="asset", description=description,
+			source="pallets/asset-registry/src/types.rs")
+		g.edge("pallet:asset-registry", ident, "defines-asset-kind",
+			file="pallets/asset-registry/src/types.rs")
+		g.edge(ident, f"asset-backend:{backend}", "asset-kind-resolves-to",
+			file="pallets/asset-registry/src/types.rs")
+	for kind in ("Token", "XYK", "StableSwap", "Bond"):
+		g.edge(f"asset-kind:{kind}", "asset-backend:mapped-erc20", "exposed-as",
+			file="traits/src/evm.rs", evidence="Erc20Encoding/Erc20Mapping")
+	g.edge("asset-kind:Token", "asset-backend:balances", "may-use-native-backend",
+		file="runtime/hydradx/src/assets.rs")
+	g.edge("asset-kind:Token", "asset-backend:protocol-minted", "may-be-protocol-controlled",
+		file="runtime/hydradx/src/assets.rs")
+	asset_components = {
+		"pallet:balances": ("asset-backend:balances",),
+		"pallet:orml-tokens": ("asset-backend:tokens",),
+		"pallet:currencies": ("asset-backend:balances", "asset-backend:tokens"),
+		"component:evm:erc20_currency": ("asset-backend:erc20",),
+		"precompile:runtime:erc20_mapping": ("asset-backend:mapped-erc20",),
+	}
+	for component, backends in asset_components.items():
+		g.node(component, "asset-component", domain="asset")
+		for backend in backends:
+			g.edge(component, backend, "uses-asset-backend", file="runtime/hydradx/src/assets.rs")
+	for amm, share_kind in (("pallet:xyk", "XYK"), ("pallet:stableswap", "StableSwap")):
+		g.edge(amm, f"asset-kind:{share_kind}", "issues-asset-kind")
+	g.node("boundary:evm-execution", "execution-boundary", domain="evm",
+		description="Native runtime entering EVM execution or a precompile making an EVM subcall")
+	g.node("boundary:frame-dispatch", "execution-boundary", domain="frame",
+		description="EVM/precompile execution dispatching a FRAME runtime call")
+	g.node("boundary:xcm-outbound", "execution-boundary", domain="xcm",
+		description="Runtime sending an XCM message to another consensus system")
+	g.node("boundary:xcm-inbound", "execution-boundary", domain="xcm",
+		description="Message queue delivering XCM for local execution")
+	g.node("component:xcm:executor", "xcm-component", domain="xcm")
+	g.node("component:xcm:router", "xcm-component", domain="xcm")
+	g.node("component:xcm:asset-transactor", "xcm-component", domain="xcm")
+	g.edge("component:xcm:router", "boundary:xcm-outbound", "sends-xcm", file="runtime/hydradx/src/xcm.rs")
+	g.edge("boundary:xcm-inbound", "component:xcm:executor", "receives-xcm", file="runtime/hydradx/src/xcm.rs")
+	g.edge("component:xcm:executor", "component:xcm:asset-transactor", "moves-xcm-asset",
+		file="runtime/hydradx/src/xcm.rs")
+	g.edge("component:xcm:asset-transactor", "asset-backend:xcm", "uses-asset-backend",
+		file="runtime/hydradx/src/xcm.rs")
+	precompile_config = "runtime/hydradx/src/evm/precompiles/mod.rs"
+	precompile_text = (root / precompile_config).read_text()
+	precompile_ids = {
+		"callpermit": "precompile:call-permit",
+		"flash-loan-receiver": "precompile:flash-loan",
+		"lock-manager": "precompile:lock-manager",
+		"dispatch-addr": "precompile:dispatch",
+		"asset-address": "precompile:runtime:multicurrency",
+		"oracle-address": "precompile:runtime:chainlink_adapter",
+	}
+	for route in runtime_inventory.precompile_inventory(precompile_text):
+		precompile = precompile_ids.get(route["route"], f"precompile:standard:{route['route']}")
+		g.node(precompile, "precompile", domain="precompile", configured_by=precompile_config,
+			address=route.get("address"), address_predicate=route.get("predicate"), dynamic_address=route["dynamic"],
+			executor=route.get("target"))
+		g.edge("boundary:evm-execution", precompile, "invokes-precompile", file=precompile_config,
+			address=route.get("address"), predicate=route.get("predicate"), executor=route.get("target"))
+	g.edge("precompile:dispatch", "boundary:frame-dispatch", "dispatches-frame", file=precompile_config,
+		line=line_of(precompile_text, precompile_text.index("pallet_evm_precompile_dispatch")),
+		evidence="Dispatch::<R>::execute(handle)")
+	runtime_lib = (root / "runtime/hydradx/src/lib.rs").read_text()
+	runtime_entries = runtime_inventory.construct_runtime_entries(runtime_lib)
+	aliases = {entry["alias"]: entry["crate"] for entry in runtime_entries}
+	runtime_components = {component_id(entry["crate"]) for entry in runtime_entries}
+	runtime_instances_by_config = {
+		(f"{canonical_config_crate(entry['crate'])}::Config", entry["instance"]): f"runtime-instance:{entry['alias']}"
+		for entry in runtime_entries
+	}
+	for entry in runtime_entries:
+		pid = component_id(entry["crate"])
+		instance = f"runtime-instance:{entry['alias']}"
+		g.node(pid, "pallet", runtime_alias=entry["alias"], crate=entry["crate"], domain="frame")
+		g.node(instance, "runtime-pallet-instance", owner=pid, domain="frame", **entry)
+		g.edge("runtime:hydradx", instance, "contains")
+		g.edge(instance, pid, "instantiates", runtime_alias=entry["alias"], instance=entry["instance"],
+			pallet_index=entry["index"])
+	if "EVM" in aliases:
+		g.edge("runtime-instance:EVM", "boundary:evm-execution", "executes-evm", evidence="Frontier pallet")
+	if "Ethereum" in aliases:
+		g.edge("runtime-instance:Ethereum", "runtime-instance:EVM", "submits-ethereum-transaction")
+	for alias in ("MessageQueue", "XcmpQueue", "CumulusXcm", "OrmlXcm"):
+		if alias in aliases:
+			g.edge("boundary:xcm-inbound", f"runtime-instance:{alias}", "delivers-xcm")
+
+	files = list((root / "pallets").glob("*/src/**/*.rs"))
+	files += list((root / "precompiles").glob("*/src/**/*.rs"))
+	files += list((root / "runtime/hydradx/src").glob("**/*.rs"))
+	files += list((root / "runtime/adapters/src").glob("**/*.rs"))
+	source_specs: list[tuple[Path, str | None, str | None, str | None]] = [
+		(path, None, None, None) for path in sorted(set(files)) if not source_excluded(path)
+	]
+	runtime_inventory_complete = True
+	try:
+		sources = runtime_inventory.runtime_source_inventory(root, runtime_entries)
+		for source in sources:
+			if not source["external"]:
+				continue
+			source_root = Path(source["source_root"])
+			for path in runtime_inventory.active_external_sources(source_root):
+				if source_excluded(path):
+					continue
+				rel = f"external/{source['crate']}/{path.relative_to(source_root).as_posix()}"
+				source_specs.append((path, component_id(source["crate"]), "frame", rel))
+		g.node("semantic-analysis:runtime-source-inventory", "semantic-coverage", tool="cargo-metadata",
+			status="ok", runtime_entries=len(runtime_entries), resolved_sources=len(sources),
+			external_sources=sum(source["external"] for source in sources))
+	except (subprocess.CalledProcessError, StopIteration) as error:
+		runtime_inventory_complete = False
+		g.node("semantic-analysis:runtime-source-inventory", "semantic-coverage", tool="cargo-metadata",
+			status="unavailable", error=str(error), runtime_entries=len(runtime_entries))
+	config_declarations: dict[str, dict[str, str]] = defaultdict(dict)
+	config_parents: dict[str, set[str]] = defaultdict(set)
+	config_declarations_exact: dict[str, dict[str, str]] = defaultdict(dict)
+	config_parents_exact: dict[str, set[str]] = defaultdict(set)
+	active_configs: dict[str, set[str | None]] = defaultdict(set)
+	source_config_data: dict[str, dict[str, object]] = {}
+	selector_definitions: dict[tuple[str, tuple[str, ...], str], dict[str, str] | None] = {}
+	for path, forced_owner, forced_domain, forced_rel in source_specs:
+		text = path.read_text(errors="replace")
+		src, _ = (forced_owner, forced_domain) if forced_owner else owner(path, root)
+		rel = forced_rel or path.relative_to(root).as_posix()
+		imports = rust_use_bindings(text)
+		default_trait = source_config_trait(src, rel)
+		type_aliases = rust_type_aliases(text, imports)
+		declarations = config_associated_types(text)
+		config_traits = list(CONFIG_TRAIT.finditer(mask_rust_comments(text)))
+		config_declarations[src].update(declarations)
+		if default_trait and config_traits:
+			config_declarations_exact[default_trait].update(declarations)
+		source_config_data[rel] = {"imports": imports, "default_trait": default_trait,
+			"type_aliases": type_aliases}
+		for match in config_traits:
+			config_parents[src].update(config_trait_components(match.group(0), src) - {src})
+			if default_trait:
+				config_parents_exact[default_trait].update(
+					trait for trait, _ in config_references(
+						match.group(0), imports, default_trait, type_aliases)
+					if trait != default_trait)
+		for runtime_match, _ in runtime_config_blocks(text):
+			raw = f"{runtime_match.group(1)}::Config"
+			if runtime_match.group(2):
+				raw += f"<{runtime_match.group(2)}>"
+			reference = config_reference(raw, imports, default_trait, type_aliases)
+			if reference:
+				active_configs[reference[0]].add(reference[1])
+		crate_scope, module = rust_source_module(rel)
+		for enum_name, variants in generated_selector_enums(text).items():
+			key = (crate_scope, module, enum_name)
+			if key not in selector_definitions:
+				selector_definitions[key] = variants
+			elif selector_definitions[key] != variants:
+				selector_definitions[key] = None
+	for config_data in source_config_data.values():
+		config_data["default_trait"] = nearest_config_trait(
+			config_data["default_trait"], config_declarations_exact)
+
+	local_symbols: dict[str, set[str]] = defaultdict(set)
+	for runtime_path in list((root / "runtime/hydradx/src").glob("**/*.rs")) + \
+		list((root / "runtime/adapters/src").glob("**/*.rs")):
+		if source_excluded(runtime_path):
+			continue
+		runtime_text = runtime_path.read_text(errors="replace")
+		runtime_owner, _ = owner(runtime_path, root)
+		inactive_ranges = inactive_cfg_ranges(runtime_text)
+		for symbol in re.finditer(r"(?m)^pub\s+(?:type|struct)\s+([A-Z][A-Za-z0-9_]*)", runtime_text):
+			if not any(start <= symbol.start() < end for start, end in inactive_ranges):
+				local_symbols[symbol.group(1)].add(runtime_owner)
+	for path, forced_owner, forced_domain, forced_rel in sorted(source_specs, key=lambda item: item[3] or item[0].as_posix()):
+		text = path.read_text(errors="replace")
+		src, domain = (forced_owner, forced_domain) if forced_owner else owner(path, root)
+		g.node(src, domain, domain=domain)
+		rel = forced_rel or path.relative_to(root).as_posix()
+		config_data = source_config_data[rel]
+		imports = config_data["imports"]
+		default_trait = config_data["default_trait"]
+		type_aliases = config_data["type_aliases"]
+		selector_bindings = selector_type_bindings(text, rel, selector_definitions)
+		inactive_ranges = inactive_cfg_ranges(text)
+		for assoc, bounds in config_associated_types(text).items():
+			associated = associated_identity(default_trait, None, assoc) if default_trait else f"associated:{src}:{assoc}"
+			configured_owner = config_owner(default_trait, src) if default_trait else src
+			g.node(associated, "associated-type", associated_type=assoc,
+				config_trait=default_trait or f"{src}::Config", config_instance=None,
+				trait_bounds=bounds, associated_role=associated_role(assoc, bounds), unresolved=True,
+				declaration_file=rel, owner=configured_owner)
+			g.edge(configured_owner, associated, "declares-associated-type", file=rel)
+
+		for m, config_body in runtime_config_blocks(text):
+			if any(start <= m.start() < end for start, end in inactive_ranges):
+				continue
+			raw_config = f"{m.group(1)}::Config"
+			if m.group(2):
+				raw_config += f"<{m.group(2)}>"
+			config_reference_value = config_reference(raw_config, imports, default_trait, type_aliases)
+			if config_reference_value:
+				config_trait, config_instance = config_reference_value
+				configured = config_owner(config_trait, src)
+			else:
+				config_trait, config_instance = f"{m.group(1)}::Config", None
+				configured = component_id(m.group(1).split("::", 1)[0])
+			for assignment in config_type_items(config_body, "="):
+				if any(start <= m.end() + int(assignment["start"]) < end for start, end in inactive_ranges):
+					continue
+				assoc, value = str(assignment["name"]), str(assignment["value"])
+				target = f"component:binding:{assoc}:{re.sub(r'\s+', '', value)[:100]}"
+				g.node(target, "runtime-binding", associated_type=assoc, value=value.strip())
+				g.edge(configured, target, "config-binding", file=rel, line=line_of(text, m.start()),
+					config_trait=config_trait, config_instance=config_instance)
+				associated = associated_identity(config_trait, config_instance, assoc)
+				bounds = g.nodes.get(associated, {}).get("trait_bounds") \
+					or config_declarations_exact.get(config_trait, {}).get(assoc) \
+					or config_declarations.get(configured, {}).get(assoc)
+				runtime_instance = runtime_instances_by_config.get((config_trait, config_instance))
+				g.node(associated, "associated-type", associated_type=assoc, config_trait=config_trait,
+					config_instance=config_instance, runtime_instance=runtime_instance,
+					associated_role=associated_role(assoc, bounds), trait_bounds=bounds, unresolved=True,
+					owner=configured)
+				g.edge(associated, target, "configured-as", file=rel, line=line_of(text, m.start()),
+					value=value.strip(), config_trait=config_trait, config_instance=config_instance)
+				resolved = config_callback_targets(value, aliases, local_symbols)
+				role = g.nodes[associated].get("associated_role")
+				resolved = [item for item in resolved if item != configured and role == "callback"
+					and assoc != "BenchmarkHelper"]
+				if not resolved and role in {"callback", "unknown"}:
+					resolved.append(target)
+				for concrete in sorted(set(resolved)):
+					g.edge(associated, concrete, "binding-resolves-to", file=rel,
+						line=line_of(text, m.start()), value=value.strip())
+
+		helper_ranges = helper_module_ranges(text)
+		scopes = scope_ranges(text)
+		function_ranges: list[tuple[int, int]] = []
+		call_index_targets = attribute_targets(text, re.compile(r"#\[pallet::call_index\((\d+)\)\]"))
+		selector_targets = attribute_target_lists(text, PRECOMPILE_PUBLIC)
+		runtime_api_match = re.search(r"\bimpl_runtime_apis!\s*\{", text)
+		runtime_api_end = body_end(text, runtime_api_match.end() - 1) if runtime_api_match else None
+		for fm in FN.finditer(text):
+			end = function_body_end(text, fm.end())
+			if not end:
+				continue
+			if any(start <= fm.start() < stop for start, stop in helper_ranges + inactive_ranges):
+				continue
+			nested_function = any(start < fm.start() < stop for start, stop in function_ranges)
+			function_ranges.append((fm.start(), end))
+			body = text[fm.start():end]
+			fid = function_source_id(text, fm, rel, scopes)
+			attrs = text[max(0, fm.start() - 500):fm.start()]
+			impl_header = impl_context(fm.start(), scopes)
+			trait_impl = implemented_trait(impl_header)
+			function_opening = text.find("{", fm.end())
+			function_header = text[fm.start():function_opening] if function_opening >= 0 else ""
+			config_context = f"{impl_header or ''} {function_header}"
+			associated_candidates = {src} | config_trait_components(config_context, src)
+			exact_config_candidates = config_references(
+				config_context, imports, default_trait, type_aliases)
+			lifecycle = fm.group(1) in LIFECYCLE_HOOKS and bool(trait_impl and re.search(r"\bHooks\b", trait_impl))
+			transactional = "#[transactional]" in attrs or "with_transaction" in body
+			can_enter = entrypoint_eligible(path, fm.start(), helper_ranges) and not nested_function
+			local_pallet_calls = [{"method": call.group(1),
+				"line": line_of(text, fm.start() + call.start())}
+				for call in LOCAL_PALLET_CALL.finditer(body)] if migration_source(rel) else []
+			g.node(fid, "function", name=fm.group(1), file=rel, line=line_of(text, fm.start()), owner=src,
+				 domain=domain, lifecycle=lifecycle, transactional=transactional, entrypoint_eligible=can_enter,
+				 impl_header=impl_header, implemented_trait=trait_impl, source_config_trait=default_trait,
+				 local_pallet_calls=local_pallet_calls,
+				 required_config_traits=[{"trait": trait, "instance": instance}
+					for trait, instance in sorted(exact_config_candidates,
+						key=lambda item: (item[0], item[1] or ""))])
+			g.edge(src, fid, "defines")
+			call_index = call_index_targets.get(fm.start())
+			if can_enter and call_index:
+				add_entrypoint(g, fid, "extrinsic", call_index=int(call_index.group(1)))
+			if can_enter and lifecycle:
+				add_entrypoint(g, fid, "runtime-hook", hook=fm.group(1))
+			special_active = fm.group(1) not in {"on_runtime_upgrade", "pre_upgrade", "post_upgrade"} or lifecycle
+			if can_enter and fm.group(1) in SPECIAL_ENTRYPOINTS and trait_impl and special_active:
+				add_entrypoint(g, fid, SPECIAL_ENTRYPOINTS[fm.group(1)], method=fm.group(1))
+			if can_enter and rel == "runtime/hydradx/src/lib.rs" and runtime_api_match and runtime_api_end \
+				and runtime_api_match.start() < fm.start() < runtime_api_end:
+				add_entrypoint(g, fid, "runtime-api", method=fm.group(1))
+			resolved_selector_uses = []
+			for selector_use in SELECTOR_VARIANT.finditer(body):
+				selector_type, variant = selector_use.groups()
+				variants = selector_bindings.get(selector_type)
+				if not variants or variant not in variants:
+					continue
+				signature = variants[variant]
+				_, selector_node = ensure_evm_selector(g, signature)
+				resolved_selector_uses.append((selector_type, variant, signature, selector_node,
+					line_of(text, fm.start() + selector_use.start())))
+			precompile_execute = can_enter and domain == "precompile" and src != "precompile:utils" \
+				and fm.group(1) == "execute" and trait_impl in {"Precompile", "PrecompileSet"}
+			selectors = selector_targets.get(fm.start(), [])
+			if can_enter and selectors:
+				add_precompile_selector_entrypoints(g, fid,
+					[(selector.group(1), line_of(text, selector.start())) for selector in selectors], rel)
+			elif precompile_execute:
+				manual_selectors = {}
+				for _, _, signature, _, line in resolved_selector_uses:
+					manual_selectors.setdefault(signature, line)
+				if manual_selectors:
+					add_precompile_selector_entrypoints(g, fid, sorted(manual_selectors.items()), rel)
+				else:
+					add_entrypoint(g, fid, "precompile-dispatch")
+			if can_enter and domain == "evm-adapter" and fm.group(1) in {"call", "execute", "transfer", "deposit", "withdraw"}:
+				add_entrypoint(g, fid, "evm-adapter", method=fm.group(1))
+			if can_enter and rel == "runtime/hydradx/src/xcm.rs" and fm.group(1) in {"execute", "process_message"}:
+				entrypoint = add_entrypoint(g, fid, "xcm-inbound", method=fm.group(1))
+				g.edge("boundary:xcm-inbound", entrypoint, "receives-xcm")
+			if not precompile_execute:
+				for selector_type, variant, _, selector_node, selector_line in resolved_selector_uses:
+					g.edge(fid, selector_node, "encodes-evm-selector", selector_type=selector_type,
+						variant=variant, file=rel, line=selector_line)
+			for check, origin_kind in ORIGIN_CHECKS.items():
+				if not re.search(rf"\b{check}\s*\(", body):
+					continue
+				origin_node = f"origin:{origin_kind}"
+				g.node(origin_node, "origin", domain="authorization", origin_kind=origin_kind)
+				g.edge(origin_node, fid, "authorizes-entry", check=check, file=rel, line=line_of(text, fm.start()))
+			for origin_type in sorted(set(re.findall(
+				r"(?:T::|<T\s+as\s+[^>]+>::)([A-Z][A-Za-z0-9_]*Origin)::ensure_origin\s*\(", body))):
+				origin_node = f"origin:runtime-config:{src}:{origin_type}"
+				g.node(origin_node, "origin", domain="authorization", origin_kind="runtime-config",
+					associated_type=origin_type)
+				references = associated_config_references(exact_config_candidates, origin_type,
+					config_declarations_exact, config_parents_exact)
+				expanded = {item for reference in references
+					for item in active_config_references(reference, active_configs)}
+				if not expanded:
+					expanded = {(f"{src}::Config", None)}
+				for config_trait, config_instance in sorted(expanded, key=lambda item: (item[0], item[1] or "")):
+					associated = associated_identity(config_trait, config_instance, origin_type) \
+						if config_trait in config_declarations_exact else f"associated:{src}:{origin_type}"
+					g.node(associated, "associated-type", associated_type=origin_type,
+						associated_role="callback", unresolved=True, owner=config_owner(config_trait, src),
+						config_trait=config_trait, config_instance=config_instance)
+					g.edge(origin_node, associated, "configured-origin", file=rel,
+						line=line_of(text, fm.start()), config_trait=config_trait,
+						config_instance=config_instance)
+				g.edge(origin_node, fid, "authorizes-entry", check=f"{origin_type}::ensure_origin", file=rel,
+					line=line_of(text, fm.start()))
+
+			storage_matches = [match for match in STORAGE.finditer(body) if is_storage_match(match)]
+			write_positions = [x.start() for x in storage_matches if x.group(2) in STORAGE_WRITES]
+			external_matches = list(EXTERNAL.finditer(body))
+			external_positions = [x.start() for x in external_matches]
+			operations = []
+			for sm in storage_matches:
+				operations.append({"offset": sm.start(), "line": line_of(text, fm.start() + sm.start()),
+					"kind": "storage-write" if sm.group(2) in STORAGE_WRITES else "storage-read",
+					"operation": sm.group(2), "storage": sm.group(1)})
+			for em in external_matches:
+				operations.append({"offset": em.start(), "line": line_of(text, fm.start() + em.start()),
+					"kind": "external-call", "operation": em.group(1).strip()})
+			g.nodes[fid]["operations"] = sorted(operations, key=lambda item: item["offset"])
+			for cm in PALLET_CALL.finditer(body):
+				target = component_id(cm.group(1))
+				g.node(target, "pallet", domain="frame")
+				g.edge(fid, target, "direct-call", method=cm.group(2), file=rel,
+					line=line_of(text, fm.start() + cm.start()))
+			for cm in INTERNAL_EVM_EXECUTOR.finditer(body):
+				target = "component:evm:executor"
+				g.node(target, "evm-adapter", domain="evm-adapter")
+				g.edge(fid, target, "direct-call", method=cm.group(1), file=rel,
+					line=line_of(text, fm.start() + cm.start()))
+			for call in associated_calls(mask_rust_comments(body)):
+				associated_type = str(call["associated_type"])
+				method = str(call["method"])
+				references: set[tuple[str, str | None]] = set()
+				if call["trait_path"]:
+					explicit = config_reference(str(call["trait_path"]), imports, default_trait, type_aliases)
+					if not explicit:
+						continue
+					references = associated_config_references({explicit}, associated_type,
+						config_declarations_exact, config_parents_exact) or {explicit}
+				else:
+					references = associated_config_references(exact_config_candidates, associated_type,
+						config_declarations_exact, config_parents_exact)
+				expanded = {item for reference in references
+					for item in active_config_references(reference, active_configs)}
+				targets = []
+				for config_trait, config_instance in sorted(expanded, key=lambda item: (item[0], item[1] or "")):
+					targets.append((associated_identity(config_trait, config_instance, associated_type),
+						config_owner(config_trait, src), config_trait, config_instance,
+						config_declarations_exact.get(config_trait, {}).get(associated_type)))
+				if not targets:
+					target_owner = associated_config_owner(associated_candidates, associated_type,
+						config_declarations, config_parents) or src
+					target = f"associated:{target_owner}:{associated_type}"
+					existing = g.nodes.get(target, {})
+					targets.append((target, target_owner, existing.get("config_trait"),
+						existing.get("config_instance"), existing.get("trait_bounds")
+						or config_declarations.get(target_owner, {}).get(associated_type)))
+				for target, target_owner, config_trait, config_instance, bounds in targets:
+					target_metadata = {"associated_type": associated_type,
+						"associated_role": associated_role(associated_type, bounds), "trait_bounds": bounds,
+						"unresolved": True, "owner": target_owner}
+					if config_trait is not None:
+						target_metadata.update({"config_trait": config_trait, "config_instance": config_instance})
+					g.node(target, "associated-type", **target_metadata)
+					g.edge(fid, target, "dynamic-call", method=method, file=rel,
+						line=line_of(text, fm.start() + int(call["start"])), config_trait=config_trait,
+						config_instance=config_instance)
+					if associated_type in {"Currency", "Currencies", "MultiCurrency", "AssetTransactor"}:
+						for backend in asset_backends:
+							g.edge(target, f"asset-backend:{backend}", "may-resolve-to")
+				if method in ASSET_METHODS:
+					operation = f"asset-operation:{ASSET_METHODS[method]}"
+					g.node(operation, "asset-operation", domain="asset", operation=ASSET_METHODS[method])
+					g.edge(fid, operation, "asset-operation", method=method, file=rel,
+						line=line_of(text, fm.start() + int(call["start"])), backend_type=associated_type)
+			for cm in RUNTIME_CALL.finditer(body):
+				if cm.group(1) in aliases:
+					target = f"pallet:{aliases[cm.group(1)].removeprefix('pallet_').replace('_', '-')}"
+					g.edge(fid, target, "runtime-alias-call", method=cm.group(2), file=rel,
+						line=line_of(text, fm.start() + cm.start()))
+
+			for sm in storage_matches:
+				storage_id = f"storage:{src}:{sm.group(1)}"
+				g.node(storage_id, "storage", owner=src, storage_name=sm.group(1))
+				g.edge(fid, storage_id, "storage-access", operation=sm.group(2),
+					line=line_of(text, fm.start() + sm.start()))
+			if external_matches:
+				g.node("boundary:external-execution", "execution-boundary", domain="dynamic",
+					description="Conservative call, dispatch, transfer, mint, or burn boundary")
+			for em in external_matches:
+				g.edge(fid, "boundary:external-execution", "external-execution",
+					expression=em.group(1).strip(), file=rel, line=line_of(text, fm.start() + em.start()))
+			for em in EVM_ENTRY.finditer(body):
+				g.edge(fid, "boundary:evm-execution", "enters-evm", expression=em.group(0).strip(),
+					file=rel, line=line_of(text, fm.start() + em.start()))
+			if domain == "precompile":
+				for dm in FRAME_DISPATCH.finditer(body):
+					g.edge(fid, "boundary:frame-dispatch", "dispatches-frame", expression=dm.group(0).strip(),
+						file=rel, line=line_of(text, fm.start() + dm.start()))
+			elif FRAME_DISPATCH.search(body):
+				g.node("boundary:nested-frame-dispatch", "execution-boundary", domain="frame",
+					description="A runtime component dispatching a nested RuntimeCall")
+				g.edge(fid, "boundary:nested-frame-dispatch", "nested-dispatch", file=rel,
+					line=line_of(text, fm.start() + FRAME_DISPATCH.search(body).start()))
+			for xm in XCM_SEND.finditer(body):
+				g.edge(fid, "component:xcm:router", "sends-xcm", expression=xm.group(0).strip(),
+					file=rel, line=line_of(text, fm.start() + xm.start()))
+			for xm in XCM_ASSET.finditer(body):
+				g.edge(fid, "component:xcm:asset-transactor", "moves-xcm-asset", expression=xm.group(0).strip(),
+					file=rel, line=line_of(text, fm.start() + xm.start()))
+			if external_positions:
+				before = any(s < external_positions[0] for s in write_positions)
+				after = any(s > external_positions[0] for s in write_positions)
+				if before or after:
+					g.node(f"candidate:{fid}", "audit-candidate", rule="external-call-amid-state",
+						storage_before=before, storage_after=after, transactional=transactional,
+						first_external_line=line_of(text, fm.start() + external_positions[0]),
+						external_call_count=len(external_positions), storage_write_count=len(write_positions))
+					g.edge(fid, f"candidate:{fid}", "flagged-by")
+
+	enrich_migration_calls(g)
+	normalize_config_value_calls(g)
+	enrich_resolutions(g)
+	enrich_configured_origins(g)
+	enrich_callback_entrypoints(g)
+	add_configured_migrations(g, root)
+	enrich_runtime_instances(g, runtime_entries)
+	classify_runtime_activity(g, runtime_components, active_configs, runtime_inventory_complete,
+		set(config_declarations_exact))
+	merge_integration_tests(g, root, aliases)
+	add_state_semantics(g)
+	merge_semantic_inventory(g, root)
+	classify_unresolved(g)
+	return g
+
+
+def write_outputs(g: Graph, output: Path) -> None:
+	output.mkdir(parents=True, exist_ok=True)
+	payload = {"schema_version": 2, "nodes": sorted(g.nodes.values(), key=lambda x: x["id"]),
+		"edges": sorted(g.edges, key=lambda x: (x["source"], x["target"], x["kind"]))}
+	(output / "interaction-graph.json").write_text(json.dumps(payload, indent=2) + "\n")
+	projections = {name: sorted(projected_edges(g, name, active_only=False),
+		key=lambda edge: (edge["source"], edge["target"], edge["kind"])) for name in EDGE_PROJECTIONS}
+	active_projections = {name: [edge for edge in edges if edge_runtime_active(g, edge)]
+		for name, edges in projections.items()}
+	projection_output = output / "projections"
+	projection_output.mkdir(exist_ok=True)
+	active_projection_output = output / "projections-active"
+	active_projection_output.mkdir(exist_ok=True)
+	for directory, selected, activity in ((projection_output, projections, "raw-inventory"),
+		(active_projection_output, active_projections, "runtime-active")):
+		for name, edges in selected.items():
+			node_ids = {endpoint for edge in edges for endpoint in (edge["source"], edge["target"])}
+			projection_payload = {"schema_version": 1, "projection": name, "activity": activity,
+				"nodes": sorted((g.nodes[ident] for ident in node_ids), key=lambda node: node["id"]),
+				"edges": edges}
+			(directory / f"{name}.json").write_text(json.dumps(projection_payload, indent=2) + "\n")
+	all_components = resolved_component_edges(g, component_edges(g))
+	components = [edge for edge in all_components if edge["kind"] in EDGE_PROJECTIONS["execution"]]
+	cycles = strongly_connected(components)
+	execution_paths, path_search = bounded_paths_with_metadata(
+		components, {"boundary:evm-execution", "boundary:frame-dispatch"})
+	dangerous = dangerous_interactions(g, cycles, execution_paths)
+	(output / "query-packs.json").write_text(json.dumps(
+		query_packs(g, components, projections, cycles, execution_paths, path_search, dangerous), indent=2) + "\n")
+	(output / "component-graph.json").write_text(json.dumps(
+		{"schema_version": 2, "projection": "execution", "edges": components, "cycles": cycles,
+			"execution_paths": execution_paths, "path_search": path_search,
+			"available_projections": sorted(projections), "dangerous_interactions": dangerous}, indent=2) + "\n")
+	gaps = prioritize_gaps(g, components)
+	gap_lines = ["# Prioritized static test gaps", "",
+		"Priorities combine missing source linkage with privilege, asset impact, and execution-domain crossings.", ""]
+	for item in gaps[:250]:
+		gap_lines.append(f"- **{item['score']}** `{item['id']}` — {', '.join(item['reasons'])}")
+	(output / "prioritized-test-gaps.md").write_text("\n".join(gap_lines) + "\n")
+	with (output / "interaction-graph.dot").open("w") as f:
+		f.write("digraph runtime_interactions {\n  rankdir=LR;\n")
+		for node in payload["nodes"]:
+			f.write(f'  "{node["id"]}" [label="{node["id"]}"];\n')
+		for edge in payload["edges"]:
+			f.write(f'  "{edge["source"]}" -> "{edge["target"]}" [label="{edge["kind"]}"];\n')
+		f.write("}\n")
+	candidates = [n for n in payload["nodes"] if n["kind"] == "audit-candidate"]
+	unresolved = [n for n in payload["nodes"] if n.get("unresolved")]
+	inventory_only_associated = [n for n in payload["nodes"]
+		if n.get("roles", [n.get("kind")]) and (n.get("kind") == "associated-type"
+			or "associated-type" in n.get("roles", [])) and n.get("runtime_active") is False]
+	lines = ["# Runtime interaction audit candidates", "", f"- Nodes: {len(payload['nodes'])}",
+		f"- Edges: {len(payload['edges'])}", f"- State/external-call candidates: {len(candidates)}",
+		f"- Unresolved associated-type targets: {len(unresolved)}",
+		f"- Inventory-only associated targets: {len(inventory_only_associated)}", "", "## Candidates", ""]
+	for candidate in candidates:
+		fid = candidate["id"].removeprefix("candidate:")
+		function = g.nodes.get(fid, {})
+		high = function.get("domain") in {"evm-adapter", "precompile"} or (
+			candidate.get("storage_before") and candidate.get("storage_after") and not candidate.get("transactional")
+		)
+		lines.append(
+			f"- **{'HIGH' if high else 'REVIEW'}** `{function.get('file')}:{function.get('line')}` "
+			f"`{function.get('name')}` — domain: `{function.get('domain')}`, transactional: `{candidate['transactional']}`, "
+			f"writes before/after first external call: `{candidate.get('storage_before')}/{candidate.get('storage_after')}`, "
+			f"calls/writes: `{candidate.get('external_call_count')}/{candidate.get('storage_write_count')}`"
+		)
+	(output / "audit-candidates.md").write_text("\n".join(lines) + "\n")
+	resolution_counts = defaultdict(int)
+	for node in unresolved:
+		resolution_counts[node.get("ambiguity_reason", "unclassified")] += 1
+	resolution_lines = ["# Runtime target resolution coverage", "",
+		f"- Unresolved associated targets: {len(unresolved)}",
+		f"- Inventory-only associated targets: {len(inventory_only_associated)}", ""]
+	resolution_lines.extend(f"- `{reason}`: {count}" for reason, count in sorted(resolution_counts.items()))
+	activity_counts = Counter(node.get("runtime_activity_reason", "inventory-only")
+		for node in inventory_only_associated)
+	if activity_counts:
+		resolution_lines.extend(["", "## Inventory-only classifications", ""])
+		resolution_lines.extend(f"- `{reason}`: {count}" for reason, count in sorted(activity_counts.items()))
+	resolution_lines.extend(["", "Every unresolved node retains its associated type and candidate runtime targets.", ""])
+	(output / "resolution-coverage.md").write_text("\n".join(resolution_lines) + "\n")
+	cycle_lines = ["# Component interaction cycles", "",
+		"Cycles use only the execution projection. Configuration, state, authorization, and deployment edges are excluded.", ""]
+	for number, cycle in enumerate(cycles, 1):
+		domains = {g.nodes.get(node, {}).get("domain") for node in cycle}
+		crosses_evm = bool(domains & {"evm-adapter", "precompile"}) or any("evm" in node.lower() or "precompile" in node.lower() for node in cycle)
+		members = set(cycle)
+		evidence = [edge for edge in components if edge["source"] in members and edge["target"] in members]
+		migration_only_return = any("/migrations/" in (edge.get("file") or "") for edge in evidence)
+		severity = "HIGH " if crosses_evm else ("MIGRATION " if migration_only_return else "")
+		cycle_lines.extend([f"## {number}. {severity}cycle ({len(cycle)} nodes)", ""])
+		cycle_lines.extend(f"- `{node}`" for node in cycle)
+		cycle_lines.extend(["", "Evidence:", ""])
+		for edge in evidence:
+			location = f"{edge.get('file')}:{edge.get('line')}" if edge.get("file") else "runtime binding"
+			method = f"::{edge['method']}" if edge.get("method") else ""
+			cycle_lines.append(f"- `{edge['source']}` → `{edge['target']}{method}` ({edge['kind']}, `{location}`)")
+		cycle_lines.append("")
+	(output / "interaction-cycles.md").write_text("\n".join(cycle_lines) + "\n")
+	boundary_edges = [edge for edge in payload["edges"]
+		if edge["kind"] in {"enters-evm", "dispatches-frame"} and edge_runtime_active(g, edge)]
+	boundary_lines = ["# Native and EVM execution boundaries", "",
+		"These are syntactic boundary crossings for audit review, not proof of an exploitable path.", ""]
+	for edge in boundary_edges:
+		function = g.nodes.get(edge["source"], {})
+		boundary_lines.append(
+			f"- `{function.get('file')}:{edge.get('line')}` `{function.get('name')}` "
+			f"→ `{edge['target']}` (`{edge['kind']}`, `{edge.get('expression')}`)"
+		)
+	(output / "execution-boundaries.md").write_text("\n".join(boundary_lines) + "\n")
+	path_lines = ["# Cross-domain execution paths", "",
+		"Bounded paths use runtime-resolved callbacks and syntactic execution boundaries.",
+		f"Search depth: {path_search['max_depth']}; per-start limit: {path_search['per_start_limit']}; "
+		f"limit-truncated starts: {len(path_search['limit_truncated_starts'])}; "
+		f"depth-truncated starts: {len(path_search['depth_truncated_starts'])}.", ""]
+	for path in execution_paths:
+		path_lines.append("- " + " → ".join(f"`{node}`" for node in path))
+	(output / "execution-paths.md").write_text("\n".join(path_lines) + "\n")
+	danger_lines = ["# Dangerous interaction candidates", "",
+		"Rule matches are review targets and retain their operation or path evidence.", ""]
+	for item in dangerous:
+		location = item.get("function") or " → ".join(item["path"])
+		danger_lines.append(f"- **{item['severity'].upper()}** `{item['rule']}` — `{location}`")
+		if item.get("operations"):
+			sequence = " → ".join(f"{operation['kind']}@{operation.get('line', '?')}"
+				for operation in item["operations"] if operation["kind"] != "storage-read")
+			danger_lines.append(f"  - ordered evidence: `{sequence}`")
+	(output / "dangerous-interactions.md").write_text("\n".join(danger_lines) + "\n")
+	coverage = g.nodes.get("semantic-analysis:rapx-coverage")
+	if coverage:
+		coverage_lines = ["# RAPx semantic coverage", "",
+			f"- Callgraph success: {coverage['callgraph_success']}/{coverage['total_packages']}", "",
+			"| Package | Callgraph | MIR | Dataflow |", "|---|---|---|---|"]
+		for package in coverage["packages"]:
+			coverage_lines.append(f"| `{package['package']}` | {package['callgraph']} | {package['mir']} | {package['dataflow']} |")
+		(output / "semantic-coverage.md").write_text("\n".join(coverage_lines) + "\n")
+	mir_coverage = sorted((node for node in g.nodes.values() if node.get("tool") == "rustc-mir"),
+		key=lambda node: node["owner"])
+	if mir_coverage:
+		mir_lines = ["# rustc MIR semantic coverage", "",
+			"Control-flow ordering comes from genuine `rustc -Zunpretty=mir` output.", "",
+			"| Owner | Source functions | Matched functions | MIR instances | Coverage | Relevant operations | Artifact |",
+			"|---|---:|---:|---:|---:|---:|---|"]
+		for item in mir_coverage:
+			ratio = item.get("source_function_coverage")
+			ratio_text = f"{ratio:.1%}" if ratio is not None else "n/a"
+			mir_lines.append(f"| `{item['owner']}` | {item.get('source_functions_total', 0)} | "
+				f"{item['matched_functions']} | {item.get('matched_instances', 0)} | {ratio_text} | "
+				f"{item['operation_count']} | `{item['artifact']}` |")
+		(output / "mir-coverage.md").write_text("\n".join(mir_lines) + "\n")
+	kind_counts = defaultdict(int)
+	for node in payload["nodes"]:
+		kind_counts[node["kind"]] += 1
+	edge_counts = defaultdict(int)
+	for edge in payload["edges"]:
+		edge_counts[edge["kind"]] += 1
+	component_nodes = {node["id"] for node in payload["nodes"] if node["kind"] in COMPONENT_NODE_KINDS}
+	coverage_lines = ["# Graph coverage", "", f"- Nodes: {len(payload['nodes'])}",
+		f"- Edges: {len(payload['edges'])}", f"- Components: {len(component_nodes)}",
+		f"- Unresolved targets: {len(unresolved)}", "", "## Node kinds", ""]
+	coverage_lines.extend(f"- `{kind}`: {count}" for kind, count in sorted(kind_counts.items()))
+	coverage_lines.extend(["", "## Edge kinds", ""])
+	coverage_lines.extend(f"- `{kind}`: {count}" for kind, count in sorted(edge_counts.items()))
+	coverage_lines.extend(["", "## Projection edges", ""])
+	coverage_lines.extend(f"- `{name}`: {len(edges)}" for name, edges in sorted(projections.items()))
+	coverage_lines.extend(["", "## Runtime-active projection edges", ""])
+	coverage_lines.extend(f"- `{name}`: {len(edges)}" for name, edges in sorted(active_projections.items()))
+	(output / "graph-coverage.md").write_text("\n".join(coverage_lines) + "\n")
+	owners = sorted({node.get("owner") for node in payload["nodes"]
+		if node["kind"] == "function" and node.get("owner") and node.get("file")})
+	entrypoint_counts = defaultdict(int)
+	active_entrypoint_counts = defaultdict(int)
+	for node in payload["nodes"]:
+		if node["kind"] == "entrypoint":
+			entrypoint_counts[node.get("entrypoint_kind", "unknown")] += 1
+			if node_runtime_active(g, node):
+				active_entrypoint_counts[node.get("entrypoint_kind", "unknown")] += 1
+	compiler_owners = {node.get("owner") for node in payload["nodes"] if node.get("tool") == "rustc-mir"}
+	historical_status = historical_property_status(g, all_components)
+	completeness = {"schema_version": 1, "source_components": len(owners),
+		"source_components_without_entrypoints": sorted(owner for owner in owners if not any(
+			node["kind"] == "entrypoint" and node.get("owner") == owner for node in payload["nodes"])),
+		"entrypoint_kinds": dict(sorted(entrypoint_counts.items())),
+		"compiler_enriched_owners": sorted(owner for owner in compiler_owners if owner),
+		"unresolved_targets": len(unresolved), "state_invariants": kind_counts["state-invariant"],
+		"asset_operations": kind_counts["asset-operation"], "deployed_contracts": kind_counts["deployed-contract"],
+		"projection_edges": {name: len(edges) for name, edges in sorted(projections.items())},
+		"path_search": path_search, "historical_properties": historical_status}
+	(output / "completeness.json").write_text(json.dumps(completeness, indent=2) + "\n")
+	complete_lines = ["# Static graph completeness", "", f"- Source components: {len(owners)}",
+		f"- Compiler-enriched owners: {len(compiler_owners)}", f"- Unresolved targets: {len(unresolved)}",
+		f"- State invariant classes: {kind_counts['state-invariant']}",
+		f"- Typed asset operations: {kind_counts['asset-operation']}",
+		f"- Deployed contracts: {kind_counts['deployed-contract']}", "", "## Entrypoint classes", ""]
+	complete_lines.extend(f"- `{kind}`: {count}" for kind, count in sorted(entrypoint_counts.items()))
+	complete_lines.extend(["", "## Historical interaction properties", ""])
+	complete_lines.extend(f"- `{'ok' if present else 'missing'}` — `{name}`"
+		for name, present in sorted(historical_status.items()))
+	complete_lines.extend(["", "## Components without discovered entrypoints", ""])
+	complete_lines.extend(f"- `{owner}`" for owner in completeness["source_components_without_entrypoints"])
+	(output / "completeness.md").write_text("\n".join(complete_lines) + "\n")
+	workspace_mir = g.nodes.get("semantic-analysis:rustc-mir-workspace", {})
+	mir_coverage_nodes = [node for node in g.nodes.values() if node.get("tool") == "rustc-mir"]
+	deployment_coverage = g.nodes.get("semantic-analysis:contract-deployments", {})
+	coverage_payload = {"nodes": len(payload["nodes"]), "edges": len(payload["edges"]),
+		"components": len(component_nodes), "unresolved_targets": len(unresolved),
+		"inventory_only_targets": len(inventory_only_associated),
+		"inventory_only_target_ids": sorted(node["id"] for node in inventory_only_associated),
+		"inventory_only_targets_by_reason": dict(sorted(Counter(
+			node.get("runtime_activity_reason", "inventory-only") for node in inventory_only_associated).items())),
+		"entrypoints": sum(active_entrypoint_counts.values()),
+		"entrypoint_kinds": len(active_entrypoint_counts),
+		"inventory_entrypoints": kind_counts["entrypoint"],
+		"state_invariants": kind_counts["state-invariant"], "asset_operations": kind_counts["asset-operation"],
+		"deployed_contracts": kind_counts["deployed-contract"],
+		"mir_packages_success": workspace_mir.get("success"),
+		"mir_packages_total": workspace_mir.get("total"),
+		"mir_packages_failed": (workspace_mir.get("total") - workspace_mir.get("success"))
+			if workspace_mir.get("total") is not None and workspace_mir.get("success") is not None else None,
+		"mir_functions_matched": sum(node.get("matched_functions", 0) for node in mir_coverage_nodes),
+		"mir_instances_matched": sum(node.get("matched_instances", 0) for node in mir_coverage_nodes),
+		"mir_source_functions_total": sum(node.get("source_functions_total", 0) for node in mir_coverage_nodes),
+		"mir_operation_count": sum(node.get("operation_count", 0) for node in mir_coverage_nodes),
+		"runtime_contract_configurations": deployment_coverage.get("runtime_configurations", 0),
+		"runtime_registry_erc20_configurations": deployment_coverage.get(
+			"asset_registry_erc20_configurations", 0)}
+	coverage_payload["projection_edges"] = {name: len(edges) for name, edges in sorted(projections.items())}
+	coverage_payload.update({f"{name}_projection_edges": len(edges) for name, edges in projections.items()})
+	coverage_payload["active_projection_edges"] = {
+		name: len(edges) for name, edges in sorted(active_projections.items())}
+	coverage_payload.update({f"active_{name}_projection_edges": len(edges)
+		for name, edges in active_projections.items()})
+	(output / "coverage.json").write_text(json.dumps(coverage_payload, indent=2) + "\n")
+	test_components: dict[str, set[str]] = defaultdict(set)
+	test_functions: set[str] = set()
+	for edge in g.edges:
+		if edge["kind"] == "test-covers-component":
+			test_components[edge["source"]].add(edge["target"])
+		elif edge["kind"] == "test-covers-entrypoint":
+			test_functions.add(edge["target"])
+	raw_coverable_components = {ident for ident in component_nodes if g.nodes.get(ident, {}).get("kind") in {
+		"pallet", "frame", "precompile", "evm-adapter", "xcm-component", "execution-boundary", "asset-component"}}
+	coverable_components = {ident for ident in raw_coverable_components if node_runtime_active(g, g.nodes[ident])}
+	all_test_components = set().union(*test_components.values()) if test_components else set()
+	raw_covered_components = all_test_components & raw_coverable_components
+	covered_components = all_test_components & coverable_components
+	covered_entrypoints_all = {edge["source"] for edge in g.edges
+		if edge["kind"] == "enters-function" and edge["target"] in test_functions}
+	raw_entrypoints = {node["id"] for node in g.nodes.values() if node["kind"] == "entrypoint"}
+	entrypoints = {ident for ident in raw_entrypoints if node_runtime_active(g, g.nodes[ident])}
+	raw_covered_entrypoints = covered_entrypoints_all & raw_entrypoints
+	covered_entrypoints = covered_entrypoints_all & entrypoints
+	active_tests = {test for test, covered in test_components.items() if covered & coverable_components}
+	covered_interactions = []
+	for edge in components:
+		tests = sorted(test for test, covered in test_components.items()
+			if edge["source"] in covered and edge["target"] in covered)
+		if tests:
+			covered_interactions.append({"edge": edge, "tests": tests})
+	integration_coverage = {"method": "source-reference co-occurrence; not behavioral proof",
+		"integration_tests": len(active_tests), "components_total": len(coverable_components),
+		"components_test_linked": len(covered_components),
+		"components_graph_only": sorted(coverable_components - covered_components),
+		"entrypoints_total": len(entrypoints), "entrypoints_test_linked": len(covered_entrypoints),
+		"entrypoints_graph_only": sorted(entrypoints - covered_entrypoints),
+		"raw_inventory": {"integration_tests": len(test_components),
+			"components_total": len(raw_coverable_components),
+			"components_test_linked": len(raw_covered_components),
+			"entrypoints_total": len(raw_entrypoints),
+			"entrypoints_test_linked": len(raw_covered_entrypoints)},
+		"interactions_total": len(components), "interactions_test_linked": len(covered_interactions),
+		"test_confidence": dict(sorted(__import__("collections").Counter(node.get("confidence", "reference")
+			for node in g.nodes.values() if node["kind"] == "integration-test").items())),
+		"test_linked_interactions": covered_interactions}
+	(output / "integration-test-coverage.json").write_text(json.dumps(integration_coverage, indent=2) + "\n")
+	integration_lines = ["# Integration-test graph coverage", "",
+		"Source linkage and component co-occurrence indicate test attention, not behavioral coverage proof.", "",
+		f"- Tests linked: {integration_coverage['integration_tests']}",
+		f"- Components linked: {len(covered_components)}/{len(coverable_components)}",
+		f"- Entrypoints linked: {len(covered_entrypoints)}/{len(entrypoints)}",
+		f"- Interactions linked by endpoint co-occurrence: {len(covered_interactions)}/{len(components)}", "",
+		"## Confidence tiers", ""]
+	integration_lines.extend(f"- `{tier}`: {count}" for tier, count in integration_coverage["test_confidence"].items())
+	integration_lines.extend(["",
+		"## Graph-only components", ""])
+	integration_lines.extend(f"- `{ident}`" for ident in sorted(coverable_components - covered_components))
+	(output / "integration-test-coverage.md").write_text("\n".join(integration_lines) + "\n")
+	coverage_payload.update({"integration_tests_linked": len(test_components),
+		"integration_components_linked": len(raw_covered_components),
+		"integration_entrypoints_linked": len(raw_covered_entrypoints),
+		"active_integration_tests_linked": len(active_tests),
+		"active_integration_components_linked": len(covered_components),
+		"active_integration_entrypoints_linked": len(covered_entrypoints)})
+	(output / "coverage.json").write_text(json.dumps(coverage_payload, indent=2) + "\n")
+	contracts = [node for node in payload["nodes"] if node["kind"] == "deployed-contract"]
+	if contracts:
+		contract_lines = ["# Deployed contract coverage", "",
+			"Classification is block-pinned; artifact-only records are not assumed to remain deployed.", "",
+			"| Network | Address | Classification | Names |", "|---|---|---|---|"]
+		for contract in contracts:
+			contract_lines.append(f"| `{contract.get('network')}` | `{contract.get('address')}` | "
+				f"{contract.get('classification', 'artifact-only')} | {', '.join(contract.get('names', []))} |")
+		(output / "contract-coverage.md").write_text("\n".join(contract_lines) + "\n")
+	write_overview_dot(g, components, output)
+	write_overview_svg(g, components, output)
+	write_graph_scale_svg(g, output)
+	focus = output / "focused"
+	focus.mkdir(exist_ok=True)
+	for stale in focus.glob("*.svg"):
+		stale.unlink()
+	for index, cycle in enumerate(cycles, 1):
+		write_focus_svg(cycle, focus / f"cycle-{index:02}.svg", f"component cycle {index}", cyclic=True)
+	for index, path_nodes in enumerate(execution_paths, 1):
+		write_focus_svg(path_nodes, focus / f"path-{index:03}.svg", f"execution path {index}")
+	router_edges = [edge for edge in all_components
+		if edge["kind"] in EDGE_PROJECTIONS["execution"] | EDGE_PROJECTIONS["callback"]]
+	write_router_svg(router_edges, focus / "router-amm.svg")
+	execution_edges = [edge for edge in components if edge["source"].startswith(("boundary:", "precompile:"))
+		or edge["target"].startswith(("boundary:", "precompile:"))]
+	dependency_edges = [edge for edge in components if edge["kind"] in {
+		"direct-call", "runtime-alias-call", "resolved-call", "rapx-call", "mir-component-call",
+		"mir-resolved-call"}]
+	write_layer_svg(g, dependency_edges, focus / "component-dependencies.svg", "Runtime component dependencies")
+	write_layer_svg(g, execution_edges, focus / "execution-boundaries.svg", "FRAME, EVM, and precompile execution")
+	write_layer_svg(g, active_projections["asset"], focus / "token-flows.svg",
+		"Balances, Tokens, ERC-20, pool shares, and asset routes")
+	write_layer_svg(g, active_projections["state"], focus / "state-invariants.svg",
+		"Storage, ledgers, pool state, guards, and invariants")
+	contract_edges = [edge for edge in active_projections["deployment"] if edge["kind"] in {
+		"uses-deployed-contract", "runtime-configures-contract", "proxy-implementation",
+		"bytecode-embeds-address", "deployment-aliases-contract", "deployment-step-produces-alias",
+		"deployment-step-references-address"}]
+	write_layer_svg(g, contract_edges, focus / "deployed-contracts.svg",
+		"Runtime, EVM adapters, deployed contracts, and implementations")
+	write_interactive_html(g, all_components, output)
+
+
+def check_coverage(output: Path, thresholds_path: Path) -> None:
+	coverage = json.loads((output / "coverage.json").read_text())
+	thresholds = json.loads(thresholds_path.read_text())
+	failures = []
+	for field, minimum in thresholds.get("minimum", {}).items():
+		if coverage.get(field) is None or coverage[field] < minimum:
+			failures.append(f"{field}={coverage.get(field)} below {minimum}")
+	for field, maximum in thresholds.get("maximum", {}).items():
+		if coverage.get(field) is None or coverage[field] > maximum:
+			failures.append(f"{field}={coverage.get(field)} above {maximum}")
+	for field, maximum in thresholds.get("optional_maximum", {}).items():
+		if coverage.get(field) is not None and coverage[field] > maximum:
+			failures.append(f"{field}={coverage.get(field)} above {maximum}")
+	for field, expected in thresholds.get("exact", {}).items():
+		if coverage.get(field) != expected:
+			failures.append(f"{field}={coverage.get(field)!r} does not equal {expected!r}")
+	if failures:
+		raise SystemExit("coverage check failed: " + "; ".join(failures))
+
+
+def main() -> None:
+	parser = argparse.ArgumentParser()
+	parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[2])
+	parser.add_argument("--output", type=Path, default=Path("target/runtime-interaction-graph"))
+	parser.add_argument("--rapx-output", type=Path)
+	parser.add_argument("--rapx-owner")
+	parser.add_argument("--rapx-manifest", type=Path)
+	parser.add_argument("--rustc-mir", action="append", default=[], metavar="OWNER=PATH")
+	parser.add_argument("--rustc-mir-manifest", type=Path)
+	parser.add_argument("--contracts-manifest", type=Path)
+	parser.add_argument("--coverage-thresholds", type=Path)
+	args = parser.parse_args()
+	g = scan(args.root.resolve())
+	if args.rapx_output:
+		if not args.rapx_owner:
+			parser.error("--rapx-owner is required with --rapx-output")
+		merge_rapx(g, args.rapx_output, args.rapx_owner)
+	if args.rapx_manifest:
+		merge_rapx_manifest(g, args.rapx_manifest, args.root.resolve())
+	for specification in args.rustc_mir:
+		if "=" not in specification:
+			parser.error("--rustc-mir must use OWNER=PATH")
+		owner_name, mir_path = specification.split("=", 1)
+		merge_rustc_mir(g, Path(mir_path), owner_name)
+	if args.rustc_mir_manifest:
+		merge_rustc_mir_manifest(g, args.rustc_mir_manifest, args.root.resolve())
+	if args.contracts_manifest:
+		merge_contracts(g, args.contracts_manifest)
+	normalize_config_value_calls(g)
+	add_state_semantics(g)
+	classify_unresolved(g)
+	write_outputs(g, args.output)
+	if args.coverage_thresholds:
+		check_coverage(args.output, args.coverage_thresholds)
+
+
+if __name__ == "__main__":
+	main()

--- a/scripts/runtime-interaction-graph/runtime_inventory.py
+++ b/scripts/runtime-interaction-graph/runtime_inventory.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+RUNTIME_ENTRY = re.compile(
+	r"(?m)^\s*(?P<alias>[A-Z][A-Za-z0-9_]*)\s*:\s*"
+	r"(?P<crate>[a-zA-Z0-9_]+)(?:::<(?P<instance>[^>]+)>)?"
+	r"(?P<options>[^=\n]*)=\s*(?P<index>\d+)\s*,"
+)
+H160_HEX = re.compile(
+	r"pub\s+const\s+(?P<name>[A-Z][A-Z0-9_]*)\s*:\s*H160\s*=\s*H160\(hex!\(\"(?P<hex>[0-9a-fA-F]{40})\"\)\)"
+)
+H160_ADDR = re.compile(
+	r"pub\s+const\s+(?P<name>[A-Z][A-Z0-9_]*)\s*:\s*H160\s*=\s*addr\((?P<value>\d+)\)"
+)
+INNER_CFG = re.compile(r"(?m)^#!\s*\[\s*cfg\s*\((?P<expression>[^\]]+)\)\s*\]")
+MODULE_DECLARATION = re.compile(
+	r"(?m)(?P<attributes>(?:^#\s*\[[^\]\n]+\][ \t]*\n)*)"
+	r"^(?:pub(?:\([^\n)]*\))?\s+)?mod\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*;",
+)
+OUTER_CFG = re.compile(r"#\s*\[\s*cfg\s*\((?P<expression>[^\]]+)\)\s*\]")
+CFG_TOKEN = re.compile(
+	r'\s*(?:(?P<identifier>[A-Za-z_][A-Za-z0-9_-]*)|(?P<string>"(?:\\.|[^"\\])*")|(?P<symbol>[(),=]))'
+)
+INACTIVE_ANALYSIS_FEATURES = {"runtime-benchmarks", "test-utils", "testing"}
+
+
+class CfgParser:
+	def __init__(self, expression: str) -> None:
+		self.tokens = []
+		offset = 0
+		while offset < len(expression):
+			if not expression[offset:].strip():
+				break
+			match = CFG_TOKEN.match(expression, offset)
+			if not match:
+				self.tokens = []
+				break
+			self.tokens.append(match.group("identifier") or match.group("string") or match.group("symbol"))
+			offset = match.end()
+		self.index = 0
+
+	def parse(self) -> bool | None:
+		value = self.predicate()
+		return value if self.index == len(self.tokens) else None
+
+	def predicate(self) -> bool | None:
+		if self.index >= len(self.tokens) or self.tokens[self.index].startswith('"'):
+			return None
+		name = self.tokens[self.index]
+		self.index += 1
+		if self.consume("="):
+			if self.index >= len(self.tokens) or not self.tokens[self.index].startswith('"'):
+				return None
+			value = json.loads(self.tokens[self.index])
+			self.index += 1
+			return False if name == "feature" and value in INACTIVE_ANALYSIS_FEATURES else None
+		if not self.consume("("):
+			return False if name == "test" else None
+		values = []
+		if not self.consume(")"):
+			while True:
+				values.append(self.predicate())
+				if self.consume(")"):
+					break
+				if not self.consume(","):
+					return None
+		if name == "all":
+			return False if False in values else (True if all(value is True for value in values) else None)
+		if name == "any":
+			return True if True in values else (False if all(value is False for value in values) else None)
+		if name == "not" and len(values) == 1:
+			return None if values[0] is None else not values[0]
+		return None
+
+	def consume(self, token: str) -> bool:
+		if self.index >= len(self.tokens) or self.tokens[self.index] != token:
+			return False
+		self.index += 1
+		return True
+
+
+def cfg_value(expression: str) -> bool | None:
+	return CfgParser(expression).parse()
+
+
+def cfg_attributes_value(attributes: str, pattern: re.Pattern[str]) -> bool | None:
+	values = [cfg_value(match.group("expression")) for match in pattern.finditer(attributes)]
+	if False in values:
+		return False
+	return True if values and all(value is True for value in values) else None
+
+
+def module_source_path(parent: Path, name: str) -> Path | None:
+	base = parent.parent if parent.name in {"lib.rs", "main.rs", "mod.rs"} else parent.parent / parent.stem
+	candidates = (base / f"{name}.rs", base / name / "mod.rs")
+	matches = [candidate for candidate in candidates if candidate.is_file()]
+	return matches[0] if len(matches) == 1 else None
+
+
+def active_external_sources(source_root: Path) -> list[Path]:
+	paths = sorted(source_root.rglob("*.rs"))
+	declarations: dict[Path, list[tuple[Path, bool | None]]] = {}
+	inner_cfg = {}
+	for parent in paths:
+		text = parent.read_text(errors="replace")
+		inner_cfg[parent.resolve()] = cfg_attributes_value(text, INNER_CFG)
+		for declaration in MODULE_DECLARATION.finditer(text):
+			child = module_source_path(parent, declaration.group("name"))
+			if child is None:
+				continue
+			value = cfg_attributes_value(declaration.group("attributes"), OUTER_CFG)
+			if value is None and not declaration.group("attributes"):
+				value = True
+			declarations.setdefault(child.resolve(), []).append((parent.resolve(), value))
+
+	def potentially_active(path: Path, visiting: set[Path]) -> bool:
+		path = path.resolve()
+		if inner_cfg[path] is False:
+			return False
+		parents = declarations.get(path)
+		if not parents or path in visiting:
+			return True
+		return any(state is not False and potentially_active(parent, visiting | {path})
+			for parent, state in parents)
+
+	return [path for path in paths if potentially_active(path, set())]
+
+
+def construct_runtime_entries(text: str) -> list[dict]:
+	entries = []
+	for match in RUNTIME_ENTRY.finditer(text):
+		options = match.group("options")
+		excluded = []
+		exclude = re.search(r"exclude_parts\s*\{([^}]*)\}", options)
+		if exclude:
+			excluded = re.findall(r"[A-Z][A-Za-z0-9_]*", exclude.group(1))
+		entries.append({
+			"alias": match.group("alias"),
+			"crate": match.group("crate"),
+			"instance": match.group("instance"),
+			"index": int(match.group("index")),
+			"excluded_parts": excluded,
+		})
+	return entries
+
+
+def _h160(value: int) -> str:
+	return "0x" + value.to_bytes(20, "big").hex()
+
+
+def precompile_inventory(text: str) -> list[dict]:
+	addresses = {match.group("name"): "0x" + match.group("hex").lower() for match in H160_HEX.finditer(text)}
+	addresses.update({match.group("name"): _h160(int(match.group("value"))) for match in H160_ADDR.finditer(text)})
+	result = []
+	for constant, address in sorted(addresses.items(), key=lambda item: item[1]):
+		condition = re.search(rf"(?:if|else\s+if)\s+address\s*==\s*{re.escape(constant)}\s*\{{", text)
+		if not condition:
+			continue
+		end = text.find("} else", condition.end())
+		branch = text[condition.end():end if end >= 0 else condition.end() + 1000]
+		execute = re.search(r"([a-zA-Z0-9_:<>.,\s]+?)::execute\s*\(", branch)
+		target = re.sub(r"\s+", "", execute.group(1)).split("Some(")[-1] if execute else None
+		result.append({"route": constant.lower().replace("_", "-"), "constant": constant,
+			"address": address, "target": target, "dynamic": False})
+	for predicate, target, route in (
+		("is_asset_address", "MultiCurrencyPrecompile", "asset-address"),
+		("is_oracle_address", "ChainlinkOraclePrecompile", "oracle-address"),
+	):
+		if re.search(rf"else\s+if\s+{predicate}\(address\)", text):
+			result.append({"route": route, "predicate": predicate, "target": target, "dynamic": True})
+	return result
+
+
+def cargo_runtime_dependencies(root: Path) -> dict[str, dict]:
+	completed = subprocess.run(
+		["cargo", "metadata", "--format-version", "1", "--locked"],
+		cwd=root,
+		check=True,
+		text=True,
+		capture_output=True,
+	)
+	metadata = json.loads(completed.stdout)
+	packages = {package["id"]: package for package in metadata["packages"]}
+	runtime = next(package for package in packages.values()
+		if Path(package["manifest_path"]).resolve() == (root / "runtime/hydradx/Cargo.toml").resolve())
+	runtime_node = next(node for node in metadata["resolve"]["nodes"] if node["id"] == runtime["id"])
+	return {
+		dependency["name"]: {
+			"package": packages[dependency["pkg"]]["name"],
+			"version": packages[dependency["pkg"]]["version"],
+			"manifest": packages[dependency["pkg"]]["manifest_path"],
+			"source": packages[dependency["pkg"]].get("source"),
+		}
+		for dependency in runtime_node["deps"]
+	}
+
+
+def runtime_source_inventory(root: Path, entries: list[dict]) -> list[dict]:
+	dependencies = cargo_runtime_dependencies(root)
+	result = []
+	for entry in entries:
+		dependency = dependencies.get(entry["crate"])
+		if not dependency:
+			continue
+		manifest = Path(dependency["manifest"])
+		source_root = manifest.parent / "src"
+		if not source_root.is_dir():
+			continue
+		result.append({**entry, **dependency, "source_root": source_root.as_posix(),
+			"external": not manifest.is_relative_to(root)})
+	return result

--- a/scripts/runtime-interaction-graph/semantic-inventory.json
+++ b/scripts/runtime-interaction-graph/semantic-inventory.json
@@ -1,0 +1,1156 @@
+{
+  "schema_version": 1,
+  "nodes": [
+    {
+      "id": "component:balances",
+      "kind": "component",
+      "domain": "asset-routing",
+      "label": "Balances pallet",
+      "description": "Runtime component that owns the native asset balance implementation.",
+      "evidence": [{"file": "runtime/hydradx/src/lib.rs", "symbol": "Balances: pallet_balances = 7,"}]
+    },
+    {
+      "id": "ledger:native-balances",
+      "kind": "ledger",
+      "domain": "asset-routing",
+      "label": "Native balances ledger",
+      "description": "Native currency account balances and total issuance exposed through the Balances adapter.",
+      "evidence": [{"file": "runtime/hydradx/src/assets.rs", "symbol": "impl pallet_balances::Config for Runtime"}]
+    },
+    {
+      "id": "component:orml-tokens",
+      "kind": "component",
+      "domain": "asset-routing",
+      "label": "ORML Tokens pallet",
+      "description": "Runtime component that owns balances and issuance for non-native, non-ERC20 assets.",
+      "evidence": [{"file": "runtime/hydradx/src/lib.rs", "symbol": "Tokens: orml_tokens = 77,"}]
+    },
+    {
+      "id": "ledger:orml-tokens",
+      "kind": "ledger",
+      "domain": "asset-routing",
+      "label": "ORML multi-token ledger",
+      "description": "Per-asset account balances and issuance maintained by ORML Tokens.",
+      "evidence": [{"file": "runtime/hydradx/src/assets.rs", "symbol": "impl orml_tokens::Config for Runtime"}]
+    },
+    {
+      "id": "component:erc20-currency",
+      "kind": "component",
+      "domain": "asset-routing",
+      "label": "ERC20 currency adapter",
+      "description": "Runtime MultiCurrency adapter that executes ERC20 supply, balance, and transfer calls.",
+      "evidence": [{"file": "runtime/hydradx/src/evm/erc20_currency.rs", "symbol": "pub struct Erc20Currency<T>(PhantomData<T>);"}]
+    },
+    {
+      "id": "ledger:erc20-contracts",
+      "kind": "ledger",
+      "domain": "asset-routing",
+      "label": "ERC20 contract ledgers",
+      "description": "External EVM contract storage queried through totalSupply and balanceOf and mutated through ERC20 calls.",
+      "evidence": [
+        {"file": "runtime/hydradx/src/evm/erc20_currency.rs", "symbol": "TotalSupply = \"totalSupply()\""},
+        {"file": "runtime/hydradx/src/evm/erc20_currency.rs", "symbol": "BalanceOf = \"balanceOf(address)\""}
+      ]
+    },
+    {
+      "id": "router:currencies",
+      "kind": "router",
+      "domain": "asset-routing",
+      "label": "Currencies ledger router",
+      "description": "MultiCurrency facade that dispatches operations to native Balances, bound ERC20 contracts, or ORML Tokens.",
+      "evidence": [{"file": "pallets/currencies/src/lib.rs", "symbol": "impl<T: Config> MultiCurrency<T::AccountId> for Pallet<T>"}]
+    },
+    {
+      "id": "router:routed-total-issuance",
+      "kind": "router",
+      "domain": "asset-routing",
+      "label": "Routed total issuance provider",
+      "description": "GetByKey provider that resolves an asset's total issuance through the Currencies routing rules.",
+      "evidence": [{"file": "pallets/currencies/src/lib.rs", "symbol": "pub struct AssetTotalIssuance<T>(PhantomData<T>);"}]
+    },
+
+    {
+      "id": "component:stableswap",
+      "kind": "component",
+      "domain": "stableswap",
+      "label": "StableSwap pallet",
+      "description": "StableSwap pool component whose assets and share tokens use the routed currency interface.",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "pub type Pools<T: Config>"}]
+    },
+    {
+      "id": "state:stableswap-pools",
+      "kind": "pool-state",
+      "domain": "stableswap",
+      "label": "StableSwap Pools storage",
+      "description": "Pool configuration and asset membership keyed by the pool share asset identifier.",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "pub type Pools<T: Config> = StorageMap"}]
+    },
+    {
+      "id": "ledger:stableswap-reserves",
+      "kind": "ledger",
+      "domain": "stableswap",
+      "label": "StableSwap reserve balances",
+      "description": "Actual routed currency balances held by each StableSwap pool account.",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "T::Currency::free_balance(*pool_asset, &pool_account)"}]
+    },
+    {
+      "id": "ledger:stableswap-shares",
+      "kind": "ledger",
+      "domain": "stableswap",
+      "label": "StableSwap routed share ledger",
+      "description": "Routed account balances and actual total issuance for the pool-id share asset.",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "let total = T::Currency::total_issuance(pool_id);"}]
+    },
+    {
+      "id": "state:stableswap-share-issuance",
+      "kind": "pool-state",
+      "domain": "stableswap",
+      "label": "StableSwap virtual share issuance",
+      "description": "Pallet-tracked share issuance used for pool math and changed only by StableSwap mint and burn helpers.",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "pub type ShareIssuance<T: Config> = StorageMap"}]
+    },
+    {
+      "id": "invariant:stableswap-share-issuance-sync",
+      "kind": "invariant",
+      "domain": "stableswap",
+      "label": "StableSwap share issuance synchronization",
+      "description": "Debug builds require exact equality; production rejects actual routed issuance greater than pallet-tracked virtual issuance.",
+      "evidence": [
+        {"file": "pallets/stableswap/src/lib.rs", "symbol": "stableswap: virtual share issuance out of sync with total issuance for pool {pool_id:?}"},
+        {"file": "pallets/stableswap/src/lib.rs", "symbol": "ensure!(total <= tracked, Error::<T>::UnaccountedShareIssuance);"}
+      ]
+    },
+    {
+      "id": "operation:stableswap-add-liquidity",
+      "kind": "operation",
+      "domain": "stableswap",
+      "label": "StableSwap add liquidity",
+      "description": "Transactional operation that transfers reserves, mints pool shares, and checks the post-state invariant.",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "fn do_add_liquidity("}]
+    },
+    {
+      "id": "operation:stableswap-remove-liquidity",
+      "kind": "operation",
+      "domain": "stableswap",
+      "label": "StableSwap remove liquidity",
+      "description": "Transactional operation that transfers reserves out, burns pool shares, and checks the post-state invariant.",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "fn do_remove_liquidity("}]
+    },
+    {
+      "id": "invariant:stableswap-add-liquidity",
+      "kind": "invariant",
+      "domain": "stableswap",
+      "label": "StableSwap add-liquidity invariant",
+      "description": "Release-mode checks require D and D divided by issued shares to be non-decreasing after an add, except the initial issuance case.",
+      "evidence": [
+        {"file": "pallets/stableswap/src/lib.rs", "symbol": "fn ensure_add_liquidity_invariant("},
+        {"file": "pallets/stableswap/src/lib.rs", "symbol": "ensure!(final_d >= initial_d, Error::<T>::InvariantError);"}
+      ]
+    },
+    {
+      "id": "invariant:stableswap-remove-liquidity",
+      "kind": "invariant",
+      "domain": "stableswap",
+      "label": "StableSwap remove-liquidity invariant",
+      "description": "Release-mode checks require D to fall while D divided by issued shares does not fall after a partial withdrawal.",
+      "evidence": [
+        {"file": "pallets/stableswap/src/lib.rs", "symbol": "fn ensure_remove_liquidity_invariant("},
+        {"file": "pallets/stableswap/src/lib.rs", "symbol": "ensure!(final_d <= initial_d, Error::<T>::InvariantError);"}
+      ]
+    },
+
+    {
+      "id": "component:xyk",
+      "kind": "component",
+      "domain": "xyk",
+      "label": "XYK pallet",
+      "description": "Constant-product pool component with routed reserve and share ledgers plus local liquidity accounting.",
+      "evidence": [{"file": "pallets/xyk/src/lib.rs", "symbol": "pub(crate) type PoolAssets<T: Config>"}]
+    },
+    {
+      "id": "state:xyk-share-token",
+      "kind": "pool-state",
+      "domain": "xyk",
+      "label": "XYK ShareToken mapping",
+      "description": "Mapping from a pair account to the routed asset identifier used for pool shares.",
+      "evidence": [{"file": "pallets/xyk/src/lib.rs", "symbol": "pub(crate) type ShareToken<T: Config>"}]
+    },
+    {
+      "id": "state:xyk-total-liquidity",
+      "kind": "pool-state",
+      "domain": "xyk",
+      "label": "XYK TotalLiquidity",
+      "description": "Pallet-local share total used as the issuance input to XYK liquidity calculations.",
+      "evidence": [{"file": "pallets/xyk/src/lib.rs", "symbol": "pub(crate) type TotalLiquidity<T: Config>"}]
+    },
+    {
+      "id": "ledger:xyk-reserves",
+      "kind": "ledger",
+      "domain": "xyk",
+      "label": "XYK pair-account reserves",
+      "description": "Actual routed balances of both pool assets held by the deterministic pair account.",
+      "evidence": [{"file": "pallets/xyk/src/lib.rs", "symbol": "let asset_a_reserve = T::Currency::free_balance(asset_a, &pair_account);"}]
+    },
+    {
+      "id": "ledger:xyk-shares",
+      "kind": "ledger",
+      "domain": "xyk",
+      "label": "XYK routed share ledger",
+      "description": "Account balances and issuance of the share-token asset selected by ShareToken.",
+      "evidence": [{"file": "pallets/xyk/src/lib.rs", "symbol": "T::Currency::deposit(share_token, &who, shares_added)?;"}]
+    },
+    {
+      "id": "operation:xyk-add-liquidity",
+      "kind": "operation",
+      "domain": "xyk",
+      "label": "XYK add liquidity",
+      "description": "Transactional reserve transfer and coupled update of share balances and TotalLiquidity.",
+      "evidence": [{"file": "pallets/xyk/src/lib.rs", "symbol": "fn do_add_liquidity("}]
+    },
+    {
+      "id": "operation:xyk-remove-liquidity",
+      "kind": "operation",
+      "domain": "xyk",
+      "label": "XYK remove liquidity",
+      "description": "Transactional proportional reserve withdrawal and coupled reduction of shares and TotalLiquidity.",
+      "evidence": [{"file": "pallets/xyk/src/lib.rs", "symbol": "fn do_remove_liquidity("}]
+    },
+    {
+      "id": "invariant:xyk-ledger-total-liquidity",
+      "kind": "invariant",
+      "domain": "xyk",
+      "label": "XYK share ledger equals TotalLiquidity",
+      "description": "Expected equality maintained by adjacent mint-or-burn and TotalLiquidity writes; the liquidity paths do not perform an independent issuance equality assertion.",
+      "evidence": [
+        {"file": "pallets/xyk/src/lib.rs", "symbol": "T::Currency::deposit(share_token, &who, shares_added)?;"},
+        {"file": "pallets/xyk/src/lib.rs", "symbol": "<TotalLiquidity<T>>::insert(&pair_account, liquidity_amount);"}
+      ]
+    },
+    {
+      "id": "invariant:xyk-reserve-backing",
+      "kind": "invariant",
+      "domain": "xyk",
+      "label": "XYK proportional reserve backing",
+      "description": "Liquidity-out calculations derive withdrawals from pair-account reserves, burned shares, and TotalLiquidity rather than asserting a separate global backing equation.",
+      "evidence": [{"file": "pallets/xyk/src/lib.rs", "symbol": "hydra_dx_math::xyk::calculate_liquidity_out"}]
+    },
+
+    {
+      "id": "component:omnipool",
+      "kind": "component",
+      "domain": "omnipool",
+      "label": "Omnipool pallet",
+      "description": "Shared-liquidity pool component with stored asset state, NFT positions, and protocol-account ledgers.",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "pub(super) type Assets<T: Config>"}]
+    },
+    {
+      "id": "state:omnipool-assets",
+      "kind": "pool-state",
+      "domain": "omnipool",
+      "label": "Omnipool Assets state",
+      "description": "Per-asset stored hub reserve, total shares, protocol shares, cap, and tradability; the asset reserve is loaded from the protocol account ledger.",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "pub(super) type Assets<T: Config> = StorageMap"}]
+    },
+    {
+      "id": "state:omnipool-positions",
+      "kind": "pool-state",
+      "domain": "omnipool",
+      "label": "Omnipool Positions state",
+      "description": "NFT-position keyed liquidity ownership records containing an asset identifier and LP share amount.",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "pub(super) type Positions<T: Config>"}]
+    },
+    {
+      "id": "state:omnipool-lp-shares",
+      "kind": "pool-state",
+      "domain": "omnipool",
+      "label": "Omnipool total shares",
+      "description": "Assets.shares total from which protocol-owned shares are separated to derive user-position ownership.",
+      "evidence": [{"file": "pallets/omnipool/src/types.rs", "symbol": "pub(super) shares: Balance,"}]
+    },
+    {
+      "id": "state:omnipool-protocol-shares",
+      "kind": "pool-state",
+      "domain": "omnipool",
+      "label": "Omnipool protocol shares",
+      "description": "Subset of an asset's total pool shares owned by the protocol rather than LP positions.",
+      "evidence": [{"file": "pallets/omnipool/src/types.rs", "symbol": "pub(super) protocol_shares: Balance,"}]
+    },
+    {
+      "id": "ledger:omnipool-asset-reserves",
+      "kind": "ledger",
+      "domain": "omnipool",
+      "label": "Omnipool asset reserve ledger",
+      "description": "Actual routed asset balances held in the Omnipool protocol account and joined with Assets state at load time.",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "let reserve = T::Currency::free_balance(asset_id, &Self::protocol_account());"}]
+    },
+    {
+      "id": "ledger:omnipool-hub-reserve",
+      "kind": "ledger",
+      "domain": "omnipool",
+      "label": "Omnipool hub asset ledger",
+      "description": "Hub asset balance held by the protocol account and expected to equal the aggregate stored hub reserves.",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "T::Currency::free_balance(T::HubAssetId::get(), &Self::protocol_account())"}]
+    },
+    {
+      "id": "operation:omnipool-add-liquidity",
+      "kind": "operation",
+      "domain": "omnipool",
+      "label": "Omnipool add liquidity",
+      "description": "Transactional operation that creates a position, moves the asset reserve, updates hub liquidity and Assets, then checks the curve invariant.",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "pub fn do_add_liquidity("}]
+    },
+    {
+      "id": "operation:omnipool-remove-liquidity",
+      "kind": "operation",
+      "domain": "omnipool",
+      "label": "Omnipool remove liquidity",
+      "description": "Transactional operation that reduces or removes a position, transfers reserve value, updates hub liquidity and Assets, then checks the curve invariant.",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "pub fn do_remove_liquidity("}]
+    },
+    {
+      "id": "invariant:omnipool-position-shares",
+      "kind": "invariant",
+      "domain": "omnipool",
+      "label": "Omnipool LP position share sum",
+      "description": "Try-runtime assertion that summed Position.shares equals Assets.shares minus Assets.protocol_shares for each represented asset.",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "state.shares - state.protocol_shares,"}]
+    },
+    {
+      "id": "invariant:omnipool-hub-backing",
+      "kind": "invariant",
+      "domain": "omnipool",
+      "label": "Omnipool hub reserve backing",
+      "description": "Try-runtime assertion that the protocol account hub balance equals the sum of Assets.hub_reserve.",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "let asset_hub_amount: Balance = Assets::<T>::iter_values().map(|v| v.hub_reserve).sum();"}]
+    },
+    {
+      "id": "invariant:omnipool-liquidity-curve",
+      "kind": "invariant",
+      "domain": "omnipool",
+      "label": "Omnipool liquidity curve invariant",
+      "description": "Release-mode bounded-product check between old and new asset and hub reserves after liquidity changes.",
+      "evidence": [
+        {"file": "pallets/omnipool/src/lib.rs", "symbol": "fn ensure_liquidity_invariant("},
+        {"file": "pallets/omnipool/src/lib.rs", "symbol": "ensure!(left <= middle, Error::<T>::InvariantError);"}
+      ]
+    },
+
+    {
+      "id": "component:circuit-breaker",
+      "kind": "component",
+      "domain": "circuit-breaker",
+      "label": "Circuit breaker pallet",
+      "description": "Runtime component configured as the asset deposit limiter for issuance-rate protection.",
+      "evidence": [{"file": "runtime/hydradx/src/assets.rs", "symbol": "type DepositLimiter = DepositCircuitBreaker;"}]
+    },
+    {
+      "id": "operation:orml-token-deposit",
+      "kind": "operation",
+      "domain": "circuit-breaker",
+      "label": "ORML token deposit hook",
+      "description": "ORML Tokens post-deposit hook boundary at which issuance increases are classified and excess deposits may be locked.",
+      "evidence": [{"file": "runtime/hydradx/src/assets.rs", "symbol": "type PostDeposit = pallet_circuit_breaker::fuses::issuance::IssuanceIncreaseFuse<Runtime>;"}]
+    },
+    {
+      "id": "guard:issuance-increase-fuse",
+      "kind": "guard",
+      "domain": "circuit-breaker",
+      "label": "Issuance increase fuse",
+      "description": "Preflight can_mint guard and post-deposit handler using current routed issuance, configured limits, and lockdown state; post-deposit handling locks excess rather than undoing issuance.",
+      "evidence": [
+        {"file": "pallets/circuit-breaker/src/fuses/issuance.rs", "symbol": "pub struct IssuanceIncreaseFuse<T: Config>"},
+        {"file": "pallets/circuit-breaker/src/fuses/issuance.rs", "symbol": "pub fn can_mint(currency_id: T::AssetId, amount: T::Balance) -> bool"}
+      ]
+    },
+    {
+      "id": "state:asset-lockdown",
+      "kind": "pool-state",
+      "domain": "circuit-breaker",
+      "label": "Asset lockdown state",
+      "description": "Per-asset locked or unlocked issuance-period state used by the deposit fuse.",
+      "evidence": [{"file": "pallets/circuit-breaker/src/lib.rs", "symbol": "pub type AssetLockdownState<T: Config>"}]
+    },
+    {
+      "id": "configuration:xcm-rate-limit",
+      "kind": "configuration",
+      "domain": "circuit-breaker",
+      "label": "Asset registry XCM rate limit",
+      "description": "Optional per-asset issuance increase limit read from asset registry metadata.",
+      "evidence": [{"file": "pallets/asset-registry/src/lib.rs", "symbol": "pub struct XcmRateLimitsInRegistry<T>(PhantomData<T>);"}]
+    }
+  ],
+  "edges": [
+    {
+      "source": "component:balances",
+      "target": "ledger:native-balances",
+      "kind": "owns",
+      "semantics": "Balances is the configured runtime implementation for the native asset ledger.",
+      "enforcement": "configuration",
+      "evidence": [{"file": "runtime/hydradx/src/assets.rs", "symbol": "impl pallet_balances::Config for Runtime"}]
+    },
+    {
+      "source": "component:orml-tokens",
+      "target": "ledger:orml-tokens",
+      "kind": "owns",
+      "semantics": "ORML Tokens owns non-native multi-asset balances and issuance.",
+      "enforcement": "configuration",
+      "evidence": [{"file": "runtime/hydradx/src/assets.rs", "symbol": "impl orml_tokens::Config for Runtime"}]
+    },
+    {
+      "source": "component:erc20-currency",
+      "target": "ledger:erc20-contracts",
+      "kind": "routes-to",
+      "semantics": "The adapter exposes ERC20 contract storage through the runtime currency interface; the contracts remain the system of record.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "runtime/hydradx/src/evm/erc20_currency.rs", "symbol": "impl<T> MultiCurrency<AccountId> for Erc20Currency<T>"}]
+    },
+    {
+      "source": "router:currencies",
+      "target": "ledger:native-balances",
+      "kind": "routes-to",
+      "semantics": "The native currency id is dispatched through the BasicCurrencyAdapter backed by Balances.",
+      "enforcement": "runtime",
+      "evidence": [
+        {"file": "pallets/currencies/src/lib.rs", "symbol": "if currency_id == T::GetNativeCurrencyId::get()"},
+        {"file": "runtime/hydradx/src/assets.rs", "symbol": "type NativeCurrency = BasicCurrencyAdapter<Runtime, Balances, Amount, BlockNumber>;"}
+      ]
+    },
+    {
+      "source": "router:currencies",
+      "target": "ledger:erc20-contracts",
+      "kind": "routes-to",
+      "semantics": "Asset ids bound to an ERC20 address are dispatched to the Erc20Currency adapter.",
+      "enforcement": "runtime",
+      "evidence": [
+        {"file": "pallets/currencies/src/lib.rs", "symbol": "match T::BoundErc20::contract_address(currency_id)"},
+        {"file": "runtime/hydradx/src/assets.rs", "symbol": "type Erc20Currency = Erc20Currency<Runtime>;"}
+      ]
+    },
+    {
+      "source": "router:currencies",
+      "target": "ledger:orml-tokens",
+      "kind": "routes-to",
+      "semantics": "Non-native asset ids without an ERC20 binding are dispatched to ORML Tokens.",
+      "enforcement": "runtime",
+      "evidence": [
+        {"file": "pallets/currencies/src/lib.rs", "symbol": "None => T::MultiCurrency::total_issuance(currency_id)"},
+        {"file": "runtime/hydradx/src/assets.rs", "symbol": "type MultiCurrency = Tokens;"}
+      ]
+    },
+    {
+      "source": "router:routed-total-issuance",
+      "target": "router:currencies",
+      "kind": "derives-from",
+      "semantics": "The issuance provider delegates to Currencies.total_issuance and therefore inherits its three-way ledger routing.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/currencies/src/lib.rs", "symbol": "Pallet::<T>::total_issuance(*currency_id)"}]
+    },
+    {
+      "source": "ledger:stableswap-reserves",
+      "target": "router:currencies",
+      "kind": "derives-from",
+      "semantics": "StableSwap reserve reads and transfers use Currencies, so each reserve resolves to Balances, ORML Tokens, or an ERC20 contract according to its asset id.",
+      "enforcement": "configuration",
+      "evidence": [{"file": "runtime/hydradx/src/assets.rs", "symbol": "impl pallet_stableswap::Config for Runtime"}]
+    },
+    {
+      "source": "ledger:stableswap-shares",
+      "target": "router:currencies",
+      "kind": "derives-from",
+      "semantics": "StableSwap share issuance and balances use the configured Currencies implementation.",
+      "enforcement": "configuration",
+      "evidence": [{"file": "runtime/hydradx/src/assets.rs", "symbol": "impl pallet_stableswap::Config for Runtime"}]
+    },
+    {
+      "source": "ledger:xyk-reserves",
+      "target": "router:currencies",
+      "kind": "derives-from",
+      "semantics": "XYK reserve reads and transfers use Currencies, preserving native, ORML, and ERC20 routing.",
+      "enforcement": "configuration",
+      "evidence": [{"file": "runtime/hydradx/src/assets.rs", "symbol": "impl pallet_xyk::Config for Runtime"}]
+    },
+    {
+      "source": "ledger:xyk-shares",
+      "target": "router:currencies",
+      "kind": "derives-from",
+      "semantics": "XYK share mint and burn operations use the configured Currencies implementation.",
+      "enforcement": "configuration",
+      "evidence": [{"file": "runtime/hydradx/src/assets.rs", "symbol": "impl pallet_xyk::Config for Runtime"}]
+    },
+    {
+      "source": "ledger:omnipool-asset-reserves",
+      "target": "router:currencies",
+      "kind": "derives-from",
+      "semantics": "Omnipool asset reserve balances use Currencies and therefore may reside in native, ORML, or ERC20 ledgers.",
+      "enforcement": "configuration",
+      "evidence": [{"file": "runtime/hydradx/src/assets.rs", "symbol": "impl pallet_omnipool::Config for Runtime"}]
+    },
+    {
+      "source": "ledger:omnipool-hub-reserve",
+      "target": "router:currencies",
+      "kind": "derives-from",
+      "semantics": "Omnipool hub asset accounting uses the configured Currencies implementation.",
+      "enforcement": "configuration",
+      "evidence": [{"file": "runtime/hydradx/src/assets.rs", "symbol": "impl pallet_omnipool::Config for Runtime"}]
+    },
+
+    {
+      "source": "component:stableswap",
+      "target": "state:stableswap-pools",
+      "kind": "owns",
+      "semantics": "StableSwap owns pool configuration and asset membership storage.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "pub type Pools<T: Config> = StorageMap"}]
+    },
+    {
+      "source": "component:stableswap",
+      "target": "ledger:stableswap-reserves",
+      "kind": "owns",
+      "semantics": "StableSwap controls reserve balances held in its pool accounts through routed transfers.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "let pool_account = Self::pool_account(pool_id);"}]
+    },
+    {
+      "source": "component:stableswap",
+      "target": "ledger:stableswap-shares",
+      "kind": "owns",
+      "semantics": "The pool id is also the routed share asset minted and burned by StableSwap.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "T::Currency::deposit(pool_id, who, amount)"}]
+    },
+    {
+      "source": "component:stableswap",
+      "target": "state:stableswap-share-issuance",
+      "kind": "owns",
+      "semantics": "StableSwap owns the virtual issuance used for all share calculations.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "pub type ShareIssuance<T: Config> = StorageMap"}]
+    },
+    {
+      "source": "component:stableswap",
+      "target": "invariant:stableswap-share-issuance-sync",
+      "kind": "owns",
+      "semantics": "StableSwap checks its virtual issuance against the routed ledger after guarded state transitions.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "fn ensure_issuance_in_sync(pool_id: T::AssetId) -> DispatchResult"}]
+    },
+    {
+      "source": "component:stableswap",
+      "target": "operation:stableswap-add-liquidity",
+      "kind": "owns",
+      "semantics": "StableSwap implements the add-liquidity state transition.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "fn do_add_liquidity("}]
+    },
+    {
+      "source": "component:stableswap",
+      "target": "operation:stableswap-remove-liquidity",
+      "kind": "owns",
+      "semantics": "StableSwap implements the remove-liquidity state transition.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "fn do_remove_liquidity("}]
+    },
+    {
+      "source": "operation:stableswap-add-liquidity",
+      "target": "ledger:stableswap-reserves",
+      "kind": "reads",
+      "semantics": "Share calculation begins from actual pool-account balances.",
+      "enforcement": "calculation",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "T::Currency::free_balance(*pool_asset, &pool_account)"}]
+    },
+    {
+      "source": "operation:stableswap-add-liquidity",
+      "target": "state:stableswap-share-issuance",
+      "kind": "reads",
+      "semantics": "Share calculation and the invariant use pallet-tracked virtual share issuance.",
+      "enforcement": "calculation",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "let share_issuance = ShareIssuance::<T>::get(pool_id);"}]
+    },
+    {
+      "source": "operation:stableswap-add-liquidity",
+      "target": "ledger:stableswap-shares",
+      "kind": "mints",
+      "semantics": "The calculated pool shares are deposited to the provider's routed share balance.",
+      "enforcement": "transactional",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "T::Currency::deposit(pool_id, who, amount)"}]
+    },
+    {
+      "source": "operation:stableswap-add-liquidity",
+      "target": "state:stableswap-share-issuance",
+      "kind": "updates",
+      "semantics": "The virtual issuance is increased before the routed share deposit in the same transaction.",
+      "enforcement": "coupled-update",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "*issuance = issuance.checked_add(amount).ok_or(ArithmeticError::Overflow)?;"}]
+    },
+    {
+      "source": "operation:stableswap-add-liquidity",
+      "target": "ledger:stableswap-reserves",
+      "kind": "transfers-to",
+      "semantics": "Provided assets are transferred into the pool account before the final invariant check.",
+      "enforcement": "transactional",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "&pool_account,"}]
+    },
+    {
+      "source": "operation:stableswap-add-liquidity",
+      "target": "invariant:stableswap-add-liquidity",
+      "kind": "enforces",
+      "semantics": "A failing D or per-share D check returns InvariantError and rolls back the transactional operation.",
+      "enforcement": "transactional",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "Self::ensure_add_liquidity_invariant(pool_id, &initial_reserves, share_issuance)?;"}]
+    },
+    {
+      "source": "invariant:stableswap-add-liquidity",
+      "target": "ledger:stableswap-reserves",
+      "kind": "reads",
+      "semantics": "The invariant recomputes D from post-transfer pool-account reserves.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "let final_d ="}]
+    },
+    {
+      "source": "invariant:stableswap-add-liquidity",
+      "target": "state:stableswap-share-issuance",
+      "kind": "reads",
+      "semantics": "The invariant uses current virtual issuance as the denominator of post-add D per share.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "let current_share_issuance = ShareIssuance::<T>::get(pool_id);"}]
+    },
+    {
+      "source": "invariant:stableswap-add-liquidity",
+      "target": "invariant:stableswap-share-issuance-sync",
+      "kind": "invokes",
+      "semantics": "The post-add invariant first verifies virtual issuance against routed total issuance.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "Self::ensure_issuance_in_sync(pool_id)?;"}]
+    },
+    {
+      "source": "operation:stableswap-remove-liquidity",
+      "target": "ledger:stableswap-reserves",
+      "kind": "reads",
+      "semantics": "Withdrawal amounts are calculated from actual pool-account reserves.",
+      "enforcement": "calculation",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "let reserve = T::Currency::free_balance(*asset_id, &pool_account);"}]
+    },
+    {
+      "source": "operation:stableswap-remove-liquidity",
+      "target": "state:stableswap-share-issuance",
+      "kind": "reads",
+      "semantics": "The operation reads current virtual share issuance to calculate proportional reserve output.",
+      "enforcement": "calculation",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "let share_issuance = ShareIssuance::<T>::get(pool_id);"}]
+    },
+    {
+      "source": "operation:stableswap-remove-liquidity",
+      "target": "ledger:stableswap-shares",
+      "kind": "burns",
+      "semantics": "The withdrawn pool share amount is burned from the provider's routed balance.",
+      "enforcement": "transactional",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "T::Currency::withdraw(pool_id, who, amount, ExistenceRequirement::AllowDeath)"}]
+    },
+    {
+      "source": "operation:stableswap-remove-liquidity",
+      "target": "state:stableswap-share-issuance",
+      "kind": "updates",
+      "semantics": "The virtual issuance is decreased before the routed share withdrawal in the same transaction.",
+      "enforcement": "coupled-update",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": ".checked_sub(amount)"}]
+    },
+    {
+      "source": "operation:stableswap-remove-liquidity",
+      "target": "ledger:stableswap-reserves",
+      "kind": "transfers-from",
+      "semantics": "Calculated amounts leave the pool account before the post-state check.",
+      "enforcement": "transactional",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "T::Currency::transfer(*asset_id, &pool_account, who, amount, ExistenceRequirement::AllowDeath)?;"}]
+    },
+    {
+      "source": "operation:stableswap-remove-liquidity",
+      "target": "invariant:stableswap-remove-liquidity",
+      "kind": "enforces",
+      "semantics": "A failing D or per-share D check returns InvariantError and rolls back the transactional withdrawal.",
+      "enforcement": "transactional",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "Self::ensure_remove_liquidity_invariant(pool_id, &initial_reserves, share_issuance)?;"}]
+    },
+    {
+      "source": "invariant:stableswap-remove-liquidity",
+      "target": "ledger:stableswap-reserves",
+      "kind": "reads",
+      "semantics": "The invariant recomputes D from post-transfer pool-account reserves.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "final_reserves.iter().map(|v| v.amount)"}]
+    },
+    {
+      "source": "invariant:stableswap-remove-liquidity",
+      "target": "state:stableswap-share-issuance",
+      "kind": "reads",
+      "semantics": "The invariant uses current virtual issuance as the denominator of post-withdrawal D per share.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "let current_share_issuance = ShareIssuance::<T>::get(pool_id);"}]
+    },
+    {
+      "source": "invariant:stableswap-remove-liquidity",
+      "target": "invariant:stableswap-share-issuance-sync",
+      "kind": "invokes",
+      "semantics": "The post-withdrawal invariant first verifies virtual issuance against routed total issuance.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "Self::ensure_issuance_in_sync(pool_id)?;"}]
+    },
+    {
+      "source": "state:stableswap-share-issuance",
+      "target": "ledger:stableswap-shares",
+      "kind": "tracks",
+      "semantics": "Mint and burn helpers couple virtual issuance updates with routed ledger mutations; the synchronization invariant detects excess routed issuance.",
+      "enforcement": "coupled-update",
+      "evidence": [
+        {"file": "pallets/stableswap/src/lib.rs", "symbol": "fn mint_shares(pool_id: T::AssetId"},
+        {"file": "pallets/stableswap/src/lib.rs", "symbol": "fn burn_shares(pool_id: T::AssetId"}
+      ]
+    },
+    {
+      "source": "invariant:stableswap-share-issuance-sync",
+      "target": "state:stableswap-share-issuance",
+      "kind": "reads",
+      "semantics": "The synchronization check reads pallet-tracked virtual issuance.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "let tracked = ShareIssuance::<T>::get(pool_id);"}]
+    },
+    {
+      "source": "invariant:stableswap-share-issuance-sync",
+      "target": "ledger:stableswap-shares",
+      "kind": "reads",
+      "semantics": "The synchronization check reads routed total issuance and rejects values above virtual issuance.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/stableswap/src/lib.rs", "symbol": "let total = T::Currency::total_issuance(pool_id);"}]
+    },
+
+    {
+      "source": "component:xyk",
+      "target": "state:xyk-share-token",
+      "kind": "owns",
+      "semantics": "XYK owns the pair-account to share-asset mapping.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/xyk/src/lib.rs", "symbol": "pub(crate) type ShareToken<T: Config>"}]
+    },
+    {
+      "source": "component:xyk",
+      "target": "state:xyk-total-liquidity",
+      "kind": "owns",
+      "semantics": "XYK owns its local total-liquidity accounting value.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/xyk/src/lib.rs", "symbol": "pub(crate) type TotalLiquidity<T: Config>"}]
+    },
+    {
+      "source": "component:xyk",
+      "target": "ledger:xyk-reserves",
+      "kind": "owns",
+      "semantics": "XYK controls routed reserve balances at the pair account.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/xyk/src/lib.rs", "symbol": "let pair_account = Self::get_pair_id(asset_pair);"}]
+    },
+    {
+      "source": "component:xyk",
+      "target": "ledger:xyk-shares",
+      "kind": "owns",
+      "semantics": "XYK mints and burns the share asset selected by ShareToken.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/xyk/src/lib.rs", "symbol": "let share_token = Self::share_token(&pair_account);"}]
+    },
+    {
+      "source": "state:xyk-share-token",
+      "target": "ledger:xyk-shares",
+      "kind": "tracks",
+      "semantics": "The mapping selects which routed asset id represents shares for a pair account.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/xyk/src/lib.rs", "symbol": "let share_token = Self::share_token(&pair_account);"}]
+    },
+    {
+      "source": "operation:xyk-add-liquidity",
+      "target": "ledger:xyk-reserves",
+      "kind": "reads",
+      "semantics": "The add calculation reads both actual pair-account reserves.",
+      "enforcement": "calculation",
+      "evidence": [{"file": "pallets/xyk/src/lib.rs", "symbol": "let asset_b_reserve = T::Currency::free_balance(asset_b, &pair_account);"}]
+    },
+    {
+      "source": "operation:xyk-add-liquidity",
+      "target": "state:xyk-total-liquidity",
+      "kind": "reads",
+      "semantics": "TotalLiquidity is used as share issuance in the add-liquidity calculation.",
+      "enforcement": "calculation",
+      "evidence": [{"file": "pallets/xyk/src/lib.rs", "symbol": "let share_issuance = Self::total_liquidity(&pair_account);"}]
+    },
+    {
+      "source": "operation:xyk-add-liquidity",
+      "target": "ledger:xyk-reserves",
+      "kind": "transfers-to",
+      "semantics": "Both supplied assets are transferred to the pair account transactionally.",
+      "enforcement": "transactional",
+      "evidence": [{"file": "pallets/xyk/src/lib.rs", "symbol": "T::Currency::transfer(asset_a, &who, &pair_account, amount_a, ExistenceRequirement::AllowDeath)?;"}]
+    },
+    {
+      "source": "operation:xyk-add-liquidity",
+      "target": "ledger:xyk-shares",
+      "kind": "mints",
+      "semantics": "Calculated shares are deposited into the routed share ledger.",
+      "enforcement": "transactional",
+      "evidence": [{"file": "pallets/xyk/src/lib.rs", "symbol": "T::Currency::deposit(share_token, &who, shares_added)?;"}]
+    },
+    {
+      "source": "operation:xyk-add-liquidity",
+      "target": "state:xyk-total-liquidity",
+      "kind": "updates",
+      "semantics": "The local total is increased immediately after the routed share mint in the same transaction.",
+      "enforcement": "coupled-update",
+      "evidence": [{"file": "pallets/xyk/src/lib.rs", "symbol": "<TotalLiquidity<T>>::insert(&pair_account, liquidity_amount);"}]
+    },
+    {
+      "source": "operation:xyk-remove-liquidity",
+      "target": "ledger:xyk-reserves",
+      "kind": "reads",
+      "semantics": "The withdrawal calculation reads actual pair-account reserves.",
+      "enforcement": "calculation",
+      "evidence": [{"file": "pallets/xyk/src/lib.rs", "symbol": "let asset_a_reserve = T::Currency::free_balance(asset_a, &pair_account);"}]
+    },
+    {
+      "source": "operation:xyk-remove-liquidity",
+      "target": "state:xyk-total-liquidity",
+      "kind": "reads",
+      "semantics": "TotalLiquidity supplies the share denominator for proportional output.",
+      "enforcement": "calculation",
+      "evidence": [{"file": "pallets/xyk/src/lib.rs", "symbol": "let total_shares = Self::total_liquidity(&pair_account);"}]
+    },
+    {
+      "source": "operation:xyk-remove-liquidity",
+      "target": "ledger:xyk-reserves",
+      "kind": "transfers-from",
+      "semantics": "Calculated reserve amounts are transferred from the pair account.",
+      "enforcement": "transactional",
+      "evidence": [{"file": "pallets/xyk/src/lib.rs", "symbol": "&pair_account,"}]
+    },
+    {
+      "source": "operation:xyk-remove-liquidity",
+      "target": "ledger:xyk-shares",
+      "kind": "burns",
+      "semantics": "Removed shares are withdrawn from the routed share ledger.",
+      "enforcement": "transactional",
+      "evidence": [{"file": "pallets/xyk/src/lib.rs", "symbol": "T::Currency::withdraw(share_token, &who, share_amount, ExistenceRequirement::AllowDeath)?;"}]
+    },
+    {
+      "source": "operation:xyk-remove-liquidity",
+      "target": "state:xyk-total-liquidity",
+      "kind": "updates",
+      "semantics": "The local total is reduced immediately after the routed share burn in the same transaction.",
+      "enforcement": "coupled-update",
+      "evidence": [{"file": "pallets/xyk/src/lib.rs", "symbol": "<TotalLiquidity<T>>::insert(&pair_account, liquidity_left);"}]
+    },
+    {
+      "source": "state:xyk-total-liquidity",
+      "target": "ledger:xyk-shares",
+      "kind": "must-equal",
+      "semantics": "TotalLiquidity is expected to equal routed share issuance, but production liquidity paths maintain this through coupled writes rather than an independent equality check.",
+      "enforcement": "coupled-update",
+      "evidence": [
+        {"file": "pallets/xyk/src/lib.rs", "symbol": "T::Currency::deposit(share_token, &who, shares_added)?;"},
+        {"file": "pallets/xyk/src/lib.rs", "symbol": "<TotalLiquidity<T>>::insert(&pair_account, liquidity_amount);"}
+      ]
+    },
+    {
+      "source": "ledger:xyk-reserves",
+      "target": "ledger:xyk-shares",
+      "kind": "backs",
+      "semantics": "A share's withdrawal value is calculated proportionally from actual reserves and TotalLiquidity; no separate global backing assertion is made here.",
+      "enforcement": "calculation",
+      "evidence": [{"file": "pallets/xyk/src/lib.rs", "symbol": "hydra_dx_math::xyk::calculate_liquidity_out"}]
+    },
+    {
+      "source": "component:xyk",
+      "target": "invariant:xyk-ledger-total-liquidity",
+      "kind": "owns",
+      "semantics": "The equality is a semantic obligation created by XYK's duplicate share accounting.",
+      "enforcement": "observation",
+      "evidence": [{"file": "pallets/xyk/src/lib.rs", "symbol": "pub(crate) type TotalLiquidity<T: Config>"}]
+    },
+    {
+      "source": "component:xyk",
+      "target": "invariant:xyk-reserve-backing",
+      "kind": "owns",
+      "semantics": "XYK liquidity calculations define proportional reserve backing for its shares.",
+      "enforcement": "calculation",
+      "evidence": [{"file": "pallets/xyk/src/lib.rs", "symbol": "hydra_dx_math::xyk::calculate_liquidity_out"}]
+    },
+
+    {
+      "source": "component:omnipool",
+      "target": "state:omnipool-assets",
+      "kind": "owns",
+      "semantics": "Omnipool owns per-asset aggregate state.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "pub(super) type Assets<T: Config> = StorageMap"}]
+    },
+    {
+      "source": "component:omnipool",
+      "target": "state:omnipool-positions",
+      "kind": "owns",
+      "semantics": "Omnipool owns NFT-position keyed LP state.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "pub(super) type Positions<T: Config>"}]
+    },
+    {
+      "source": "state:omnipool-assets",
+      "target": "state:omnipool-lp-shares",
+      "kind": "tracks",
+      "semantics": "Assets stores the aggregate shares field for each pool asset.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/omnipool/src/types.rs", "symbol": "pub(super) shares: Balance,"}]
+    },
+    {
+      "source": "state:omnipool-assets",
+      "target": "state:omnipool-protocol-shares",
+      "kind": "tracks",
+      "semantics": "Assets separately stores the protocol-owned subset of aggregate shares.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/omnipool/src/types.rs", "symbol": "pub(super) protocol_shares: Balance,"}]
+    },
+    {
+      "source": "ledger:omnipool-asset-reserves",
+      "target": "state:omnipool-assets",
+      "kind": "backs",
+      "semantics": "Loading a usable reserve state joins stored Assets fields with the actual protocol-account asset balance.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "Ok((state, reserve).into())"}]
+    },
+    {
+      "source": "state:omnipool-positions",
+      "target": "state:omnipool-lp-shares",
+      "kind": "must-equal",
+      "semantics": "For each asset, summed Position.shares must equal Assets.shares minus Assets.protocol_shares.",
+      "enforcement": "try-runtime",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "state.shares - state.protocol_shares,"}]
+    },
+    {
+      "source": "state:omnipool-assets",
+      "target": "ledger:omnipool-hub-reserve",
+      "kind": "must-equal",
+      "semantics": "The sum of Assets.hub_reserve must equal the protocol account's hub asset balance.",
+      "enforcement": "try-runtime",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "account_balance, asset_hub_amount,"}]
+    },
+    {
+      "source": "operation:omnipool-add-liquidity",
+      "target": "ledger:omnipool-asset-reserves",
+      "kind": "transfers-to",
+      "semantics": "The supplied asset amount is transferred to the protocol account.",
+      "enforcement": "transactional",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "*state_changes.asset.delta_reserve,"}]
+    },
+    {
+      "source": "operation:omnipool-add-liquidity",
+      "target": "state:omnipool-positions",
+      "kind": "writes",
+      "semantics": "A new LP position containing the calculated shares is inserted.",
+      "enforcement": "transactional",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "<Positions<T>>::insert(instance_id, lp_position);"}]
+    },
+    {
+      "source": "operation:omnipool-add-liquidity",
+      "target": "state:omnipool-assets",
+      "kind": "writes",
+      "semantics": "The updated aggregate asset state is persisted after reserve and hub updates.",
+      "enforcement": "transactional",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "Self::set_asset_state(asset, new_asset_state);"}]
+    },
+    {
+      "source": "operation:omnipool-add-liquidity",
+      "target": "ledger:omnipool-hub-reserve",
+      "kind": "updates",
+      "semantics": "Hub asset liquidity is updated from the calculated delta in the same transaction.",
+      "enforcement": "transactional",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "Self::update_hub_asset_liquidity(&state_changes.asset.total_delta_hub_reserve())?;"}]
+    },
+    {
+      "source": "operation:omnipool-add-liquidity",
+      "target": "invariant:omnipool-liquidity-curve",
+      "kind": "enforces",
+      "semantics": "The completed transition calls the release-mode curve check and rolls back on error.",
+      "enforcement": "transactional",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "Self::ensure_liquidity_invariant((asset, asset_state, new_asset_state))?;"}]
+    },
+    {
+      "source": "operation:omnipool-remove-liquidity",
+      "target": "ledger:omnipool-asset-reserves",
+      "kind": "transfers-from",
+      "semantics": "Calculated asset value is transferred out of the protocol account.",
+      "enforcement": "transactional",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "&Self::protocol_account(),"}]
+    },
+    {
+      "source": "operation:omnipool-remove-liquidity",
+      "target": "state:omnipool-positions",
+      "kind": "writes",
+      "semantics": "The LP position is reduced or removed according to the withdrawn shares.",
+      "enforcement": "transactional",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "<Positions<T>>::remove(position_id);"}]
+    },
+    {
+      "source": "operation:omnipool-remove-liquidity",
+      "target": "state:omnipool-assets",
+      "kind": "writes",
+      "semantics": "The updated aggregate asset state is persisted after withdrawal calculations.",
+      "enforcement": "transactional",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "Self::set_asset_state(asset_id, new_asset_state);"}]
+    },
+    {
+      "source": "operation:omnipool-remove-liquidity",
+      "target": "ledger:omnipool-hub-reserve",
+      "kind": "updates",
+      "semantics": "Hub asset liquidity is adjusted from the calculated removal delta.",
+      "enforcement": "transactional",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "Self::update_hub_asset_liquidity("}]
+    },
+    {
+      "source": "operation:omnipool-remove-liquidity",
+      "target": "invariant:omnipool-liquidity-curve",
+      "kind": "enforces",
+      "semantics": "The completed transition calls the release-mode curve check and rolls back on error.",
+      "enforcement": "transactional",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "Self::ensure_liquidity_invariant((asset_id, asset_state, new_asset_state))?;"}]
+    },
+    {
+      "source": "invariant:omnipool-liquidity-curve",
+      "target": "ledger:omnipool-asset-reserves",
+      "kind": "reads",
+      "semantics": "The bounded-product check uses old and new actual asset reserve values.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "let new_reserve = U256::from(new_state.reserve);"}]
+    },
+    {
+      "source": "invariant:omnipool-liquidity-curve",
+      "target": "state:omnipool-assets",
+      "kind": "reads",
+      "semantics": "The bounded-product check uses old and new hub reserve state.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "let new_hub_reserve = U256::from(new_state.hub_reserve);"}]
+    },
+    {
+      "source": "invariant:omnipool-position-shares",
+      "target": "state:omnipool-positions",
+      "kind": "reads",
+      "semantics": "Try-runtime aggregates shares from every stored LP position.",
+      "enforcement": "try-runtime",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "for position in Positions::<T>::iter_values()"}]
+    },
+    {
+      "source": "invariant:omnipool-position-shares",
+      "target": "state:omnipool-lp-shares",
+      "kind": "reads",
+      "semantics": "Try-runtime compares the aggregate position total with the per-asset total shares field.",
+      "enforcement": "try-runtime",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "state.shares - state.protocol_shares,"}]
+    },
+    {
+      "source": "invariant:omnipool-position-shares",
+      "target": "state:omnipool-protocol-shares",
+      "kind": "reads",
+      "semantics": "Protocol-owned shares are subtracted before comparison with user LP positions.",
+      "enforcement": "try-runtime",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "state.shares - state.protocol_shares,"}]
+    },
+    {
+      "source": "invariant:omnipool-hub-backing",
+      "target": "state:omnipool-assets",
+      "kind": "reads",
+      "semantics": "Try-runtime sums every stored Assets.hub_reserve before comparing it with the ledger balance.",
+      "enforcement": "try-runtime",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "let asset_hub_amount: Balance = Assets::<T>::iter_values().map(|v| v.hub_reserve).sum();"}]
+    },
+    {
+      "source": "invariant:omnipool-hub-backing",
+      "target": "ledger:omnipool-hub-reserve",
+      "kind": "reads",
+      "semantics": "Try-runtime reads the protocol account hub asset balance for comparison.",
+      "enforcement": "try-runtime",
+      "evidence": [{"file": "pallets/omnipool/src/lib.rs", "symbol": "let account_balance = T::Currency::free_balance(T::HubAssetId::get(), &Self::protocol_account());"}]
+    },
+
+    {
+      "source": "component:circuit-breaker",
+      "target": "guard:issuance-increase-fuse",
+      "kind": "owns",
+      "semantics": "The circuit breaker provides the issuance fuse used by the token deposit hook.",
+      "enforcement": "configuration",
+      "evidence": [{"file": "pallets/circuit-breaker/src/fuses/issuance.rs", "symbol": "pub struct IssuanceIncreaseFuse<T: Config>"}]
+    },
+    {
+      "source": "component:circuit-breaker",
+      "target": "state:asset-lockdown",
+      "kind": "owns",
+      "semantics": "The circuit breaker stores each asset's issuance period or lockdown state.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/circuit-breaker/src/lib.rs", "symbol": "pub type AssetLockdownState<T: Config>"}]
+    },
+    {
+      "source": "operation:orml-token-deposit",
+      "target": "guard:issuance-increase-fuse",
+      "kind": "invokes",
+      "semantics": "ORML Tokens invokes the fuse after a deposit through CurrencyHooks.PostDeposit.",
+      "enforcement": "configuration",
+      "evidence": [
+        {"file": "runtime/hydradx/src/assets.rs", "symbol": "type PostDeposit = pallet_circuit_breaker::fuses::issuance::IssuanceIncreaseFuse<Runtime>;"},
+        {"file": "runtime/hydradx/src/assets.rs", "symbol": "type CurrencyHooks = CurrencyHooks;"}
+      ]
+    },
+    {
+      "source": "guard:issuance-increase-fuse",
+      "target": "router:routed-total-issuance",
+      "kind": "reads",
+      "semantics": "The fuse obtains current issuance through AssetTotalIssuance, so native, ERC20, and ORML routing semantics apply.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "runtime/hydradx/src/assets.rs", "symbol": "type Issuance = AssetTotalIssuance<Runtime>;"}]
+    },
+    {
+      "source": "guard:issuance-increase-fuse",
+      "target": "configuration:xcm-rate-limit",
+      "kind": "configured-by",
+      "semantics": "The per-asset deposit limit is supplied from Asset Registry xcm_rate_limit metadata.",
+      "enforcement": "configuration",
+      "evidence": [
+        {"file": "runtime/hydradx/src/assets.rs", "symbol": "type DepositLimit = XcmRateLimitsInRegistry<Runtime>;"},
+        {"file": "pallets/asset-registry/src/lib.rs", "symbol": "Pallet::<T>::assets(k).and_then(|details| details.xcm_rate_limit)"}
+      ]
+    },
+    {
+      "source": "guard:issuance-increase-fuse",
+      "target": "state:asset-lockdown",
+      "kind": "reads",
+      "semantics": "Classification depends on whether the asset is unlocked, actively locked, or has an expired period.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/circuit-breaker/src/fuses/issuance.rs", "symbol": "let state = AssetLockdownState::<T>::get(currency_id);"}]
+    },
+    {
+      "source": "guard:issuance-increase-fuse",
+      "target": "state:asset-lockdown",
+      "kind": "writes",
+      "semantics": "Post-deposit handling resets the issuance window or records lockdown through circuit-breaker state transitions.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/circuit-breaker/src/fuses/issuance.rs", "symbol": "Pallet::<T>::do_lockdown_asset(currency_id, context.lockdown_until)?;"}]
+    },
+    {
+      "source": "guard:issuance-increase-fuse",
+      "target": "state:asset-lockdown",
+      "kind": "locks",
+      "semantics": "When post-deposit growth exceeds the limit, excess balance is reserved and the asset enters lockdown; issuance itself is not rolled back by this hook.",
+      "enforcement": "runtime",
+      "evidence": [
+        {"file": "pallets/circuit-breaker/src/fuses/issuance.rs", "symbol": "Pallet::<T>::do_lock_deposit(who, currency_id, to_lock)?;"},
+        {"file": "pallets/circuit-breaker/src/fuses/issuance.rs", "symbol": "Pallet::<T>::do_lockdown_asset(currency_id, context.lockdown_until)?;"}
+      ]
+    },
+    {
+      "source": "guard:issuance-increase-fuse",
+      "target": "operation:orml-token-deposit",
+      "kind": "guards",
+      "semantics": "can_mint can reject a proposed mint before execution when its caller uses the preflight API; the configured ORML hook is separately post-deposit.",
+      "enforcement": "runtime",
+      "evidence": [{"file": "pallets/circuit-breaker/src/fuses/issuance.rs", "symbol": "pub fn can_mint(currency_id: T::AssetId, amount: T::Balance) -> bool"}]
+    }
+  ]
+}

--- a/scripts/runtime-interaction-graph/semantic-inventory.schema.json
+++ b/scripts/runtime-interaction-graph/semantic-inventory.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "semantic-inventory.schema.json",
+  "title": "Hydration runtime semantic interaction inventory",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "nodes", "edges"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "nodes": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/node"}
+    },
+    "edges": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/edge"}
+    }
+  },
+  "$defs": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*(?::[a-z0-9][a-z0-9-]*)+$"
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["file", "symbol"],
+      "properties": {
+        "file": {"type": "string", "minLength": 1, "pattern": "^[^/].*\\.rs$"},
+        "symbol": {"type": "string", "minLength": 1}
+      }
+    },
+    "node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "kind", "domain", "label", "description", "evidence"],
+      "properties": {
+        "id": {"$ref": "#/$defs/id"},
+        "kind": {
+          "enum": ["component", "configuration", "guard", "invariant", "ledger", "operation", "pool-state", "router"]
+        },
+        "domain": {
+          "enum": ["asset-routing", "circuit-breaker", "omnipool", "stableswap", "xyk"]
+        },
+        "label": {"type": "string", "minLength": 1},
+        "description": {"type": "string", "minLength": 1},
+        "evidence": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/evidence"}}
+      }
+    },
+    "edge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source", "target", "kind", "semantics", "enforcement", "evidence"],
+      "properties": {
+        "source": {"$ref": "#/$defs/id"},
+        "target": {"$ref": "#/$defs/id"},
+        "kind": {
+          "enum": ["backs", "burns", "configured-by", "derives-from", "enforces", "guards", "invokes", "locks", "mints", "must-equal", "owns", "reads", "routes-to", "tracks", "transfers-from", "transfers-to", "updates", "writes"]
+        },
+        "semantics": {"type": "string", "minLength": 1},
+        "enforcement": {
+          "enum": ["calculation", "configuration", "coupled-update", "observation", "runtime", "transactional", "try-runtime"]
+        },
+        "evidence": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/evidence"}}
+      }
+    }
+  }
+}

--- a/scripts/runtime-interaction-graph/semantic_inventory.py
+++ b/scripts/runtime-interaction-graph/semantic_inventory.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+ID_PATTERN = re.compile(r"^[a-z][a-z0-9-]*(?::[a-z0-9][a-z0-9-]*)+$")
+ALLOWED_NODE_KINDS = frozenset({
+	"component",
+	"configuration",
+	"guard",
+	"invariant",
+	"ledger",
+	"operation",
+	"pool-state",
+	"router",
+})
+ALLOWED_DOMAINS = frozenset({"asset-routing", "circuit-breaker", "omnipool", "stableswap", "xyk"})
+ALLOWED_EDGE_KINDS = frozenset({
+	"backs",
+	"burns",
+	"configured-by",
+	"derives-from",
+	"enforces",
+	"guards",
+	"invokes",
+	"locks",
+	"mints",
+	"must-equal",
+	"owns",
+	"reads",
+	"routes-to",
+	"tracks",
+	"transfers-from",
+	"transfers-to",
+	"updates",
+	"writes",
+})
+ALLOWED_ENFORCEMENT = frozenset({
+	"calculation",
+	"configuration",
+	"coupled-update",
+	"observation",
+	"runtime",
+	"transactional",
+	"try-runtime",
+})
+
+
+class InventoryError(ValueError):
+	pass
+
+
+def _require(condition: bool, message: str) -> None:
+	if not condition:
+		raise InventoryError(message)
+
+
+def _require_object(value: Any, context: str) -> dict[str, Any]:
+	_require(isinstance(value, dict), f"{context} must be an object")
+	return value
+
+
+def _require_string(value: Any, context: str) -> str:
+	_require(isinstance(value, str) and bool(value.strip()), f"{context} must be a non-empty string")
+	return value
+
+
+def _require_keys(value: dict[str, Any], required: set[str], context: str) -> None:
+	missing = required - value.keys()
+	unknown = value.keys() - required
+	_require(not missing, f"{context} is missing keys: {', '.join(sorted(missing))}")
+	_require(not unknown, f"{context} has unknown keys: {', '.join(sorted(unknown))}")
+
+
+def _source_evidence(
+	evidence: Any,
+	root: Path,
+	context: str,
+	cache: dict[Path, tuple[str, str]],
+) -> list[dict[str, Any]]:
+	_require(isinstance(evidence, list) and bool(evidence), f"{context}.evidence must be a non-empty array")
+	normalized = []
+	for index, raw_item in enumerate(evidence):
+		item_context = f"{context}.evidence[{index}]"
+		item = _require_object(raw_item, item_context)
+		_require_keys(item, {"file", "symbol"}, item_context)
+		relative_text = _require_string(item["file"], f"{item_context}.file")
+		symbol = _require_string(item["symbol"], f"{item_context}.symbol")
+		relative = Path(relative_text)
+		_require(not relative.is_absolute(), f"{item_context}.file must be relative to the repository root")
+		_require(".." not in relative.parts, f"{item_context}.file cannot traverse outside the repository root")
+		path = (root / relative).resolve()
+		try:
+			path.relative_to(root)
+		except ValueError as error:
+			raise InventoryError(f"{item_context}.file resolves outside the repository root") from error
+		_require(path.suffix == ".rs", f"{item_context}.file must reference a Rust source file")
+		_require(path.is_file(), f"{item_context}.file does not exist: {relative_text}")
+		if path not in cache:
+			contents = path.read_text(encoding="utf-8")
+			cache[path] = (contents, hashlib.sha256(contents.encode()).hexdigest())
+		contents, source_sha256 = cache[path]
+		offset = contents.find(symbol)
+		_require(offset >= 0, f"{item_context}.symbol was not found in {relative_text}: {symbol}")
+		normalized.append({
+			"file": relative.as_posix(),
+			"symbol": symbol,
+			"line": contents.count("\n", 0, offset) + 1,
+			"source_sha256": source_sha256,
+		})
+	return normalized
+
+
+def validate_inventory(payload: Any, root: Path) -> dict[str, Any]:
+	root = root.resolve()
+	_require(root.is_dir(), f"repository root does not exist: {root}")
+	document = _require_object(payload, "inventory")
+	_require_keys(document, {"schema_version", "nodes", "edges"}, "inventory")
+	_require(document["schema_version"] == SCHEMA_VERSION, f"schema_version must be {SCHEMA_VERSION}")
+	_require(isinstance(document["nodes"], list), "inventory.nodes must be an array")
+	_require(isinstance(document["edges"], list), "inventory.edges must be an array")
+
+	cache: dict[Path, tuple[str, str]] = {}
+	nodes = []
+	node_ids = set()
+	for index, raw_node in enumerate(document["nodes"]):
+		context = f"inventory.nodes[{index}]"
+		node = _require_object(raw_node, context)
+		_require_keys(node, {"id", "kind", "domain", "label", "description", "evidence"}, context)
+		node_id = _require_string(node["id"], f"{context}.id")
+		_require(bool(ID_PATTERN.fullmatch(node_id)), f"{context}.id has an invalid format: {node_id}")
+		_require(node_id not in node_ids, f"duplicate node id: {node_id}")
+		node_ids.add(node_id)
+		kind = _require_string(node["kind"], f"{context}.kind")
+		domain = _require_string(node["domain"], f"{context}.domain")
+		_require(kind in ALLOWED_NODE_KINDS, f"{context}.kind is unsupported: {kind}")
+		_require(domain in ALLOWED_DOMAINS, f"{context}.domain is unsupported: {domain}")
+		nodes.append({
+			"id": node_id,
+			"kind": kind,
+			"domain": domain,
+			"label": _require_string(node["label"], f"{context}.label"),
+			"description": _require_string(node["description"], f"{context}.description"),
+			"semantic_source": "explicit-inventory",
+			"evidence": _source_evidence(node["evidence"], root, context, cache),
+		})
+
+	edges = []
+	edge_ids = set()
+	for index, raw_edge in enumerate(document["edges"]):
+		context = f"inventory.edges[{index}]"
+		edge = _require_object(raw_edge, context)
+		_require_keys(edge, {"source", "target", "kind", "semantics", "enforcement", "evidence"}, context)
+		source = _require_string(edge["source"], f"{context}.source")
+		target = _require_string(edge["target"], f"{context}.target")
+		kind = _require_string(edge["kind"], f"{context}.kind")
+		enforcement = _require_string(edge["enforcement"], f"{context}.enforcement")
+		_require(source in node_ids, f"{context}.source references an unknown node: {source}")
+		_require(target in node_ids, f"{context}.target references an unknown node: {target}")
+		_require(kind in ALLOWED_EDGE_KINDS, f"{context}.kind is unsupported: {kind}")
+		_require(enforcement in ALLOWED_ENFORCEMENT, f"{context}.enforcement is unsupported: {enforcement}")
+		edge_id = f"{source}|{kind}|{target}"
+		_require(edge_id not in edge_ids, f"duplicate semantic edge: {edge_id}")
+		edge_ids.add(edge_id)
+		edges.append({
+			"id": edge_id,
+			"source": source,
+			"target": target,
+			"kind": kind,
+			"semantics": _require_string(edge["semantics"], f"{context}.semantics"),
+			"enforcement": enforcement,
+			"semantic_source": "explicit-inventory",
+			"evidence": _source_evidence(edge["evidence"], root, context, cache),
+		})
+
+	nodes.sort(key=lambda node: node["id"])
+	edges.sort(key=lambda edge: edge["id"])
+	evidence_files = sorted({item["file"] for item in nodes + edges for item in item["evidence"]})
+	return {
+		"schema_version": SCHEMA_VERSION,
+		"nodes": nodes,
+		"edges": edges,
+		"coverage": {
+			"node_count": len(nodes),
+			"edge_count": len(edges),
+			"domains": sorted({node["domain"] for node in nodes}),
+			"node_kinds": sorted({node["kind"] for node in nodes}),
+			"edge_kinds": sorted({edge["kind"] for edge in edges}),
+			"evidence_files": evidence_files,
+			"evidence_file_count": len(evidence_files),
+		},
+	}
+
+
+def load_inventory(root: Path, inventory_path: Path | None = None) -> dict[str, Any]:
+	root_inventory = root / "scripts/runtime-interaction-graph/semantic-inventory.json"
+	path = inventory_path or root_inventory
+	payload = json.loads(path.read_text(encoding="utf-8"))
+	return validate_inventory(payload, root)
+
+
+def main() -> None:
+	default_root = Path(__file__).resolve().parents[2]
+	parser = argparse.ArgumentParser(description="Validate and normalize the runtime semantic inventory")
+	parser.add_argument("--root", type=Path, default=default_root)
+	parser.add_argument("--inventory", type=Path, default=Path(__file__).with_name("semantic-inventory.json"))
+	parser.add_argument("--output", type=Path)
+	args = parser.parse_args()
+	try:
+		result = load_inventory(args.root, args.inventory)
+	except (InventoryError, json.JSONDecodeError, OSError) as error:
+		parser.error(str(error))
+	encoded = json.dumps(result, indent=2, sort_keys=True) + "\n"
+	if args.output:
+		args.output.parent.mkdir(parents=True, exist_ok=True)
+		args.output.write_text(encoded, encoding="utf-8")
+	else:
+		print(encoded, end="")
+
+
+if __name__ == "__main__":
+	main()

--- a/scripts/runtime-interaction-graph/serve_graph.py
+++ b/scripts/runtime-interaction-graph/serve_graph.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import mimetypes
+import socket
+import threading
+import sys
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from types import SimpleNamespace
+from urllib.parse import unquote, urlsplit
+
+
+SCRIPT_DIRECTORY = Path(__file__).resolve().parent
+if str(SCRIPT_DIRECTORY) not in sys.path:
+	sys.path.insert(0, str(SCRIPT_DIRECTORY))
+import query_graph
+
+
+SERVICE_SCHEMA_VERSION = 1
+DEFAULT_MAX_BODY_BYTES = 65_536
+DEFAULT_MAX_RECORDS = 250
+DEFAULT_MAX_TOKENS = 16_000
+DEFAULT_MAX_EXPANSIONS = 2_000
+DEFAULT_MAX_CONCURRENCY = 8
+DEFAULT_SOCKET_TIMEOUT = 10.0
+OPERATIONS = ("neighbors", "node", "packs", "paths", "search", "summary")
+STATIC_FILES = frozenset({"interaction-graph.html", "interaction-graph.json", "graph-scale.svg",
+	"component-graph.json", "query-packs.json", "coverage.json", "completeness.json"})
+
+
+@dataclass(frozen=True)
+class StaticRepresentation:
+	path: Path
+	size: int
+	etag: str
+
+
+@dataclass(frozen=True)
+class StaticAsset:
+	content_type: str
+	cache_control: str
+	identity: StaticRepresentation
+	gzip: StaticRepresentation | None
+
+
+@dataclass(frozen=True)
+class ServiceState:
+	root: Path
+	index: query_graph.GraphIndex
+	companions: dict[str, dict | None]
+	companion_sha256: dict[str, str]
+	component_index: query_graph.GraphIndex | None
+	graph_sha256: str
+	max_body_bytes: int
+	max_records: int
+	max_tokens: int
+	max_expansions: int
+	static_assets: dict[str, StaticAsset]
+
+
+def static_representation(path: Path, root: Path) -> StaticRepresentation | None:
+	if not path.exists():
+		return None
+	resolved = path.resolve()
+	try:
+		resolved.relative_to(root)
+	except ValueError as error:
+		raise query_graph.QueryFailure("invalid-static-artifact",
+			"static artifact must stay inside the artifact root") from error
+	if not resolved.is_file():
+		raise query_graph.QueryFailure("invalid-static-artifact", "static artifact must be a regular file")
+	content = resolved.read_bytes()
+	if path.name.endswith(".gz") and not content.startswith(b"\x1f\x8b"):
+		raise query_graph.QueryFailure("invalid-static-artifact", "compressed static artifact is not gzip data")
+	digest = hashlib.sha256(content).hexdigest()
+	return StaticRepresentation(resolved, len(content), f'"{digest}"')
+
+
+def load_static_assets(root: Path) -> dict[str, StaticAsset]:
+	assets = {}
+	for name in sorted(STATIC_FILES):
+		identity = static_representation(root / name, root)
+		if identity is None:
+			continue
+		compressed = static_representation(root / f"{name}.gz", root)
+		content_type = mimetypes.guess_type(name)[0] or "application/octet-stream"
+		cache_control = "no-cache" if Path(name).suffix.casefold() in {".html", ".json"} \
+			else "public, max-age=300, must-revalidate"
+		assets[name] = StaticAsset(content_type, cache_control, identity, compressed)
+	return assets
+
+
+def load_state(root: Path, max_body_bytes: int = DEFAULT_MAX_BODY_BYTES,
+	max_records: int = DEFAULT_MAX_RECORDS, max_tokens: int = DEFAULT_MAX_TOKENS,
+	max_expansions: int = DEFAULT_MAX_EXPANSIONS) -> ServiceState:
+	root = root.resolve()
+	if not root.is_dir():
+		raise query_graph.QueryFailure("invalid-artifact-root", "artifact root must be a directory")
+	if max_body_bytes < 1:
+		raise query_graph.QueryFailure("invalid-server-limit", "max body bytes must be positive")
+	if not 1 <= max_records <= 10_000:
+		raise query_graph.QueryFailure("invalid-server-limit", "max records must be from 1 to 10000")
+	if not 256 <= max_tokens <= 1_000_000:
+		raise query_graph.QueryFailure("invalid-server-limit", "max tokens must be from 256 to 1000000")
+	if not 1 <= max_expansions <= 100_000:
+		raise query_graph.QueryFailure("invalid-server-limit", "max expansions must be from 1 to 100000")
+	graph_path = root / "interaction-graph.json"
+	payload = query_graph.load_json(graph_path, dict, "graph")
+	index = query_graph.GraphIndex(payload)
+	args = SimpleNamespace(graph=graph_path, coverage=None, completeness=None, query_packs=None,
+		component_graph=None, no_auto_companions=False)
+	companions, companion_sha256 = query_graph.load_companions(args)
+	for required in ("coverage", "query_packs", "component_graph"):
+		if companions.get(required) is None:
+			raise query_graph.QueryFailure("missing-companion", f"required companion is missing: {required}")
+	if companions["query_packs"].get("schema_version") != 1:
+		raise query_graph.QueryFailure("invalid-query-packs",
+			"query-packs.json must use schema_version 1")
+	coverage = companions["coverage"]
+	for field, actual in (("nodes", len(index.nodes)), ("edges", len(index.edges))):
+		if coverage.get(field) != actual:
+			raise query_graph.QueryFailure("stale-coverage",
+				f"coverage {field} count does not match interaction-graph.json")
+	component_index = query_graph.component_index(index, companions.get("component_graph"))
+	if component_index is None:
+		raise query_graph.QueryFailure("missing-companion", "required companion is missing: component_graph")
+	graph_sha256 = hashlib.sha256(graph_path.read_bytes()).hexdigest()
+	static_assets = load_static_assets(root)
+	missing_assets = sorted(STATIC_FILES - static_assets.keys())
+	if missing_assets:
+		raise query_graph.QueryFailure("missing-static-artifact",
+			f"required static artifact is missing: {missing_assets[0]}")
+	return ServiceState(root, index, companions, companion_sha256, component_index, graph_sha256,
+		max_body_bytes, max_records, max_tokens, max_expansions, static_assets)
+
+
+def accepts_gzip(value: str | None) -> bool:
+	if not value:
+		return False
+	qualities = {}
+	for part in value.split(","):
+		pieces = [piece.strip() for piece in part.split(";")]
+		name = pieces[0].casefold()
+		if not name:
+			continue
+		quality = 1.0
+		for parameter in pieces[1:]:
+			if parameter.casefold().startswith("q="):
+				try:
+					quality = float(parameter[2:])
+				except ValueError:
+					quality = 0.0
+		if not 0.0 <= quality <= 1.0:
+			quality = 0.0
+		qualities[name] = quality
+	if "gzip" in qualities:
+		return qualities["gzip"] > 0
+	return qualities.get("*", 0.0) > 0
+
+
+class GraphHTTPServer(ThreadingHTTPServer):
+	daemon_threads = True
+	allow_reuse_address = True
+
+	def __init__(self, address: tuple[str, int], state: ServiceState,
+		max_concurrency: int = DEFAULT_MAX_CONCURRENCY,
+		socket_timeout: float = DEFAULT_SOCKET_TIMEOUT) -> None:
+		if max_concurrency < 1:
+			raise ValueError("max concurrency must be positive")
+		if socket_timeout <= 0:
+			raise ValueError("socket timeout must be positive")
+		self.state = state
+		self.socket_timeout = socket_timeout
+		self.request_slots = threading.BoundedSemaphore(max_concurrency)
+		super().__init__(address, GraphRequestHandler)
+
+	def get_request(self):
+		request, address = super().get_request()
+		request.settimeout(self.socket_timeout)
+		return request, address
+
+	def process_request(self, request, client_address) -> None:
+		self.request_slots.acquire()
+		try:
+			super().process_request(request, client_address)
+		except Exception:
+			self.request_slots.release()
+			raise
+
+	def process_request_thread(self, request, client_address) -> None:
+		try:
+			super().process_request_thread(request, client_address)
+		finally:
+			self.request_slots.release()
+
+
+class GraphRequestHandler(BaseHTTPRequestHandler):
+	server_version = "runtime-graph"
+	sys_version = ""
+
+	@property
+	def state(self) -> ServiceState:
+		return self.server.state
+
+	def version_string(self) -> str:
+		return self.server_version
+
+	def log_message(self, format: str, *args: object) -> None:
+		return
+
+	def _begin_response(self, status: int, content_type: str, content_length: int,
+		cache_control: str = "no-store", content_encoding: str | None = None,
+		location: str | None = None, etag: str | None = None) -> None:
+		self.send_response(status)
+		self.send_header("Content-Type", content_type)
+		self.send_header("Content-Length", str(content_length))
+		self.send_header("Cache-Control", cache_control)
+		self.send_header("Access-Control-Allow-Origin", "*")
+		self.send_header("Access-Control-Allow-Methods", "GET, HEAD, POST, OPTIONS")
+		self.send_header("Access-Control-Allow-Headers", "Content-Type")
+		self.send_header("Cross-Origin-Resource-Policy", "cross-origin")
+		self.send_header("Content-Security-Policy",
+			"default-src 'none'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; "
+			"img-src 'self' data:; font-src 'self'; connect-src 'self'; base-uri 'none'; "
+			"frame-ancestors 'none'; form-action 'none'")
+		self.send_header("Permissions-Policy", "camera=(), geolocation=(), microphone=()")
+		self.send_header("Referrer-Policy", "no-referrer")
+		self.send_header("X-Content-Type-Options", "nosniff")
+		self.send_header("X-Frame-Options", "DENY")
+		if content_encoding:
+			self.send_header("Content-Encoding", content_encoding)
+		if etag:
+			self.send_header("ETag", etag)
+		self.send_header("Vary", "Accept-Encoding")
+		if location:
+			self.send_header("Location", location)
+		self.end_headers()
+
+	def _send_bytes(self, status: int, body: bytes, content_type: str = "application/json; charset=utf-8",
+		cache_control: str = "no-store", content_encoding: str | None = None,
+		head_only: bool = False) -> None:
+		self._begin_response(status, content_type, len(body), cache_control, content_encoding)
+		if body and not head_only:
+			self.wfile.write(body)
+
+	def _send_json(self, status: int, value: object, head_only: bool = False) -> None:
+		body = (json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True) + "\n").encode()
+		self._send_bytes(status, body, head_only=head_only)
+
+	def _send_query_failure(self, status: int, failure: query_graph.QueryFailure,
+		operation: str = "invalid", parameters: dict | None = None,
+		max_records: int | None = None, max_tokens: int | None = None) -> None:
+		body = query_graph.error_response(operation, parameters or {}, failure,
+			self.state.companions, max_records or self.state.max_records,
+			max_tokens or self.state.max_tokens, self.state.graph_sha256,
+			self.state.companion_sha256, self.state.index).encode()
+		self._send_bytes(status, body + b"\n")
+
+	def send_error(self, code: int, message: str | None = None,
+		explain: str | None = None) -> None:
+		self._send_json(code, {"error": "http-error", "status": code})
+
+	def do_OPTIONS(self) -> None:
+		self._begin_response(204, "text/plain; charset=utf-8", 0)
+
+	def do_GET(self) -> None:
+		self._handle_read(False)
+
+	def do_HEAD(self) -> None:
+		self._handle_read(True)
+
+	def _handle_read(self, head_only: bool) -> None:
+		path = urlsplit(self.path).path
+		if path == "/":
+			self._begin_response(302, "text/plain; charset=utf-8", 0,
+				cache_control="no-store", location="/interaction-graph.html")
+			return
+		if path == "/healthz":
+			self._send_json(200, {"schema_version": SERVICE_SCHEMA_VERSION, "status": "ok"}, head_only)
+			return
+		if path == "/readyz":
+			self._send_json(200, {"schema_version": SERVICE_SCHEMA_VERSION, "status": "ready",
+				"graph": {"fingerprint": self.state.graph_sha256,
+					"nodes": len(self.state.index.nodes), "edges": len(self.state.index.edges),
+					"companions": self.state.companion_sha256}}, head_only)
+			return
+		if path == "/api/v1":
+			self._send_json(200, self._metadata(), head_only)
+			return
+		if path.startswith("/api/"):
+			body = b'{"error":"endpoint-not-found"}\n'
+			self._send_bytes(404, body, head_only=head_only)
+			return
+		self._serve_static(path, head_only)
+
+	def do_POST(self) -> None:
+		path = urlsplit(self.path).path
+		if path != "/api/v1/query":
+			self._send_query_failure(404,
+				query_graph.QueryFailure("endpoint-not-found", "API endpoint does not exist"))
+			return
+		self._handle_query()
+
+	def _metadata(self) -> dict:
+		return {
+			"schema_version": SERVICE_SCHEMA_VERSION,
+			"service": "runtime-interaction-graph",
+			"query_response_schema_version": query_graph.SCHEMA_VERSION,
+			"operations": list(OPERATIONS),
+			"graph": {"schema_version": 2, "fingerprint": self.state.graph_sha256,
+				"companions": self.state.companion_sha256,
+				"nodes": len(self.state.index.nodes), "edges": len(self.state.index.edges)},
+			"limits": {"max_body_bytes": self.state.max_body_bytes,
+				"max_records": self.state.max_records, "max_tokens": self.state.max_tokens,
+				"max_expansions": self.state.max_expansions},
+		}
+
+	def _read_json_request(self) -> dict:
+		if self.headers.get_all("Transfer-Encoding"):
+			self.close_connection = True
+			raise query_graph.QueryFailure("invalid-request", "transfer encoding is not supported")
+		if self.headers.get_all("Content-Encoding"):
+			self.close_connection = True
+			raise query_graph.QueryFailure("invalid-request", "content encoding is not supported")
+		content_type = self.headers.get_content_type()
+		charset = self.headers.get_content_charset()
+		if content_type != "application/json" or \
+			(charset is not None and charset.casefold() != "utf-8"):
+			raise query_graph.QueryFailure("unsupported-content-type", "request must use application/json UTF-8")
+		length_values = self.headers.get_all("Content-Length") or []
+		if not length_values:
+			raise query_graph.QueryFailure("length-required", "Content-Length is required")
+		if len(length_values) != 1 or "," in length_values[0]:
+			self.close_connection = True
+			raise query_graph.QueryFailure("invalid-content-length", "exactly one Content-Length is required")
+		length_value = length_values[0]
+		try:
+			length = int(length_value)
+		except ValueError as error:
+			raise query_graph.QueryFailure("invalid-content-length", "Content-Length must be an integer") from error
+		if length < 0:
+			raise query_graph.QueryFailure("invalid-content-length", "Content-Length must not be negative")
+		if length > self.state.max_body_bytes:
+			self.close_connection = True
+			raise query_graph.QueryFailure("request-body-too-large", "request body exceeds the server limit")
+		try:
+			body = self.rfile.read(length)
+		except (OSError, socket.timeout) as error:
+			self.close_connection = True
+			raise query_graph.QueryFailure("invalid-request-body", "request body could not be read") from error
+		if len(body) != length:
+			self.close_connection = True
+			raise query_graph.QueryFailure("invalid-request-body", "request body ended before Content-Length")
+		def reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict:
+			result = {}
+			for key, item in pairs:
+				if key in result:
+					raise ValueError(f"duplicate key: {key}")
+				result[key] = item
+			return result
+		try:
+			value = json.loads(body.decode("utf-8"),
+				parse_constant=lambda value: (_ for _ in ()).throw(ValueError(value)),
+				object_pairs_hook=reject_duplicate_keys)
+		except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as error:
+			raise query_graph.QueryFailure("invalid-json", "request body must be valid JSON") from error
+		if not isinstance(value, dict):
+			raise query_graph.QueryFailure("invalid-query", "query request must be a JSON object")
+		return value
+
+	def _handle_query(self) -> None:
+		request_records = self.state.max_records
+		request_tokens = self.state.max_tokens
+		operation = "invalid"
+		try:
+			request = self._read_json_request()
+			candidate_records = request.get("max_records", self.state.max_records)
+			if isinstance(candidate_records, int) and not isinstance(candidate_records, bool) \
+				and 1 <= candidate_records <= self.state.max_records:
+				request_records = candidate_records
+			candidate_tokens = request.get("max_tokens", self.state.max_tokens)
+			if isinstance(candidate_tokens, int) and not isinstance(candidate_tokens, bool) \
+				and 256 <= candidate_tokens <= self.state.max_tokens:
+				request_tokens = candidate_tokens
+			request_records = query_graph.bounded_int(request, "max_records", self.state.max_records,
+				1, self.state.max_records)
+			request_tokens = query_graph.bounded_int(request, "max_tokens", self.state.max_tokens,
+				256, self.state.max_tokens)
+			operation_value = request.get("operation")
+			if isinstance(operation_value, str):
+				operation = operation_value
+			if "max_expansions" in request or operation in {"neighbors", "paths"}:
+				request["max_expansions"] = query_graph.bounded_int(request, "max_expansions",
+					min(DEFAULT_MAX_EXPANSIONS, self.state.max_expansions), 1,
+					self.state.max_expansions)
+			body = query_graph.execute(self.state.index, self.state.companions, request,
+				request_records, request_tokens, self.state.graph_sha256, self.state.component_index,
+				companion_sha256=self.state.companion_sha256).encode() + b"\n"
+			self._send_bytes(200, body)
+		except query_graph.QueryFailure as error:
+			status = 413 if error.code == "request-body-too-large" else \
+				415 if error.code == "unsupported-content-type" else \
+				411 if error.code == "length-required" else 400
+			self._send_query_failure(status, error, operation,
+				max_records=request_records, max_tokens=request_tokens)
+		except Exception:
+			self._send_query_failure(500,
+				query_graph.QueryFailure("internal-error", "query service failed"), operation,
+				max_records=request_records, max_tokens=request_tokens)
+
+	def _serve_static(self, request_path: str, head_only: bool) -> None:
+		try:
+			decoded = unquote(request_path, errors="strict")
+		except UnicodeError:
+			self._send_not_found(head_only)
+			return
+		if not decoded.startswith("/") or "\\" in decoded or "\x00" in decoded:
+			self._send_not_found(head_only)
+			return
+		name = decoded[1:]
+		asset = self.state.static_assets.get(name)
+		if asset is None:
+			self._send_not_found(head_only)
+			return
+		selected = asset.identity
+		content_encoding = None
+		if accepts_gzip(self.headers.get("Accept-Encoding")) and asset.gzip is not None:
+			selected = asset.gzip
+			content_encoding = "gzip"
+		if self._etag_matches(selected.etag):
+			self._begin_response(304, asset.content_type, 0, asset.cache_control,
+				content_encoding, etag=selected.etag)
+			return
+		try:
+			self._begin_response(200, asset.content_type, selected.size, asset.cache_control,
+				content_encoding, etag=selected.etag)
+			if not head_only:
+				with selected.path.open("rb") as source:
+					while chunk := source.read(64 * 1024):
+						self.wfile.write(chunk)
+		except OSError:
+			if not self.wfile.closed:
+				self.close_connection = True
+
+	def _etag_matches(self, etag: str) -> bool:
+		value = self.headers.get("If-None-Match")
+		if not value:
+			return False
+		return any(candidate == "*" or candidate.removeprefix("W/") == etag
+			for candidate in (part.strip() for part in value.split(",")))
+
+	def _send_not_found(self, head_only: bool) -> None:
+		body = b'{"error":"not-found"}\n'
+		self._send_bytes(404, body, head_only=head_only)
+
+
+def create_server(state: ServiceState, host: str, port: int,
+	max_concurrency: int = DEFAULT_MAX_CONCURRENCY,
+	socket_timeout: float = DEFAULT_SOCKET_TIMEOUT) -> GraphHTTPServer:
+	return GraphHTTPServer((host, port), state, max_concurrency, socket_timeout)
+
+
+def parser() -> argparse.ArgumentParser:
+	result = argparse.ArgumentParser(description="Serve a generated runtime interaction graph")
+	result.add_argument("--root", type=Path, required=True,
+		help="generated artifact directory containing interaction-graph.json")
+	result.add_argument("--host", default="127.0.0.1")
+	result.add_argument("--port", type=int, default=8000)
+	result.add_argument("--max-body-bytes", type=int, default=DEFAULT_MAX_BODY_BYTES)
+	result.add_argument("--max-records", type=int, default=DEFAULT_MAX_RECORDS)
+	result.add_argument("--max-tokens", type=int, default=DEFAULT_MAX_TOKENS)
+	result.add_argument("--max-expansions", type=int, default=DEFAULT_MAX_EXPANSIONS)
+	result.add_argument("--max-concurrency", type=int, default=DEFAULT_MAX_CONCURRENCY)
+	result.add_argument("--socket-timeout", type=float, default=DEFAULT_SOCKET_TIMEOUT)
+	return result
+
+
+def main() -> int:
+	args = parser().parse_args()
+	if not 0 <= args.port <= 65_535:
+		parser().error("--port must be from 0 to 65535")
+	if args.max_concurrency < 1:
+		parser().error("--max-concurrency must be positive")
+	if args.socket_timeout <= 0:
+		parser().error("--socket-timeout must be positive")
+	try:
+		state = load_state(args.root, args.max_body_bytes, args.max_records,
+			args.max_tokens, args.max_expansions)
+	except query_graph.QueryFailure as error:
+		parser().error(str(error))
+	server = create_server(state, args.host, args.port, args.max_concurrency,
+		args.socket_timeout)
+	try:
+		server.serve_forever()
+	except KeyboardInterrupt:
+		pass
+	finally:
+		server.server_close()
+	return 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/scripts/runtime-interaction-graph/test_analysis_provenance.py
+++ b/scripts/runtime-interaction-graph/test_analysis_provenance.py
@@ -1,0 +1,74 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE = Path(__file__).with_name("analysis_provenance.py")
+SPEC = importlib.util.spec_from_file_location("analysis_provenance", MODULE)
+provenance = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(provenance)
+
+
+class AnalysisProvenanceTests(unittest.TestCase):
+	def test_tool_fingerprint_should_cover_every_local_input(self):
+		with tempfile.TemporaryDirectory() as directory:
+			root = Path(directory)
+			collector = root / "collector.py"
+			helper = root / "helper.py"
+			collector.write_text("import helper\n")
+			helper.write_text("VALUE = 1\n")
+			before = provenance.tool_input_fingerprint([collector, helper])
+			helper.write_text("VALUE = 2\n")
+			after = provenance.tool_input_fingerprint([collector, helper])
+			self.assertNotEqual(before["sha256"], after["sha256"])
+			self.assertEqual(set(after["files"]), {"collector.py", "helper.py"})
+			self.assertTrue(provenance.valid_tool_input_fingerprint(after))
+			tampered = {**after, "files": {**after["files"], "helper.py": "0" * 64}}
+			self.assertFalse(provenance.valid_tool_input_fingerprint(tampered))
+
+	def test_tool_fingerprint_should_reject_invalid_names_and_hashes(self):
+		with self.assertRaisesRegex(ValueError, "invalid tool input name"):
+			provenance.tool_input_digest({"../collector.py": "0" * 64})
+		with self.assertRaisesRegex(ValueError, "invalid tool input checksum"):
+			provenance.tool_input_digest({"collector.py": "not-a-hash"})
+
+	def test_tree_fingerprint_should_change_when_source_changes(self):
+		with tempfile.TemporaryDirectory() as directory:
+			root = Path(directory)
+			(root / "pallets/example/src").mkdir(parents=True)
+			source = root / "pallets/example/src/lib.rs"
+			source.write_text("fn first() {}\n")
+			before = provenance.tree_fingerprint(root)
+			source.write_text("fn second() {}\n")
+			after = provenance.tree_fingerprint(root)
+			self.assertNotEqual(before["sha256"], after["sha256"])
+			self.assertEqual(after["file_count"], 1)
+
+	def test_tree_fingerprint_should_cover_integration_test_sources(self):
+		with tempfile.TemporaryDirectory() as directory:
+			root = Path(directory)
+			(root / "integration-tests/src").mkdir(parents=True)
+			source = root / "integration-tests/src/lib.rs"
+			source.write_text("fn first_test() {}\n")
+			before = provenance.tree_fingerprint(root)
+			source.write_text("fn changed_test() {}\n")
+			self.assertNotEqual(before["sha256"], provenance.tree_fingerprint(root)["sha256"])
+
+	def test_reusable_artifact_should_require_matching_content_and_inputs(self):
+		with tempfile.TemporaryDirectory() as directory:
+			artifact = Path(directory) / "package.mir"
+			artifact.write_text("mir")
+			entry = {
+				"status": "ok",
+				"input_fingerprint": "inputs",
+				"artifact_sha256": provenance.file_sha256(artifact),
+			}
+			self.assertTrue(provenance.reusable_artifact(entry, "inputs", artifact))
+			artifact.write_text("stale")
+			self.assertFalse(provenance.reusable_artifact(entry, "inputs", artifact))
+			self.assertFalse(provenance.reusable_artifact(entry, "changed-inputs", artifact))
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/scripts/runtime-interaction-graph/test_contract_graph_import.py
+++ b/scripts/runtime-interaction-graph/test_contract_graph_import.py
@@ -1,0 +1,199 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE = Path(__file__).with_name("runtime_interaction_graph.py")
+CI_FIXTURE = Path(__file__).with_name("fixtures") / "ci-contracts.json"
+SPEC = importlib.util.spec_from_file_location("runtime_interaction_graph_contracts", MODULE)
+graph = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(graph)
+
+
+CHAIN_A = 42
+CHAIN_B = 43
+PROXY = "0x1111111111111111111111111111111111111111"
+IMPLEMENTATION = "0x2222222222222222222222222222222222222222"
+UNOBSERVED = "0x3333333333333333333333333333333333333333"
+
+
+def chain_address(chain_id, address):
+	return f"eip155:{chain_id}:{address}"
+
+
+def observation(project, network, chain_id, address, **data):
+	return {"project": project, "network": network, "chain_id": chain_id, "address": address,
+		"chain_address_id": chain_address(chain_id, address), "has_code": True, **data}
+
+
+class ContractGraphImportTests(unittest.TestCase):
+	def import_payload(self, payload):
+		with tempfile.TemporaryDirectory() as directory:
+			path = Path(directory) / "contracts.json"
+			path.write_text(json.dumps(payload))
+			result = graph.Graph()
+			count = graph.merge_contracts(result, path)
+			return result, count
+
+	def test_schema_v2_uses_chain_physical_identity_and_separate_aliases(self):
+		contracts = [
+			{"project": "aave", "network": "hydration", "name": "Pool-Proxy", "address": PROXY,
+				"artifact": "aave/pool.json", "abi_functions": [
+					{"signature": "supply(address,uint256)", "selector": "0xf2b9fdb8"}],
+				"abi_signatures": ["supply(address,uint256)"]},
+			{"project": "hollar", "network": "hydration", "name": "HollarPool", "address": PROXY,
+				"artifact": "hollar/pool.json", "abi_functions": [
+					{"signature": "supply(address,uint256)", "selector": "0xf2b9fdb8"}]},
+			{"project": "aave", "network": "hydration", "name": "Pool-Implementation",
+				"address": IMPLEMENTATION, "artifact": "aave/implementation.json", "abi_functions": []},
+			{"project": "other", "network": "other-chain", "name": "SameRawAddress",
+				"address": IMPLEMENTATION, "artifact": "other/contract.json", "abi_functions": []},
+			{"project": "whm", "network": "external", "name": "Router", "address": UNOBSERVED,
+				"artifact": "whm/router.json", "abi_functions": []},
+		]
+		observations = [
+			observation("aave", "hydration", CHAIN_A, PROXY, implementation=IMPLEMENTATION,
+				implementation_chain_address_id=chain_address(CHAIN_A, IMPLEMENTATION),
+				embedded_addresses=[IMPLEMENTATION]),
+			observation("hollar", "hydration", CHAIN_A, PROXY, implementation=IMPLEMENTATION,
+				implementation_chain_address_id=chain_address(CHAIN_A, IMPLEMENTATION),
+				embedded_addresses=[IMPLEMENTATION]),
+			observation("aave", "hydration", CHAIN_A, IMPLEMENTATION, implementation=None,
+				implementation_chain_address_id=None, embedded_addresses=[]),
+			observation("other", "other-chain", CHAIN_B, IMPLEMENTATION, implementation=None,
+				implementation_chain_address_id=None, embedded_addresses=[]),
+		]
+		payload = {"schema_version": 2, "contracts": contracts, "observations": observations,
+			"address_references": [{"project": "whm", "network": "external",
+				"migration_step": "configure-token", "field": "sourceAsset", "role": "asset",
+				"address": "0x4444444444444444444444444444444444444444",
+				"artifact": "whm/external.json", "artifact_sha256": "reference-hash"}],
+			"rpc_snapshot": {"chain_id": CHAIN_A, "block_hash": "0xevm", "block_number": 10},
+			"substrate_snapshot": {"genesis_hash": "0xgenesis", "block_hash": "0xsubstrate",
+				"block_number": 10},
+			"chain_context": {"evm_chain_id": CHAIN_A, "evm_block_hash": "0xevm",
+				"substrate_genesis_hash": "0xgenesis", "substrate_block_hash": "0xsubstrate",
+				"block_number": 10},
+			"collection_provenance": {"descriptor_sha256": "descriptor"},
+			"enrichment_provenance": {"input_sha256": "collection"},
+			"runtime_collection_provenance": {"input_sha256": "enrichment"},
+			"runtime_configurations": [{"component": "pallet:hsm", "storage": "hsm.flashMinter",
+				"chain_id": CHAIN_B, "address": IMPLEMENTATION,
+				"chain_address_id": chain_address(CHAIN_B, IMPLEMENTATION)}]}
+		result, count = self.import_payload(payload)
+
+		proxy = f"deployed-contract:{chain_address(CHAIN_A, PROXY)}"
+		implementation_a = f"deployed-contract:{chain_address(CHAIN_A, IMPLEMENTATION)}"
+		implementation_b = f"deployed-contract:{chain_address(CHAIN_B, IMPLEMENTATION)}"
+		self.assertEqual(count, 3)
+		self.assertIn(proxy, result.nodes)
+		self.assertIn(implementation_a, result.nodes)
+		self.assertIn(implementation_b, result.nodes)
+		self.assertIn(f"deployment-alias:aave:hydration:{PROXY}", result.nodes)
+		self.assertIn(f"deployment-alias:hollar:hydration:{PROXY}", result.nodes)
+		self.assertIn(f"deployment-alias:whm:external:{UNOBSERVED}", result.nodes)
+		self.assertNotIn(f"deployed-contract:{chain_address(CHAIN_A, UNOBSERVED)}", result.nodes)
+		reference = "deployment-address-reference:whm:external:0x4444444444444444444444444444444444444444"
+		self.assertEqual(result.nodes[reference]["kind"], "deployment-address-reference")
+		self.assertFalse(result.nodes[reference]["onchain_observed"])
+		self.assertTrue(any(edge["source"] == "deployment-step:whm:external:configure-token"
+			and edge["target"] == reference and edge["kind"] == "deployment-step-references-address"
+			and edge["role"] == "asset" for edge in result.edges))
+		self.assertFalse(any(node["kind"] == "deployed-contract" and
+			node.get("address") == "0x4444444444444444444444444444444444444444"
+			for node in result.nodes.values()))
+
+		proxy_edges = [edge for edge in result.edges
+			if edge["source"] == proxy and edge["kind"] == "proxy-implementation"]
+		self.assertEqual({edge["target"] for edge in proxy_edges}, {implementation_a})
+		embedded_edges = [edge for edge in result.edges
+			if edge["source"] == proxy and edge["kind"] == "bytecode-embeds-address"]
+		self.assertEqual({edge["target"] for edge in embedded_edges}, {implementation_a})
+		self.assertTrue(any(edge["source"] == "pallet:hsm" and edge["target"] == implementation_b
+			and edge["kind"] == "runtime-configures-contract" for edge in result.edges))
+
+		function = f"contract-function:{chain_address(CHAIN_A, PROXY)}:supply(address,uint256)"
+		self.assertEqual(result.nodes[function]["selector"], "0xf2b9fdb8")
+		self.assertEqual(result.nodes["evm-selector:0xf2b9fdb8"]["selector"], "0xf2b9fdb8")
+		self.assertTrue(any(edge["source"] == "evm-selector:0xf2b9fdb8"
+			and edge["target"] == function and edge["kind"] == "selector-matches-contract-function"
+			for edge in result.edges))
+
+		coverage = result.nodes["semantic-analysis:contract-deployments"]
+		self.assertEqual(coverage["chain_context"], payload["chain_context"])
+		self.assertEqual(coverage["rpc_snapshot"], payload["rpc_snapshot"])
+		self.assertEqual(coverage["substrate_snapshot"], payload["substrate_snapshot"])
+		self.assertEqual(coverage["collection_provenance"], payload["collection_provenance"])
+		self.assertEqual(coverage["enrichment_provenance"], payload["enrichment_provenance"])
+		self.assertEqual(coverage["runtime_collection_provenance"],
+			payload["runtime_collection_provenance"])
+		self.assertEqual(coverage["address_references"], 1)
+
+	def test_ci_fixture_should_cover_deployments_and_required_runtime_bindings(self):
+		payload = json.loads(CI_FIXTURE.read_text())
+		result, count = self.import_payload(payload)
+		self.assertEqual(count, 6)
+		coverage = result.nodes["semantic-analysis:contract-deployments"]
+		self.assertEqual(coverage["runtime_configurations"], 4)
+		self.assertEqual(coverage["asset_registry_erc20_configurations"], 1)
+		bindings = {(edge["source"], edge.get("storage")) for edge in result.edges
+			if edge["kind"] == "runtime-configures-contract"}
+		self.assertTrue({
+			("pallet:gigahdx", "gigaHdx.gigaHdxPoolContract"),
+			("pallet:hsm", "hsm.flashMinter"),
+			("pallet:liquidation", "liquidation.borrowingContract"),
+			("pallet:asset-registry", "assetRegistry.assetLocations"),
+		}.issubset(bindings))
+		self.assertTrue(any(edge["kind"] == "proxy-implementation" for edge in result.edges))
+		self.assertTrue(any(edge["kind"] == "selector-matches-contract-function" for edge in result.edges))
+
+	def test_selector_collisions_should_converge_on_physical_selector_identity(self):
+		result = graph.Graph()
+		_, first = graph.ensure_evm_selector(result, "burn(uint256)")
+		_, second = graph.ensure_evm_selector(result, "collate_propagate_storage(bytes16)")
+		self.assertEqual(first, "evm-selector:0x42966c68")
+		self.assertEqual(first, second)
+		self.assertEqual(result.nodes[first]["signatures"],
+			["burn(uint256)", "collate_propagate_storage(bytes16)"])
+		self.assertTrue(result.nodes[first]["selector_collision"])
+
+	def test_schema_v2_rejects_cross_chain_proxy_resolution(self):
+		payload = {"schema_version": 2, "contracts": [{"project": "p", "network": "n", "name": "Proxy",
+			"address": PROXY, "artifact": "proxy.json", "abi_functions": []}], "observations": [
+			observation("p", "n", CHAIN_A, PROXY, implementation=IMPLEMENTATION,
+				implementation_chain_address_id=chain_address(CHAIN_B, IMPLEMENTATION), embedded_addresses=[])]}
+		with self.assertRaisesRegex(ValueError, "same chain"):
+			self.import_payload(payload)
+
+	def test_schema_v2_chain_descriptor_canonicalizes_unobserved_deployments(self):
+		payload = {"schema_version": 2, "chains": [{"id": "mainnet", "evm_chain_id": CHAIN_A,
+			"deployment_networks": ["hydration"]}], "contracts": [{"project": "p", "network": "hydration",
+				"name": "Pool", "address": PROXY, "artifact": "pool.json", "abi_functions": [
+				{"signature": "supply(address,uint256)", "selector": "0xf2b9fdb8"}]}]}
+		result, count = self.import_payload(payload)
+		physical = f"deployed-contract:{chain_address(CHAIN_A, PROXY)}"
+		self.assertEqual(count, 1)
+		self.assertFalse(result.nodes[physical]["onchain_observed"])
+		self.assertEqual(result.nodes[physical]["chain_address_id"], chain_address(CHAIN_A, PROXY))
+		self.assertIn(f"contract-function:{chain_address(CHAIN_A, PROXY)}:supply(address,uint256)", result.nodes)
+
+	def test_schema_v2_rejects_conflicting_canonical_selectors(self):
+		payload = {"schema_version": 2, "contracts": [
+			{"project": "a", "network": "n", "name": "A", "address": PROXY, "artifact": "a.json",
+				"abi_functions": [{"signature": "f(uint256)", "selector": "0x11111111"}]},
+			{"project": "b", "network": "n", "name": "B", "address": IMPLEMENTATION,
+				"artifact": "b.json",
+				"abi_functions": [{"signature": "f(uint256)", "selector": "0x22222222"}]},
+		]}
+		with self.assertRaisesRegex(ValueError, "conflicting selectors"):
+			self.import_payload(payload)
+
+	def test_unknown_manifest_schema_is_not_imported_as_legacy(self):
+		with self.assertRaisesRegex(ValueError, "unsupported contract manifest schema_version"):
+			self.import_payload({"schema_version": 3, "contracts": []})
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/scripts/runtime-interaction-graph/test_evm_deployments.py
+++ b/scripts/runtime-interaction-graph/test_evm_deployments.py
@@ -1,0 +1,314 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+DIRECTORY = Path(__file__).parent
+CI_FIXTURE = DIRECTORY / "fixtures/ci-contracts.json"
+
+
+def load(name: str):
+	path = DIRECTORY / name
+	spec = importlib.util.spec_from_file_location(path.stem, path)
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+contracts = load("collect_contracts.py")
+enrichment = load("enrich_contracts_rpc.py")
+build = load("build_evm_graph.py")
+
+
+GENESIS = "0x" + "11" * 32
+
+
+def chain(network="hydration"):
+	return {"id": "test", "evm_chain_id": 42, "substrate_genesis_hash": GENESIS,
+		"substrate_spec_name": "hydradx", "runtime_configuration_minimums": {
+			"total": 1, "asset_registry_erc20": 1, "required_bindings": {
+				"gigaHdx.gigaHdxPoolContract": 1, "hsm.flashMinter": 1,
+				"liquidation.borrowingContract": 1}}, "deployment_networks": [network]}
+
+
+class ContractCollectionTests(unittest.TestCase):
+	def test_nested_tuple_signatures_and_selectors_should_be_canonical(self):
+		abi = json.loads((DIRECTORY / "fixtures/nested-tuple-abi.json").read_text())
+		self.assertEqual(contracts.abi_functions(abi), [
+			{"signature": "bar((address,(uint256,bytes32)[])[])", "selector": "0x306724ff"},
+			{"signature": "transfer(address,uint256)", "selector": "0xa9059cbb"},
+		])
+		self.assertEqual(contracts.canonical_abi_type({"type": "uint[]"}), "uint256[]")
+		self.assertEqual(contracts.canonical_abi_type({"type": "int[2][]"}), "int256[2][]")
+
+	def test_collection_should_record_descriptor_source_and_artifact_hashes(self):
+		with tempfile.TemporaryDirectory() as directory:
+			root = Path(directory)
+			hardhat = root / "hardhat/hydration"
+			whm = root / "whm"
+			hardhat.mkdir(parents=True)
+			whm.mkdir()
+			abi = json.loads((DIRECTORY / "fixtures/nested-tuple-abi.json").read_text())
+			(hardhat / "Pool.json").write_text(json.dumps({
+				"address": "0x1111111111111111111111111111111111111111", "abi": abi,
+			}))
+			(whm / "production.json").write_text(json.dumps({"steps": [{
+				"name": "deploy", "status": "completed",
+				"output": {
+					"proxyAddress": "0x2222222222222222222222222222222222222222",
+					"ownerAddress": "0x3333333333333333333333333333333333333333",
+					"asset": "0x4444444444444444444444444444444444444444",
+				},
+			}]}))
+			descriptor = root / "sources.json"
+			descriptor.write_text(json.dumps({"schema_version": 2,
+				"chains": [chain()],
+				"sources": [
+					{"project": "hardhat", "kind": "hardhat", "root": "hardhat", "networks": ["hydration"]},
+					{"project": "whm", "kind": "whm", "root": "whm", "networks": ["production"]},
+				]}))
+			payload = contracts.collect(descriptor)
+			self.assertEqual(payload["schema_version"], 2)
+			self.assertEqual(len(payload["contracts"]), 2)
+			self.assertEqual(payload["collection_provenance"]["descriptor_sha256"],
+				contracts.sha256_file(descriptor))
+			self.assertTrue(all(item["artifact_sha256"] for item in payload["contracts"]))
+			pool = next(item for item in payload["contracts"] if item["project"] == "hardhat")
+			self.assertEqual(pool["abi_functions"][0]["signature"], "bar((address,(uint256,bytes32)[])[])")
+			whm_contract = next(item for item in payload["contracts"] if item["project"] == "whm")
+			self.assertEqual(whm_contract["deployment_role"], "proxy")
+			self.assertEqual({item["role"] for item in payload["address_references"]},
+				{"authorization-account", "asset"})
+			self.assertNotIn("0x3333333333333333333333333333333333333333",
+				{item["address"] for item in payload["contracts"]})
+
+	def test_collection_should_fail_when_required_source_is_missing(self):
+		with tempfile.TemporaryDirectory() as directory:
+			descriptor = Path(directory) / "sources.json"
+			descriptor.write_text(json.dumps({"schema_version": 2,
+				"chains": [chain()],
+				"sources": [{"project": "missing", "kind": "hardhat", "root": "missing",
+					"networks": ["hydration"]}]}))
+			with self.assertRaises(FileNotFoundError):
+				contracts.collect(descriptor)
+
+	def test_descriptor_should_require_substrate_identity_in_schema_v2(self):
+		with tempfile.TemporaryDirectory() as directory:
+			descriptor = Path(directory) / "sources.json"
+			descriptor.write_text(json.dumps({"schema_version": 1, "chains": [chain()], "sources": []}))
+			with self.assertRaisesRegex(ValueError, "schema_version 2"):
+				contracts.load_descriptor(descriptor)
+			descriptor.write_text(json.dumps({"schema_version": 2,
+				"chains": [{"id": "test", "evm_chain_id": 42, "deployment_networks": ["hydration"]}],
+				"sources": []}))
+			with self.assertRaisesRegex(ValueError, "chain descriptor"):
+				contracts.load_descriptor(descriptor)
+
+	def test_whm_references_should_have_typed_roles_without_becoming_contracts(self):
+		with tempfile.TemporaryDirectory() as directory:
+			root = Path(directory)
+			(root / "production.json").write_text(json.dumps({"steps": [
+				{"name": "001-deploy-router", "status": "completed", "output": {
+					"implAddress": "0x1111111111111111111111111111111111111111",
+					"proxyAddress": "0x2222222222222222222222222222222222222222",
+					"ownerAddress": "0x3333333333333333333333333333333333333333"}},
+				{"name": "002-configure", "status": "completed", "output": {
+					"sourceAsset": "0x4444444444444444444444444444444444444444",
+					"oracle": "0x5555555555555555555555555555555555555555",
+					"handler": "0x6666666666666666666666666666666666666666",
+					"proxyAddress": "0x7777777777777777777777777777777777777777"}},
+			]}))
+			items, references, _ = contracts.whm_deployments("whm", root, {"production"})
+			self.assertEqual({item["deployment_role"] for item in items}, {"implementation", "proxy"})
+			self.assertEqual({item["role"] for item in references},
+				{"authorization-account", "asset", "oracle", "handler", "contract-reference"})
+			self.assertTrue({item["address"] for item in items}.isdisjoint(
+				{item["address"] for item in references}))
+
+
+class RpcEnrichmentTests(unittest.TestCase):
+	def payload(self):
+		return {"schema_version": 2, "collection_provenance": {
+			"descriptor_sha256": "a" * 64, "sources": [{"project": "p", "input_sha256": "b" * 64}]},
+			"address_references": [{"project": "p", "network": "hydration", "migration_step": "configure",
+				"field": "asset", "role": "asset", "address": "0x3333333333333333333333333333333333333333",
+				"artifact_sha256": "e" * 64}],
+			"contracts": [
+				{"project": "p", "network": "hydration", "name": "Pool",
+					"address": "0x1111111111111111111111111111111111111111", "artifact_sha256": "c" * 64},
+				{"project": "p", "network": "hydration", "name": "Token",
+					"address": "0x2222222222222222222222222222222222222222", "artifact_sha256": "d" * 64},
+			]}
+
+	def rpc_call(self, _url, method, _params):
+		return {"eth_chainId": "0x2a", "eth_getBlockByNumber": {
+			"number": "0x10", "hash": "0xabc", "parentHash": "0xdef", "stateRoot": "0x123",
+		}}[method]
+
+	def test_enrichment_should_record_chain_address_and_input_provenance(self):
+		implementation = "3333333333333333333333333333333333333333"
+		results = ["0x6000" + "22" * 20, "0x" + "00" * 32,
+			"0x6001", "0x" + "00" * 12 + implementation]
+		result = enrichment.enrich(self.payload(), "rpc", "0x10", {"hydration"}, 42, "input-hash",
+			rpc_call=self.rpc_call, rpc_batch_call=lambda _url, _calls: results)
+		self.assertEqual(result["rpc_snapshot"]["chain_id"], 42)
+		self.assertEqual(result["enrichment_provenance"]["input_sha256"], "input-hash")
+		self.assertEqual(result["observations"][0]["chain_address_id"],
+			"eip155:42:0x1111111111111111111111111111111111111111")
+		self.assertEqual(result["observations"][0]["embedded_addresses"],
+			["0x2222222222222222222222222222222222222222"])
+		self.assertEqual(result["observations"][1]["implementation_chain_address_id"],
+			f"eip155:42:0x{implementation}")
+		self.assertEqual(result["address_references"], self.payload()["address_references"])
+		self.assertNotIn(self.payload()["address_references"][0]["address"],
+			{item["address"] for item in result["observations"]})
+
+	def test_enrichment_should_reject_wrong_rpc_chain(self):
+		with self.assertRaisesRegex(ValueError, "does not match expected"):
+			enrichment.enrich(self.payload(), "rpc", "0x10", {"hydration"}, 43, "input-hash",
+				rpc_call=self.rpc_call, rpc_batch_call=lambda _url, _calls: [])
+
+	def test_enrichment_should_reject_untyped_address_reference(self):
+		payload = self.payload()
+		payload["address_references"][0].pop("role")
+		with self.assertRaisesRegex(ValueError, "address reference inventory"):
+			enrichment.validate_collection(payload)
+
+
+class EvmBuildTests(unittest.TestCase):
+	def test_ci_fixture_should_satisfy_runtime_configuration_minimums(self):
+		payload = json.loads(CI_FIXTURE.read_text())
+		chain_config = build.load_chain(CI_FIXTURE, "hydration-mainnet-ci")
+		self.assertEqual(build.validate_runtime_configuration_coverage(
+			payload, chain_config["runtime_configuration_minimums"]), {
+			"total": 4,
+			"asset_registry_erc20": 1,
+			"required_bindings": {
+				"gigaHdx.gigaHdxPoolContract": 1,
+				"hsm.flashMinter": 1,
+				"liquidation.borrowingContract": 1,
+			},
+			"required_queries": 5,
+		})
+
+	def test_output_hashes_should_cover_nested_outputs_and_exclude_self(self):
+		with tempfile.TemporaryDirectory() as directory:
+			output = Path(directory)
+			(output / "focused").mkdir()
+			(output / "graph.json").write_text("graph")
+			(output / "focused/view.svg").write_text("svg")
+			(output / "evm-build-provenance.json").write_text("old")
+			self.assertEqual(set(build.output_hashes(output)), {"graph.json", "focused/view.svg"})
+
+	def test_load_chain_should_require_expected_substrate_identity(self):
+		with tempfile.TemporaryDirectory() as directory:
+			descriptor = Path(directory) / "sources.json"
+			descriptor.write_text(json.dumps({"schema_version": 2, "chains": [chain()]}))
+			self.assertEqual(build.load_chain(descriptor, "test")["substrate_genesis_hash"], GENESIS)
+			descriptor.write_text(json.dumps({"schema_version": 2, "chains": [
+				{"id": "test", "evm_chain_id": 42, "deployment_networks": ["hydration"]}]}))
+			with self.assertRaisesRegex(ValueError, "invalid chain descriptor"):
+				build.load_chain(descriptor, "test")
+
+	def test_runtime_configuration_coverage_should_enforce_descriptor_minimums(self):
+		payload = {"runtime_collection_provenance": {"query_coverage": {
+			"required_query_count": 5, "available_query_count": 5}}, "runtime_configurations": [
+			{"component": "pallet:gigahdx", "storage": "gigaHdx.gigaHdxPoolContract"},
+			{"component": "pallet:hsm", "storage": "hsm.flashMinter"},
+			{"component": "pallet:liquidation", "storage": "liquidation.borrowingContract"},
+			{"component": "pallet:asset-registry", "storage": "assetRegistry.assetLocations",
+				"asset_type": "erc20"},
+		]}
+		minimums = {"total": 4, "asset_registry_erc20": 1, "required_bindings": {
+			"gigaHdx.gigaHdxPoolContract": 1, "hsm.flashMinter": 1,
+			"liquidation.borrowingContract": 1}}
+		self.assertEqual(build.validate_runtime_configuration_coverage(
+			payload, minimums),
+			{"total": 4, "asset_registry_erc20": 1, "required_bindings": {
+				"gigaHdx.gigaHdxPoolContract": 1, "hsm.flashMinter": 1,
+				"liquidation.borrowingContract": 1}, "required_queries": 5})
+		with self.assertRaisesRegex(ValueError, "asset_registry_erc20=1 is below minimum 2"):
+			build.validate_runtime_configuration_coverage(payload,
+				{**minimums, "asset_registry_erc20": 2})
+		payload["runtime_configurations"] = payload["runtime_configurations"][1:]
+		with self.assertRaisesRegex(ValueError, "gigaHdx.gigaHdxPoolContract=0 is below minimum 1"):
+			build.validate_runtime_configuration_coverage(payload,
+				{**minimums, "total": 3})
+		payload["runtime_collection_provenance"]["query_coverage"]["available_query_count"] = 4
+		with self.assertRaisesRegex(ValueError, "incomplete required-query coverage"):
+			build.validate_runtime_configuration_coverage(payload, minimums)
+
+	def test_graph_command_should_only_include_explicit_semantic_manifests(self):
+		command = build.graph_command(Path("scripts"), Path("runtime.json"), Path("output"), None, None)
+		self.assertNotIn("--rapx-manifest", command)
+		self.assertNotIn("--rustc-mir-manifest", command)
+		self.assertEqual(command[command.index("--coverage-thresholds") + 1],
+			Path("scripts/coverage-thresholds.json"))
+		command = build.graph_command(Path("scripts"), Path("runtime.json"), Path("output"),
+			Path("rapx.json"), Path("mir.json"))
+		self.assertIn("--rapx-manifest", command)
+		self.assertIn("--rustc-mir-manifest", command)
+		self.assertEqual(command[command.index("--coverage-thresholds") + 1],
+			Path("scripts/coverage-thresholds-full.json"))
+
+	def test_semantic_manifest_should_reuse_strict_validator_and_return_logical_paths(self):
+		with tempfile.TemporaryDirectory() as directory:
+			root = Path(directory)
+			manifest = root / "semantic/manifest.json"
+			manifest.parent.mkdir()
+			source_inputs = {"sha256": "a" * 64, "file_count": 1}
+			payload = {"schema_version": 2, "tool": "rapx", "toolchain": "nightly",
+				"provenance": {"source_inputs": source_inputs, "collector_sha256": "b" * 64},
+				"packages": [{"package": "pallet-example", "analyses": {
+					"callgraph": {"status": "ok", "path": "artifacts/callgraph.txt",
+						"artifact_sha256": "c" * 64}}}]}
+			manifest.write_text(json.dumps(payload))
+			with mock.patch.object(build.runtime_graph, "validate_semantic_manifest") as validator:
+				result = build.validate_semantic_manifest(manifest, "rapx", source_inputs, root)
+			validator.assert_called_once_with(payload, manifest, "rapx", root)
+			self.assertEqual(result["path"], "semantic/manifest.json")
+			self.assertFalse(Path(result["path"]).is_absolute())
+			self.assertEqual(result["artifacts"], [
+				{"path": "artifacts/callgraph.txt", "sha256": "c" * 64},
+			])
+			self.assertFalse(Path(result["artifacts"][0]["path"]).is_absolute())
+			with self.assertRaisesRegex(ValueError, "stale or different"):
+				with mock.patch.object(build.runtime_graph, "validate_semantic_manifest"):
+					build.validate_semantic_manifest(
+						manifest, "rapx", {"sha256": "d" * 64, "file_count": 1}, root)
+
+	def test_graph_generator_fingerprint_should_cover_transitive_inputs_and_active_policy(self):
+		with tempfile.TemporaryDirectory() as directory:
+			scripts = Path(directory)
+			for name in (*build.GRAPH_GENERATOR_INPUTS, "coverage-thresholds.json",
+				"coverage-thresholds-full.json"):
+				(scripts / name).write_text(name)
+			standard = build.graph_generator_fingerprint(scripts, None)
+			self.assertEqual(standard, build.graph_generator_fingerprint(scripts, None))
+			self.assertEqual(set(standard["files"]),
+				{*build.GRAPH_GENERATOR_INPUTS, "coverage-thresholds.json"})
+			self.assertNotIn("coverage-thresholds-full.json", standard["files"])
+			full = build.graph_generator_fingerprint(scripts, Path("mir.json"))
+			self.assertEqual(set(full["files"]),
+				{*build.GRAPH_GENERATOR_INPUTS, "coverage-thresholds-full.json"})
+			self.assertNotEqual(standard["sha256"], full["sha256"])
+			(scripts / "mir_parser.py").write_text("changed")
+			self.assertNotEqual(full["sha256"],
+				build.graph_generator_fingerprint(scripts, Path("mir.json"))["sha256"])
+
+	def test_prepare_output_should_reject_non_empty_directory_before_build(self):
+		with tempfile.TemporaryDirectory() as directory:
+			output = Path(directory) / "new"
+			build.prepare_output(output)
+			self.assertTrue(output.is_dir())
+			build.prepare_output(output)
+			(output / "stale.json").write_text("stale")
+			with self.assertRaisesRegex(ValueError, "must be empty"):
+				build.prepare_output(output)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/scripts/runtime-interaction-graph/test_evm_deployments.py
+++ b/scripts/runtime-interaction-graph/test_evm_deployments.py
@@ -288,6 +288,8 @@ class EvmBuildTests(unittest.TestCase):
 				(scripts / name).write_text(name)
 			standard = build.graph_generator_fingerprint(scripts, None)
 			self.assertEqual(standard, build.graph_generator_fingerprint(scripts, None))
+			self.assertTrue({"graph_explorer.js", "graph_explorer.css"}.issubset(
+				build.GRAPH_GENERATOR_INPUTS))
 			self.assertEqual(set(standard["files"]),
 				{*build.GRAPH_GENERATOR_INPUTS, "coverage-thresholds.json"})
 			self.assertNotIn("coverage-thresholds-full.json", standard["files"])

--- a/scripts/runtime-interaction-graph/test_graph_correctness.py
+++ b/scripts/runtime-interaction-graph/test_graph_correctness.py
@@ -1,0 +1,86 @@
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+
+MODULE = Path(__file__).with_name("runtime_interaction_graph.py")
+SPEC = importlib.util.spec_from_file_location("runtime_interaction_graph_correctness", MODULE)
+graph = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(graph)
+ROOT = MODULE.parents[2]
+
+
+class GraphCorrectnessTests(unittest.TestCase):
+	def test_runtime_mod_owners_should_include_their_relative_path(self):
+		root = Path("/repo")
+		paths = [
+			root / "runtime/hydradx/src/xcm/mod.rs",
+			root / "runtime/hydradx/src/governance/mod.rs",
+			root / "runtime/hydradx/src/evm/accounts/mod.rs",
+			root / "runtime/hydradx/src/evm/adapters/mod.rs",
+			root / "runtime/hydradx/src/evm/precompiles/assets/mod.rs",
+			root / "runtime/hydradx/src/evm/precompiles/dispatch/mod.rs",
+		]
+		owners = [graph.owner(path, root)[0] for path in paths]
+		self.assertEqual(len(set(owners)), len(owners), dict(zip(map(str, paths), owners)))
+
+	def test_function_source_ids_should_ignore_blank_lines_and_include_scope(self):
+		source = """mod first {
+	impl Handler for Alpha {
+		fn execute() { alpha(); }
+	}
+	impl Handler for Beta {
+		fn execute() { beta(); }
+	}
+}
+mod second {
+	impl Handler for Alpha {
+		fn execute() { second(); }
+	}
+}
+"""
+		with_blank_lines = "\n\n" + source.replace("fn execute() {", "fn execute()\n\n\t\t{")
+
+		def identifiers(text: str) -> list[str]:
+			scopes = graph.scope_ranges(text)
+			return [graph.function_source_id(text, match, "runtime/example.rs", scopes)
+				for match in graph.FN.finditer(text)]
+
+		original = identifiers(source)
+		shifted = identifiers(with_blank_lines)
+		self.assertEqual(original, shifted)
+		self.assertEqual(len(original), 3)
+		self.assertEqual(len(set(original)), len(original))
+
+	def test_execution_projection_should_exclude_configuration_and_deployment_edges(self):
+		g = graph.Graph()
+		g.edge("pallet:a", "pallet:b", "direct-call")
+		g.edge("pallet:b", "pallet:a", "config-binding")
+		g.edge("pallet:c", "deployed-contract:x", "uses-deployed-contract")
+		g.edge("deployed-contract:x", "boundary:evm-execution", "direct-call")
+
+		self.assertIn(["pallet:a", "pallet:b"], graph.strongly_connected(g.edges))
+		self.assertIn(
+			["pallet:c", "deployed-contract:x", "boundary:evm-execution"],
+			graph.bounded_paths(g.edges, {"boundary:evm-execution"}),
+		)
+
+		execution = graph.projected_edges(g, "execution")
+		self.assertEqual({edge["kind"] for edge in execution}, {"direct-call"})
+		self.assertEqual(graph.strongly_connected(execution), [])
+		self.assertNotIn(
+			["pallet:c", "deployed-contract:x", "boundary:evm-execution"],
+			graph.bounded_paths(execution, {"boundary:evm-execution"}),
+		)
+
+	def test_real_scan_should_have_integral_unique_edges(self):
+		g = graph.scan(ROOT)
+		dangling = [edge for edge in g.edges if edge["source"] not in g.nodes or edge["target"] not in g.nodes]
+		keys = [json.dumps(edge, sort_keys=True, separators=(",", ":"), default=str) for edge in g.edges]
+		self.assertEqual(dangling, [])
+		self.assertEqual(len(keys), len(set(keys)))
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/scripts/runtime-interaction-graph/test_mir_parser.py
+++ b/scripts/runtime-interaction-graph/test_mir_parser.py
@@ -1,0 +1,45 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE = Path(__file__).with_name("mir_parser.py")
+SPEC = importlib.util.spec_from_file_location("mir_parser", MODULE)
+mir = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(mir)
+
+
+class MirParserTests(unittest.TestCase):
+	def test_parser_should_separate_instances_and_normal_from_unwind_flow(self):
+		text = """fn pallet::<impl at pallets/example/src/lib.rs:10:1: 20:2>::run(_1: T) -> () {
+    bb0: {
+        _2 = pallet_other::Pallet::<T>::execute(copy _1) -> [return: bb1, unwind: bb2];
+    }
+    bb1: {
+        _3 = StorageMap::<Prefix, Blake2, K, V>::insert(copy _1, copy _2) -> [return: bb3, unwind: bb2];
+    }
+    bb2: {
+        _4 = StorageValue::<Recovery>::put(copy _1) -> [return: bb3, unwind continue];
+    }
+    bb3: { return; }
+}
+"""
+		instances = mir.parse(text)
+		self.assertEqual(len(instances), 1)
+		instance = instances[0]
+		self.assertEqual(instance["name"], "run")
+		self.assertEqual(instance["source_file"], "pallets/example/src/lib.rs")
+		self.assertEqual(instance["blocks"][0]["normal_successors"], [1])
+		self.assertEqual(instance["blocks"][0]["unwind_successors"], [2])
+		self.assertEqual(instance["blocks"][0]["operations"][0]["kind"], "call")
+		self.assertEqual(mir.order_flags(instance["blocks"]), (False, False))
+		self.assertEqual(mir.order_flags(instance["blocks"], "unwind_successors"), (False, False))
+
+	def test_instance_ids_should_distinguish_monomorphized_symbols(self):
+		first = "pallet::<impl at pallets/example/src/lib.rs:1:1: 2:2>::run::<u32>"
+		second = "pallet::<impl at pallets/example/src/lib.rs:1:1: 2:2>::run::<u64>"
+		self.assertNotEqual(mir.instance_id(first), mir.instance_id(second))
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/scripts/runtime-interaction-graph/test_query_graph.py
+++ b/scripts/runtime-interaction-graph/test_query_graph.py
@@ -1,0 +1,298 @@
+import hashlib
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+MODULE_PATH = Path(__file__).with_name("query_graph.py")
+SPEC = importlib.util.spec_from_file_location("runtime_graph_query", MODULE_PATH)
+query_graph = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(query_graph)
+
+
+def fixture_graph() -> dict:
+	return {
+		"schema_version": 2,
+		"nodes": [
+			{"id": "a", "kind": "pallet", "domain": "frame", "runtime_active": True},
+			{"id": "b", "kind": "function", "owner": "a", "name": "bridge"},
+			{"id": "c", "kind": "pallet", "runtime_active": False},
+			{"id": "d", "kind": "function", "owner": "c", "name": "inherited-inactive"},
+			{"id": "e", "kind": "execution-boundary", "domain": "evm", "runtime_active": True},
+		],
+		"edges": [
+			{"source": "a", "target": "b", "kind": "call", "file": "one.rs", "line": 1},
+			{"source": "a", "target": "b", "kind": "call", "file": "two.rs", "line": 2},
+			{"source": "b", "target": "e", "kind": "enters-evm"},
+			{"source": "c", "target": "a", "kind": "inactive-call"},
+			{"source": "a", "target": "d", "kind": "inactive-call"},
+			{"source": "e", "target": "a", "kind": "cycle"},
+		],
+	}
+
+
+def fixture_companions() -> dict:
+	return {
+		"coverage": {"unresolved_targets": 1, "inventory_only_targets": 2,
+			"mir_packages_failed": 1},
+		"completeness": {"source_components_without_entrypoints": ["pallet:x"],
+			"historical_properties": {"expected-path": False},
+			"path_search": {"limit_truncated_starts": ["a"], "depth_truncated_starts": []}},
+		"query_packs": {"schema_version": 1, "cycles": [["a", "b"]], "origins": {"root": ["a"]}},
+	}
+
+
+class QueryGraphTests(unittest.TestCase):
+	def setUp(self):
+		self.index = query_graph.GraphIndex(fixture_graph())
+		self.companions = fixture_companions()
+		self.fingerprint = "a" * 64
+
+	def execute(self, request: dict, max_records: int = 50, max_tokens: int = 4_000) -> dict:
+		return json.loads(query_graph.execute(
+			self.index, self.companions, request, max_records, max_tokens, self.fingerprint))
+
+	def test_summary_should_use_stable_envelope_and_expose_companion_warnings(self):
+		request = {"operation": "summary"}
+		first = query_graph.execute(self.index, self.companions, request, 50, 4_000, self.fingerprint)
+		second = query_graph.execute(self.index, self.companions, request, 50, 4_000, self.fingerprint)
+		self.assertEqual(first, second)
+		payload = json.loads(first)
+		self.assertEqual(payload["schema_version"], 1)
+		self.assertEqual(payload["tool"], query_graph.TOOL)
+		self.assertEqual(payload["graph"]["fingerprint"]["value"], self.fingerprint)
+		self.assertEqual(payload["graph"]["companions"], {})
+		self.assertEqual(payload["result"]["matched"], payload["result"]["returned"])
+		self.assertTrue(payload["result"]["total_is_exact"])
+		graph = next(record for record in payload["result"]["records"] if record["section"] == "graph")
+		self.assertEqual(graph["node_runtime_activity"], {"active": 2, "inactive": 2, "unclassified": 1})
+		codes = {item["code"] for item in payload["warnings"]}
+		self.assertTrue({"unresolved-targets", "mir-packages-failed", "historical-properties-missing",
+			"runtime-activity-unclassified"}.issubset(codes))
+		self.assertLessEqual(payload["budget"]["estimated_tokens"], payload["budget"]["max_tokens"])
+
+	def test_search_should_exclude_only_explicit_or_inherited_inactive_nodes(self):
+		default = self.execute({"operation": "search", "text": "bridge"})
+		self.assertEqual([record["node"]["id"] for record in default["result"]["records"]], ["b"])
+		self.assertEqual(default["result"]["records"][0]["runtime_activity"], "unclassified")
+		explicit = self.execute({"operation": "search", "text": "c", "include_inactive": True})
+		self.assertEqual(explicit["result"]["records"][0]["runtime_activity"], "inactive")
+		inherited = self.execute({"operation": "search", "text": "inherited-inactive",
+			"include_inactive": True})
+		self.assertEqual(inherited["result"]["records"][0]["runtime_activity"], "inactive")
+		with self.assertRaisesRegex(query_graph.QueryFailure, "must be a boolean"):
+			query_graph.search(self.index, {"text": "bridge", "include_inactive": "false"})
+		ranked = self.execute({"operation": "search", "text": "a", "scope": "all"})
+		self.assertEqual(ranked["result"]["records"][0]["node"]["id"], "a")
+		self.assertEqual(ranked["result"]["records"][0]["match"],
+			{"rank": 0, "reason": "exact-node-id"})
+
+	def test_neighbors_should_return_bounded_multihop_parallel_evidence(self):
+		one_hop = self.execute({"operation": "neighbors", "id": "a", "direction": "outgoing"})
+		self.assertEqual(len(one_hop["result"]["records"]), 2)
+		self.assertEqual({record["to"] for record in one_hop["result"]["records"]}, {"b"})
+		self.assertEqual(len({record["evidence_sha256"] for record in one_hop["result"]["records"]}), 2)
+		two_hop = self.execute({"operation": "neighbors", "id": "a", "direction": "outgoing", "depth": 2})
+		self.assertIn("e", {record["to"] for record in two_hop["result"]["records"]})
+		self.assertEqual(two_hop["result"]["metadata"]["nodes_reached"], 3)
+		self.assertEqual(two_hop["result"]["metadata"]["activity_policy"],
+			"exclude explicit inactive (including inherited owner/function false); retain missing as unclassified")
+
+	def test_neighbors_should_emit_each_canonical_evidence_once_and_report_limits(self):
+		payload = {"schema_version": 2, "nodes": [
+			{"id": "a", "kind": "pallet"}, {"id": "b", "kind": "pallet"}], "edges": [
+				{"source": "a", "target": "b", "kind": "call"},
+			]}
+		index = query_graph.GraphIndex(payload)
+		records, matched, reasons, metadata = query_graph.neighbors(index,
+			{"id": "a", "direction": "both", "depth": 2})
+		self.assertEqual((len(records), matched, reasons), (1, 1, []))
+		self.assertEqual((records[0]["edge"]["source"], records[0]["edge"]["target"]), ("a", "b"))
+
+		loops = query_graph.GraphIndex({"schema_version": 2,
+			"nodes": [{"id": "a", "kind": "pallet"}], "edges": [
+				{"source": "a", "target": "a", "kind": "loop", "line": 1},
+				{"source": "a", "target": "a", "kind": "loop", "line": 2},
+			]})
+		records, matched, reasons, _ = query_graph.neighbors(loops,
+			{"id": "a", "direction": "both", "depth": 1})
+		self.assertEqual((len(records), matched), (2, 2))
+		self.assertEqual(len({record["evidence_sha256"] for record in records}), 2)
+		self.assertEqual(reasons, [])
+		records, matched, reasons, metadata = query_graph.neighbors(loops,
+			{"id": "a", "direction": "both", "depth": 1, "max_expansions": 1})
+		self.assertEqual((len(records), matched, metadata["expansions"]), (1, 1, 1))
+		self.assertEqual(reasons, ["expansion-limit"])
+		response = json.loads(query_graph.execute(loops, self.companions,
+			{"operation": "neighbors", "id": "a", "direction": "both", "depth": 1,
+				"max_expansions": 1}, 50, 4_000, self.fingerprint))
+		self.assertFalse(response["result"]["total_is_exact"])
+		self.assertIsNone(response["result"]["omitted"])
+		minimal = query_graph.minimal_record(records[0])
+		self.assertEqual({key: minimal[key] for key in ("depth", "from", "to")},
+			{"depth": 1, "from": "a", "to": "a"})
+		chain = query_graph.GraphIndex({"schema_version": 2, "nodes": [
+			{"id": ident, "kind": "pallet"} for ident in ("a", "b", "c")], "edges": [
+				{"source": "a", "target": "b", "kind": "call"},
+				{"source": "b", "target": "c", "kind": "call"},
+			]})
+		_, _, reasons, metadata = query_graph.neighbors(chain,
+			{"id": "a", "direction": "outgoing", "depth": 1})
+		self.assertEqual(reasons, ["depth-limit"])
+		self.assertFalse(metadata["search_complete"])
+
+	def test_paths_should_preserve_parallel_evidence_and_report_search_limits(self):
+		all_paths = self.execute({"operation": "paths", "source": "a", "target": "e",
+			"max_depth": 2, "max_paths": 10})
+		self.assertEqual(all_paths["result"]["matched"], 1)
+		first_step = all_paths["result"]["records"][0]["steps"][0]
+		self.assertEqual(first_step["evidence_count"], 2)
+		self.assertEqual(len(set(first_step["evidence_sha256s"])), 2)
+		limited = self.execute({"operation": "paths", "source": "a", "target": "e",
+			"max_depth": 1, "max_paths": 1})
+		self.assertTrue(limited["truncated"])
+		self.assertIn("depth-limit", limited["truncation_reasons"])
+
+	def test_paths_should_support_component_graph_view(self):
+		components = query_graph.component_index(self.index, {"schema_version": 2,
+			"projection": "execution", "edges": [
+			{"source": "a", "target": "b", "kind": "component-call"},
+			{"source": "a", "target": "b", "kind": "mir-component-call", "line": 4},
+			{"source": "b", "target": "e", "kind": "component-call"},
+		]})
+		payload = json.loads(query_graph.execute(self.index, self.companions,
+			{"operation": "paths", "source": "a", "target": "e", "view": "components"},
+			50, 4_000, self.fingerprint, components))
+		self.assertEqual(payload["result"]["matched"], 1)
+		self.assertEqual(payload["result"]["metadata"]["view"], "components")
+		step = payload["result"]["records"][0]["steps"][0]
+		self.assertEqual(step["edge_kinds"], ["component-call", "mir-component-call"])
+		self.assertEqual(step["evidence_count"], 2)
+		self.assertEqual(len(step["evidence_variants"]), 2)
+		self.assertNotIn("c", components.nodes)
+		with self.assertRaisesRegex(query_graph.QueryFailure, "graph node does not exist"):
+			query_graph.paths(components, {"source": "c", "target": "c"})
+
+	def test_node_should_return_metadata_and_operational_edge_counts(self):
+		payload = self.execute({"operation": "node", "id": "d"})
+		record = payload["result"]["records"][0]
+		self.assertEqual(record["runtime_activity"], "inactive")
+		self.assertEqual(record["edge_counts"]["incoming"], 1)
+		self.assertEqual(record["edge_counts"]["operational_incoming"], 0)
+
+	def test_packs_should_list_and_filter_stored_query_sections(self):
+		sections = self.execute({"operation": "packs"})
+		self.assertEqual([record["section"] for record in sections["result"]["records"]],
+			["cycles", "origins"])
+		cycles = self.execute({"operation": "packs", "section": "cycles", "contains": "a"})
+		self.assertEqual(cycles["result"]["matched"], 1)
+
+	def test_output_should_obey_record_and_approximate_token_budgets(self):
+		payload = self.execute({"operation": "search", "text": "a", "scope": "all"},
+			max_records=2, max_tokens=800)
+		self.assertLessEqual(payload["result"]["returned"], 2)
+		self.assertIn("record-limit", payload["truncation_reasons"])
+		self.assertLessEqual(payload["budget"]["estimated_tokens"], 800)
+		self.assertEqual(payload["result"]["omitted"],
+			payload["result"]["matched"] - payload["result"]["returned"])
+
+	def test_tiny_budget_should_size_large_prefix_with_bounded_encoder_calls(self):
+		records = [{"record_type": "node", "runtime_activity": "unclassified",
+			"node": {"id": f"node:{index:05}", "kind": "function", "payload": "x" * 1_000}}
+			for index in range(10_000)]
+		original = query_graph.encode_envelope
+		with mock.patch.object(query_graph, "encode_envelope", wraps=original) as encoder:
+			text = query_graph.render_envelope("search", {"text": "node"}, records, len(records),
+				[], [], 10_000, 256, graph_sha256=self.fingerprint)
+		self.assertLessEqual(encoder.call_count, 32)
+		self.assertLessEqual(len(text) + 1, 256 * 4)
+		payload = json.loads(text)
+		self.assertIn("token-limit", payload["truncation_reasons"])
+		self.assertLessEqual(payload["budget"]["estimated_tokens"], 256)
+		self.assertEqual(payload["result"]["omitted"],
+			payload["result"]["matched"] - payload["result"]["returned"])
+
+	def test_broad_search_should_complete_under_tiny_budget(self):
+		index = query_graph.GraphIndex({"schema_version": 2,
+			"nodes": [{"id": f"node:{number:05}", "kind": "function", "name": "match-node"}
+				for number in range(2_000)], "edges": []})
+		text = query_graph.execute(index, {"coverage": None, "completeness": None,
+			"query_packs": None, "component_graph": None},
+			{"operation": "search", "text": "node"}, 10_000, 256, self.fingerprint)
+		payload = json.loads(text)
+		self.assertEqual(payload["result"]["matched"], 2_000)
+		self.assertLessEqual(len(text) + 1, 256 * 4)
+
+	def test_invalid_graph_should_reject_dangling_edges(self):
+		payload = fixture_graph()
+		payload["edges"].append({"source": "a", "target": "missing", "kind": "call"})
+		with self.assertRaisesRegex(query_graph.QueryFailure, "dangling graph edge"):
+			query_graph.GraphIndex(payload)
+		payload = fixture_graph()
+		payload["schema_version"] = 1
+		with self.assertRaisesRegex(query_graph.QueryFailure, "schema_version 2"):
+			query_graph.GraphIndex(payload)
+
+	def test_component_graph_schema_and_coverage_counts_should_be_validated(self):
+		with self.assertRaisesRegex(query_graph.QueryFailure, "schema_version 2"):
+			query_graph.component_index(self.index, {"projection": "execution", "edges": []})
+		with self.assertRaisesRegex(query_graph.QueryFailure, "execution projection"):
+			query_graph.component_index(self.index,
+				{"schema_version": 2, "projection": "state", "edges": []})
+		companions = fixture_companions()
+		companions["coverage"].update({"nodes": 999, "edges": 998})
+		warnings = query_graph.companion_warnings(companions, self.index)
+		mismatches = [item for item in warnings if item["code"] == "companion-count-mismatch"]
+		self.assertEqual({item["details"]["field"] for item in mismatches}, {"nodes", "edges"})
+
+	def test_cli_batch_should_auto_load_companions_and_continue_after_errors(self):
+		with tempfile.TemporaryDirectory() as directory:
+			root = Path(directory)
+			graph = root / "interaction-graph.json"
+			graph.write_text(json.dumps(fixture_graph()))
+			(root / "coverage.json").write_text(json.dumps(self.companions["coverage"]))
+			(root / "completeness.json").write_text(json.dumps(self.companions["completeness"]))
+			(root / "query-packs.json").write_text(json.dumps(self.companions["query_packs"]))
+			(root / "component-graph.json").write_text(json.dumps({"schema_version": 2,
+				"projection": "execution", "edges": [
+					{"source": "a", "target": "b", "kind": "component-call"}]}))
+			requests = "\n".join((
+				json.dumps({"operation": [], "max_records": 1, "max_tokens": 256}),
+				json.dumps({"operation": "summary"}),
+				json.dumps({"operation": "search", "text": "bridge", "scope": []}),
+				json.dumps({"operation": "search", "text": "bridge"}),
+			)) + "\n"
+			completed = subprocess.run([sys.executable, MODULE_PATH.as_posix(), "--graph", graph.as_posix(),
+				"--max-tokens", "2000", "batch"], input=requests, text=True, capture_output=True, check=False)
+			self.assertEqual(completed.returncode, 2)
+			responses = [json.loads(line) for line in completed.stdout.splitlines()]
+			self.assertEqual(completed.stderr, "")
+			self.assertEqual(len(responses), 4)
+			self.assertEqual(responses[0]["result"]["metadata"]["error"], "invalid-operation")
+			self.assertEqual(responses[0]["budget"], {"max_records": 1, "max_tokens": 256,
+				"estimation": "ceil(serialized ASCII characters / 4)",
+				"estimated_tokens": responses[0]["budget"]["estimated_tokens"]})
+			self.assertEqual(responses[1]["result"]["metadata"].get("error"), None)
+			self.assertEqual(responses[2]["result"]["metadata"]["error"], "invalid-query")
+			self.assertEqual(responses[3]["result"]["matched"], 1)
+			self.assertEqual(responses[3]["graph"]["fingerprint"]["value"],
+				hashlib.sha256(graph.read_bytes()).hexdigest())
+			self.assertEqual(set(responses[3]["graph"]["companions"]),
+				{"coverage", "completeness", "query_packs", "component_graph"})
+
+	def test_published_response_schema_should_match_envelope_shape(self):
+		schema = json.loads(MODULE_PATH.with_name("query-response.schema.json").read_text())
+		self.assertEqual(schema["properties"]["schema_version"]["const"], 1)
+		self.assertEqual(schema["properties"]["tool"]["const"], query_graph.TOOL)
+		payload = self.execute({"operation": "summary"})
+		self.assertEqual(set(schema["required"]), set(payload))
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/scripts/runtime-interaction-graph/test_runtime_interaction_graph.py
+++ b/scripts/runtime-interaction-graph/test_runtime_interaction_graph.py
@@ -405,15 +405,22 @@ fn example<'a>(value: &'a str) {
 
 	def test_interactive_html_inline_scripts_should_compile(self):
 		g = graph.Graph()
-		g.node("pallet:a", "pallet", artifact="<untrusted>&evidence")
-		g.node("pallet:b", "pallet")
+		g.node("pallet:a", "pallet", domain="frame",
+			description="</script><untrusted>&evidence __GRAPH_SCRIPT__")
+		g.node("pallet:b", "pallet", domain="frame")
 		g.edge("pallet:a", "pallet:b", "contains", selector="0x12345678")
 		with tempfile.TemporaryDirectory() as directory:
 			output = Path(directory)
 			graph.write_interactive_html(g, graph.component_edges(g), output)
 			contents = (output / "interaction-graph.html").read_text()
-			self.assertIn("&evidence", contents)
+			self.assertNotIn("</script><untrusted>", contents)
+			self.assertIn("\\u003cuntrusted\\u003e", contents)
+			self.assertIn("\\u0026evidence", contents)
+			self.assertIn("evidence __GRAPH_SCRIPT__", contents)
 			self.assertIn('href="graph-scale.svg"', contents)
+			self.assertIn('id="graph-canvas"', contents)
+			self.assertIn('id="projection"', contents)
+			self.assertIn("Click any node or edge", contents)
 			for script in graph.re.findall(r"<script>(.*?)</script>", contents, graph.re.DOTALL):
 				try:
 					completed = graph.subprocess.run(["node", "--check"], input=script,
@@ -421,6 +428,37 @@ fn example<'a>(value: &'a str) {
 				except FileNotFoundError:
 					self.skipTest("node is unavailable")
 				self.assertEqual(completed.returncode, 0, completed.stderr)
+			first = (output / "interaction-graph.html").read_bytes()
+			graph.write_interactive_html(g, graph.component_edges(g), output)
+			self.assertEqual(first, (output / "interaction-graph.html").read_bytes())
+
+	def test_interactive_graph_payload_should_aggregate_pairs_and_projections(self):
+		g = graph.Graph()
+		g.node("pallet:a", "pallet", domain="frame", runtime_active=True)
+		g.node("pallet:b", "pallet", domain="frame", runtime_active=True)
+		g.edge("pallet:a", "pallet:b", "direct-call", method="one", file="a.rs", line=1)
+		g.edge("pallet:a", "pallet:b", "direct-call", method="two", file="a.rs", line=2)
+		g.edge("pallet:a", "pallet:b", "resolved-call", method="three", file="a.rs", line=3)
+		g.edge("pallet:a", "pallet:b", "contains")
+		payload = graph.interactive_graph_payload(g, graph.component_edges(g))
+		self.assertEqual(payload["schema_version"], 1)
+		self.assertEqual([node["id"] for node in payload["nodes"]], ["pallet:a", "pallet:b"])
+		self.assertEqual(payload["projections"]["execution"], {
+			"nodes": 2, "pairs": 1, "evidence_edges": 3,
+			"kinds": ["direct-call", "resolved-call"],
+		})
+		self.assertEqual(payload["projections"]["callback"]["evidence_edges"], 1)
+		self.assertEqual(payload["projections"]["configuration"]["evidence_edges"], 1)
+		self.assertEqual(payload["edges"], [{
+			"source": "pallet:a", "target": "pallet:b", "count": 4,
+			"kind_counts": {"contains": 1, "direct-call": 2, "resolved-call": 1},
+			"projection_counts": {"callback": 1, "configuration": 1, "execution": 3},
+			"samples": [
+				{"kind": "contains"},
+				{"kind": "direct-call", "file": "a.rs", "line": 1, "method": "one"},
+				{"kind": "resolved-call", "file": "a.rs", "line": 3, "method": "three"},
+			],
+		}])
 
 	def test_strongly_connected_reports_cycles_only(self):
 		edges = [

--- a/scripts/runtime-interaction-graph/test_runtime_interaction_graph.py
+++ b/scripts/runtime-interaction-graph/test_runtime_interaction_graph.py
@@ -1,0 +1,1408 @@
+import importlib.util
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from unittest import mock
+
+
+MODULE = Path(__file__).with_name("runtime_interaction_graph.py")
+SPEC = importlib.util.spec_from_file_location("runtime_interaction_graph", MODULE)
+graph = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(graph)
+DIFF_SPEC = importlib.util.spec_from_file_location("diff_snapshots", MODULE.with_name("diff_snapshots.py"))
+snapshot_diff = importlib.util.module_from_spec(DIFF_SPEC)
+DIFF_SPEC.loader.exec_module(snapshot_diff)
+GRAPH_DIFF_SPEC = importlib.util.spec_from_file_location("diff_graphs", MODULE.with_name("diff_graphs.py"))
+graph_diff = importlib.util.module_from_spec(GRAPH_DIFF_SPEC)
+GRAPH_DIFF_SPEC.loader.exec_module(graph_diff)
+
+
+def semantic_provenance(tool: str, source_inputs: dict | None = None) -> dict:
+	collector_name = "collect_mir.py" if tool == "rustc-mir" else "collect_rapx.py"
+	tool_inputs = graph.semantic_tool_inputs(tool)
+	toolchain = graph.collect_mir.TOOLCHAIN if tool == "rustc-mir" else graph.collect_rapx.TOOLCHAIN
+	return {"source_inputs": source_inputs or {"sha256": "0" * 64, "file_count": 1},
+		"collector_sha256": tool_inputs["files"][collector_name], "tool_inputs": tool_inputs,
+		"toolchain": toolchain}
+
+
+class RuntimeInteractionGraphTests(unittest.TestCase):
+	def test_body_end_handles_nested_blocks(self):
+		text = "fn f() { if true { call(); } storage(); } fn g() {}"
+		self.assertEqual(text[: graph.body_end(text, 0)], "fn f() { if true { call(); } storage(); }")
+
+	def test_function_body_end_rejects_bodyless_trait_declarations(self):
+		text = "trait T { fn declared(value: [u8; 32]); fn implemented() { call(); } }"
+		declared, implemented = list(graph.FN.finditer(text))
+		self.assertIsNone(graph.function_body_end(text, declared.end()))
+		self.assertEqual(text[implemented.start():graph.function_body_end(text, implemented.end())],
+			"fn implemented() { call(); }")
+
+	def test_source_ids_do_not_change_with_line_offsets(self):
+		self.assertEqual(graph.source_id("function", "pallets/example/src/lib.rs", "call", 1),
+			"function:pallets/example/src/lib.rs:call")
+		self.assertEqual(graph.source_id("function", "pallets/example/src/lib.rs", "call", 2),
+			"function:pallets/example/src/lib.rs:call:2")
+
+	def test_runtime_aliases_resolve_construct_runtime_entries(self):
+		text = """
+ Router: pallet_route_executor = 67,
+ Stableswap:
+	 pallet_stableswap
+	 exclude_parts { GenesisConfig }
+	 = 70,
+ Ethereum: pallet_ethereum = 92,
+ Ethereum::on_finalize(System::block_number() + 1);
+ if matches!(version, 3..=5) {}
+"""
+		self.assertEqual(
+			graph.runtime_aliases(text),
+			{"Router": "pallet_route_executor", "Stableswap": "pallet_stableswap",
+				"Ethereum": "pallet_ethereum"},
+		)
+
+	def test_runtime_config_blocks_keep_adjacent_implementations_separate(self):
+		text = """impl pallet_first::Config for Runtime {
+	type Handler = FirstHandler;
+}
+impl pallet_second::Config for Runtime {
+	type Handler = SecondHandler;
+}
+impl pallet_last::Config for Runtime {
+	type Handler = LastHandler;
+}"""
+		blocks = {match.group(1): body for match, body in graph.runtime_config_blocks(text)}
+		self.assertEqual(set(blocks), {"pallet_first", "pallet_second", "pallet_last"})
+		self.assertIn("FirstHandler", blocks["pallet_first"])
+		self.assertNotIn("SecondHandler", blocks["pallet_first"])
+		self.assertIn("SecondHandler", blocks["pallet_second"])
+		self.assertNotIn("LastHandler", blocks["pallet_second"])
+		self.assertIn("LastHandler", blocks["pallet_last"])
+
+	def test_config_callback_targets_should_ignore_nested_generic_types(self):
+		value = """WrapRunner<
+			Self,
+			pallet_evm::runner::stack::Runner<Self>,
+			hydradx_adapters::price::FeeAssetBalanceInCurrency<
+				Runtime,
+				ConvertBalance<TenMinutesOraclePrice, XykPaymentAssetSupport, DotAssetId>,
+				FeeCurrencyOverrideOrDefault,
+				FungibleCurrencies<Runtime>,
+			>,
+		>"""
+		local_symbols = {
+			"WrapRunner": {"component:evm:runner"},
+			"FeeAssetBalanceInCurrency": {"component:runtime-adapters:price"},
+			"ConvertBalance": {"component:runtime-adapters:price"},
+			"FeeCurrencyOverrideOrDefault": {"component:runtime:assets"},
+			"FungibleCurrencies": {"component:runtime:assets"},
+		}
+		self.assertEqual(graph.config_callback_targets(value, {}, local_symbols),
+			["component:evm:runner"])
+
+	def test_config_callback_targets_should_keep_top_level_tuple_members(self):
+		aliases = {
+			"Omnipool": "pallet_omnipool",
+			"Stableswap": "pallet_stableswap",
+			"XYK": "pallet_xyk",
+			"LBP": "pallet_lbp",
+			"HSM": "pallet_hsm",
+		}
+		self.assertEqual(
+			graph.config_callback_targets(
+				"(Omnipool, Stableswap, XYK, LBP, Aave, HSM)", aliases,
+				{"Aave": {"component:evm:aave_trade_executor"}},
+			),
+			[
+				"component:evm:aave_trade_executor", "pallet:hsm", "pallet:lbp", "pallet:omnipool",
+				"pallet:stableswap", "pallet:xyk",
+			],
+		)
+
+	def test_component_id_should_canonicalize_warehouse_liquidity_mining(self):
+		self.assertEqual(graph.component_id("warehouse_liquidity_mining"), "pallet:liquidity-mining")
+		self.assertEqual(graph.component_id("pallet_liquidity_mining"), "pallet:liquidity-mining")
+
+	def test_graph_edges_are_exactly_deduplicated_and_have_nodes(self):
+		g = graph.Graph()
+		g.edge("source", "target", "calls", evidence=["same"])
+		g.edge("source", "target", "calls", evidence=["same"])
+		g.edge("source", "target", "calls", evidence=["different"])
+		self.assertEqual(len(g.edges), 2)
+		self.assertEqual(set(g.nodes), {"source", "target"})
+		self.assertTrue(g.nodes["source"]["placeholder"])
+		g.node("source", "function", name="source")
+		self.assertEqual(g.nodes["source"]["kind"], "function")
+		self.assertNotIn("placeholder", g.nodes["source"])
+
+	def test_semantic_inventory_should_be_loaded_only_from_scanned_root(self):
+		with tempfile.TemporaryDirectory() as directory:
+			base = Path(directory) / "base"
+			head = Path(directory) / "head"
+			base.mkdir()
+			(head / "scripts/runtime-interaction-graph").mkdir(parents=True)
+			(head / "pallets/example/src").mkdir(parents=True)
+			(head / "pallets/example/src/lib.rs").write_text("pub struct ExampleLedger;\n")
+			inventory = {
+				"schema_version": 1,
+				"nodes": [{
+					"id": "ledger:example",
+					"kind": "ledger",
+					"domain": "asset-routing",
+					"label": "Example ledger",
+					"description": "Inventory local to the scanned head root.",
+					"evidence": [{"file": "pallets/example/src/lib.rs", "symbol": "pub struct ExampleLedger;"}],
+				}],
+				"edges": [],
+			}
+			(head / "scripts/runtime-interaction-graph/semantic-inventory.json").write_text(
+				graph.json.dumps(inventory))
+
+			base_graph = graph.Graph()
+			head_graph = graph.Graph()
+			self.assertIsNone(graph.merge_semantic_inventory(base_graph, base))
+			self.assertNotIn("semantic-analysis:explicit-inventory", base_graph.nodes)
+			self.assertIsNotNone(graph.merge_semantic_inventory(head_graph, head))
+			self.assertIn("ledger:example", head_graph.nodes)
+			self.assertEqual(head_graph.nodes["semantic-analysis:explicit-inventory"]["node_count"], 1)
+
+	def test_generated_and_helper_functions_are_not_entrypoint_eligible(self):
+		text = '#[cfg(feature = "runtime-benchmarks")]\npub mod benchmark_helpers { fn call() {} }\nfn live() {}'
+		ranges = graph.helper_module_ranges(text)
+		helper = next(match for match in graph.FN.finditer(text) if match.group(1) == "call")
+		live = next(match for match in graph.FN.finditer(text) if match.group(1) == "live")
+		self.assertFalse(graph.entrypoint_eligible(Path("runtime/helpers.rs"), helper.start(), ranges))
+		self.assertTrue(graph.entrypoint_eligible(Path("runtime/helpers.rs"), live.start(), ranges))
+		self.assertFalse(graph.entrypoint_eligible(Path("pallets/example/src/weights.rs"), live.start(), []))
+		self.assertTrue(graph.source_excluded(Path("precompiles/utils/src/testing/execution.rs")))
+		self.assertTrue(graph.source_excluded(
+			Path("runtime/hydradx/src/evm/evm-utility/macro/src/lib.rs")))
+
+	def test_inactive_cfg_ranges_should_exclude_benchmarks_but_not_production_fallbacks(self):
+		text = '''
+#[cfg(feature = "runtime-benchmarks")]
+impl Benchmark for Runtime { fn dispatch_benchmark() {} }
+#[cfg(not(feature = "runtime-benchmarks"))]
+impl Live for Runtime { fn execute() {} }
+'''
+		ranges = graph.inactive_cfg_ranges(text)
+		benchmark = text.index("dispatch_benchmark")
+		live = text.index("fn execute")
+		self.assertTrue(any(start <= benchmark < end for start, end in ranges))
+		self.assertFalse(any(start <= live < end for start, end in ranges))
+
+	def test_config_associated_types_should_exclude_inactive_cfg_declarations(self):
+		text = '''
+pub trait Config {
+	type Live: Live;
+	#[cfg(feature = "runtime-benchmarks")]
+	type BenchmarkHelper: Helper;
+	#[cfg(not(feature = "runtime-benchmarks"))]
+	type ProductionHelper: Helper;
+}
+'''
+		self.assertEqual(graph.config_associated_types(text), {
+			"Live": "Live",
+			"ProductionHelper": "Helper",
+		})
+
+	def test_config_associated_types_should_parse_gats_and_ignore_documentation_examples(self):
+		text = '''
+//! pub trait Config { type Fake: Fake; }
+pub trait Config {
+	type TryCallCurrency<'a>: TryConvert<&'a <Self as frame_system::Config>::RuntimeCall, AssetIdOf<Self>>;
+}
+'''
+		self.assertEqual(graph.config_associated_types(text), {
+			"TryCallCurrency": "TryConvert<&'a <Self as frame_system::Config>::RuntimeCall, AssetIdOf<Self>>",
+		})
+
+	def test_config_type_items_should_parse_gat_assignments(self):
+		items = graph.config_type_items("type TryCallCurrency<'a> = TryCallCurrency;", "=")
+		self.assertEqual([(item["name"], item["generics"], item["value"]) for item in items],
+			[("TryCallCurrency", "<'a>", "TryCallCurrency")])
+
+	def test_empty_root_config_should_anchor_nested_source_modules(self):
+		declarations = {"pallet_example::Config": {}}
+		self.assertEqual(
+			graph.nearest_config_trait("pallet_example::types::Config", declarations),
+			"pallet_example::Config",
+		)
+
+	def test_rust_use_bindings_should_expand_groups_and_canonicalize_config_aliases(self):
+		text = '''
+use pallet_evm::{self, runner::Runner as EvmRunnerT, Config};
+pub(crate) use pallet_collective as pallet_collective_technical_committee;
+'''
+		bindings = graph.rust_use_bindings(text)
+		self.assertEqual(bindings["Config"], {"pallet_evm::Config"})
+		self.assertEqual(bindings["EvmRunnerT"], {"pallet_evm::runner::Runner"})
+		self.assertEqual(graph.config_reference("Config", bindings, None),
+			("pallet_evm::Config", None))
+		self.assertEqual(graph.config_reference(
+			"pallet_collective_technical_committee::Config<TechnicalCollective>", bindings, None,
+			{"TechnicalCollective": {"pallet_collective::Instance2"}}),
+			("pallet_collective::Config", "Instance2"))
+		local = graph.rust_use_bindings("use crate::{Config, Pallet};")
+		self.assertEqual(graph.config_reference("Config", local, "pallet_currencies::Config"),
+			("pallet_currencies::Config", None))
+		aliased_self = graph.rust_use_bindings(
+			"use cumulus_pallet_parachain_system::{self as parachain_system, Config};")
+		self.assertEqual(aliased_self["parachain_system"], {"cumulus_pallet_parachain_system"})
+		self.assertEqual(graph.config_reference("parachain_system::Config", aliased_self, None),
+			("cumulus_pallet_parachain_system::Config", None))
+		self.assertEqual(graph.config_reference("super::pallet::Config", {}, "pallet_aura_ext::Config"),
+			("pallet_aura_ext::Config", None))
+
+	def test_associated_calls_should_preserve_explicit_trait_qualification(self):
+		calls = graph.associated_calls('''
+<T as pallet_evm::Config>::GasWeightMapping::gas_to_weight(1, true);
+T::AddressMapping::into_account_id(address);
+<Runtime as pallet_evm::Config>::ChainId::get();
+<R as pallet_evm::Config>::PrecompilesValue::get();
+R::AddressMapping::into_account_id(address);
+''')
+		self.assertEqual([(call["subject"], call["trait_path"], call["associated_type"], call["method"])
+			for call in calls], [
+			("T", "pallet_evm::Config", "GasWeightMapping", "gas_to_weight"),
+			("T", None, "AddressMapping", "into_account_id"),
+			("Runtime", "pallet_evm::Config", "ChainId", "get"),
+			("R", "pallet_evm::Config", "PrecompilesValue", "get"),
+			("R", None, "AddressMapping", "into_account_id"),
+		])
+
+	def test_rust_mask_should_preserve_lifetimes_and_ignore_literal_or_comment_calls(self):
+		text = '''
+fn example<'a>(value: &'a str) {
+	let _ = r#"T::LiteralHandler::call(); // not a comment"#;
+	let _ = 'x';
+	// T::CommentHandler::call();
+	T::LiveHandler::call();
+}
+'''
+		calls = graph.associated_calls(graph.mask_rust_comments(text))
+		self.assertEqual([(call["associated_type"], call["method"]) for call in calls],
+			[("LiveHandler", "call")])
+
+	def test_mir_associated_call_should_require_config_projection_as_receiver(self):
+		self.assertEqual(graph.mir_associated_call(
+			"<<T as pallet::Config<I>>::MultiCurrency as orml_traits::MultiCurrency<A>>::transfer"), {
+			"subject": "T", "trait_path": "pallet::Config",
+			"config_instance": "I",
+			"associated_type": "MultiCurrency", "method": "transfer",
+		})
+		self.assertEqual(graph.mir_associated_call(
+			"<<R as pallet_evm::Config>::AddressMapping as AddressMapping<A>>::into_account_id"), {
+			"subject": "R", "trait_path": "pallet_evm::Config",
+			"config_instance": None,
+			"associated_type": "AddressMapping", "method": "into_account_id",
+		})
+		self.assertIsNone(graph.mir_associated_call(
+			"<<<R as pallet_evm::Config>::Timestamp as Time>::Moment as Convert<u128>>::convert"))
+		self.assertIsNone(graph.mir_associated_call(
+			"<Result<<T as pallet::Config>::Handler, E> as Try>::branch"))
+
+	def test_associated_config_references_should_stop_at_nearest_redeclaration(self):
+		declarations = {
+			"pallet_child::Config": {"Currency": "Currency"},
+			"pallet_parent::Config": {"Currency": "Currency"},
+		}
+		parents = {"pallet_child::Config": {"pallet_parent::Config"}}
+		self.assertEqual(graph.associated_config_references(
+			{("pallet_child::Config", None)}, "Currency", declarations, parents),
+			{("pallet_child::Config", None)},
+		)
+
+	def test_outputs_are_deterministic(self):
+		g = graph.Graph()
+		g.node("b", "pallet")
+		g.node("a", "runtime")
+		g.edge("a", "b", "contains")
+		with tempfile.TemporaryDirectory() as directory:
+			out = Path(directory)
+			graph.write_outputs(g, out)
+			first = (out / "interaction-graph.json").read_text()
+			graph.write_outputs(g, out)
+			self.assertEqual(first, (out / "interaction-graph.json").read_text())
+
+	def test_graph_scale_summary_should_separate_activity_and_evidence_counts(self):
+		g = graph.Graph()
+		g.node("pallet:active", "pallet", domain="frame", runtime_active=True)
+		g.node("component:inactive", "evm-adapter", domain="evm-adapter", runtime_active=False)
+		g.node("entrypoint:active", "entrypoint", domain="frame", runtime_active=True)
+		g.node("associated:inactive:Handler", "associated-type", owner="component:inactive", runtime_active=False)
+		g.node("mir-operation:active", "mir-operation", function="entrypoint:active")
+		g.node("contract-function:foo", "contract-function")
+		g.edge("pallet:active", "entrypoint:active", "direct-call")
+		g.edge("pallet:active", "entrypoint:active", "mir-call", semantic_source="rustc-mir")
+		g.edge("pallet:active", "component:inactive", "rapx-call", semantic_source="rapx")
+		g.edge("pallet:active", "entrypoint:active", "enforces", semantic_source="explicit-inventory")
+		g.edge("pallet:active", "entrypoint:active", "selector-matches-contract-function")
+		g.edge("pallet:active", "contract-function:foo", "exposes-function")
+
+		summary = graph.graph_scale_summary(g)
+		self.assertEqual(summary["totals"], {
+			"nodes": {"raw": 6, "operational": 4, "active": 2, "unclassified": 2, "inactive": 2},
+			"edges": {"raw": 6, "operational": 5, "active": 4, "unclassified": 1, "inactive": 1},
+			"components": {"raw": 2, "operational": 1, "active": 1, "unclassified": 0, "inactive": 1},
+			"entrypoints": {"raw": 1, "operational": 1, "active": 1, "unclassified": 0, "inactive": 0},
+		})
+		self.assertEqual({item["name"]: (item["raw"], item["operational"], item["active"],
+			item["unclassified"], item["inactive"]) for item in summary["domains"]}, {
+			"frame": (3, 3, 2, 1, 0),
+			"evm-adapter": (2, 0, 0, 0, 2),
+			"unclassified": (1, 1, 0, 1, 0),
+		})
+		self.assertEqual(summary["inventory_only_targets"], 1)
+		self.assertEqual(summary["unresolved_targets"], 0)
+		self.assertEqual(summary["evidence"], [
+			{"name": "source scan", "raw": 1, "operational": 1,
+				"active": 1, "unclassified": 0, "inactive": 0},
+			{"name": "rustc MIR", "raw": 1, "operational": 1,
+				"active": 1, "unclassified": 0, "inactive": 0},
+			{"name": "RAPx", "raw": 1, "operational": 0,
+				"active": 0, "unclassified": 0, "inactive": 1},
+			{"name": "semantic inventory", "raw": 1, "operational": 1,
+				"active": 1, "unclassified": 0, "inactive": 0},
+			{"name": "deployment / chain", "raw": 2, "operational": 2,
+				"active": 1, "unclassified": 1, "inactive": 0},
+		])
+
+	def test_graph_scale_svg_should_be_bounded_and_deterministic(self):
+		g = graph.Graph()
+		g.node("pallet:active", "pallet", domain="frame")
+		g.node("boundary:evm", "execution-boundary", domain="evm")
+		g.edge("pallet:active", "boundary:evm", "enters-evm")
+		with tempfile.TemporaryDirectory() as directory:
+			output = Path(directory)
+			path = graph.write_graph_scale_svg(g, output)
+			first = path.read_bytes()
+			root = ET.fromstring(first)
+			self.assertEqual((root.attrib["width"], root.attrib["height"]), ("1600", "1200"))
+			self.assertEqual(root.attrib["aria-labelledby"], "title")
+			self.assertEqual(root.attrib["aria-describedby"], "description")
+			self.assertIn("Hydration runtime interaction graph", first.decode())
+			self.assertIn("unclassified", first.decode())
+			self.assertIn("fill:#475569", first.decode())
+			graph.write_graph_scale_svg(g, output)
+			self.assertEqual(first, path.read_bytes())
+
+	def test_component_projection_should_preserve_edge_evidence(self):
+		g = graph.Graph()
+		g.node("function:a", "function", owner="pallet:a")
+		g.node("function:b", "function", owner="pallet:b")
+		g.edge("function:a", "function:b", "direct-call", file="pallets/a/src/lib.rs", line=42,
+			selector="0x12345678", storage="Pools", block_hash="0x" + "a" * 64,
+			semantic_source="source")
+		edge = graph.component_edges(g)[0]
+		self.assertEqual((edge["source"], edge["target"]), ("pallet:a", "pallet:b"))
+		self.assertEqual(edge["evidence_source"], "function:a")
+		self.assertEqual(edge["evidence_target"], "function:b")
+		self.assertEqual(edge["selector"], "0x12345678")
+		self.assertEqual(edge["storage"], "Pools")
+		self.assertEqual(edge["block_hash"], "0x" + "a" * 64)
+
+	def test_interactive_html_inline_scripts_should_compile(self):
+		g = graph.Graph()
+		g.node("pallet:a", "pallet", artifact="<untrusted>&evidence")
+		g.node("pallet:b", "pallet")
+		g.edge("pallet:a", "pallet:b", "contains", selector="0x12345678")
+		with tempfile.TemporaryDirectory() as directory:
+			output = Path(directory)
+			graph.write_interactive_html(g, graph.component_edges(g), output)
+			contents = (output / "interaction-graph.html").read_text()
+			self.assertIn("&evidence", contents)
+			self.assertIn('href="graph-scale.svg"', contents)
+			for script in graph.re.findall(r"<script>(.*?)</script>", contents, graph.re.DOTALL):
+				try:
+					completed = graph.subprocess.run(["node", "--check"], input=script,
+						text=True, capture_output=True)
+				except FileNotFoundError:
+					self.skipTest("node is unavailable")
+				self.assertEqual(completed.returncode, 0, completed.stderr)
+
+	def test_strongly_connected_reports_cycles_only(self):
+		edges = [
+			{"source": "a", "target": "b"},
+			{"source": "b", "target": "a"},
+			{"source": "b", "target": "c"},
+		]
+		self.assertEqual(graph.strongly_connected(edges), [["a", "b"]])
+
+	def test_storage_reads_are_not_mutations(self):
+		self.assertNotIn("get", graph.STORAGE_WRITES)
+		self.assertIn("try_mutate", graph.STORAGE_WRITES)
+		plain = graph.STORAGE.search("NoncesStorage::insert(key, value)")
+		generic = graph.STORAGE.search("Positions::<T>::get(id)")
+		associated = graph.STORAGE.search("Currency::get(id)")
+		self.assertEqual(plain.groups(), ("NoncesStorage", "insert"))
+		self.assertEqual(generic.groups(), ("Positions", "get"))
+		self.assertTrue(graph.is_storage_match(plain))
+		self.assertTrue(graph.is_storage_match(generic))
+		self.assertFalse(graph.is_storage_match(associated))
+
+	def test_evm_and_frame_boundary_patterns(self):
+		self.assertTrue(graph.EVM_ENTRY.search("T::Runner::call(source, target)"))
+		self.assertTrue(graph.EVM_ENTRY.search("handle.call(address, input)"))
+		self.assertEqual(graph.INTERNAL_EVM_EXECUTOR.search("Executor::<Runtime>::call(context)").group(1),
+			"call")
+
+	def test_generated_selector_bindings_should_resolve_annotated_import_alias_only(self):
+		definition_text = """
+#[module_evm_utility_macro::generate_function_selector]
+#[repr(u32)]
+pub enum WireFunction {
+	Supply = "supply(address,uint256)",
+}
+pub enum ArbitraryFunction {
+	Supply = "wrong()",
+}
+"""
+		definitions = {
+			("runtime/hydradx", ("evm", "selectors"), "WireFunction"):
+				graph.generated_selector_enums(definition_text)["WireFunction"],
+		}
+		consumer = "use crate::evm::selectors::WireFunction as ImportedFunction;"
+		bindings = graph.selector_type_bindings(consumer, "runtime/hydradx/src/caller.rs", definitions)
+		self.assertEqual(bindings, {"ImportedFunction": {"Supply": "supply(address,uint256)"}})
+		self.assertNotIn("ArbitraryFunction", bindings)
+
+	def test_precompile_public_aliases_should_create_distinct_selector_entrypoints(self):
+		text = """
+#[precompile::public("freezeAsset()")]
+#[precompile::public("freeze_asset()")]
+fn freeze() {}
+"""
+		targets = graph.attribute_target_lists(text, graph.PRECOMPILE_PUBLIC)
+		function = next(graph.FN.finditer(text))
+		self.assertEqual([match.group(1) for match in targets[function.start()]],
+			["freezeAsset()", "freeze_asset()"])
+		g = graph.Graph()
+		g.node("function:freeze", "function", owner="precompile:test")
+		entrypoints = graph.add_precompile_selector_entrypoints(g, "function:freeze",
+			[(match.group(1), 1) for match in targets[function.start()]], "precompiles/test/src/lib.rs")
+		self.assertEqual(len(entrypoints), 2)
+		self.assertEqual(len({g.nodes[entrypoint]["selector"] for entrypoint in entrypoints}), 2)
+		self.assertTrue(all(g.nodes[entrypoint]["signature"] in {"freezeAsset()", "freeze_asset()"}
+			for entrypoint in entrypoints))
+		self.assertTrue(graph.FRAME_DISPATCH.search("RuntimeCall::dispatch(origin)"))
+
+	def test_runtime_binding_should_resolve_dynamic_call(self):
+		g = graph.Graph()
+		g.node("associated:pallet:source:Router", "associated-type", unresolved=True)
+		g.node("function:source", "function", owner="pallet:source")
+		g.edge("function:source", "associated:pallet:source:Router", "dynamic-call", method="sell")
+		g.edge("associated:pallet:source:Router", "pallet:router", "binding-resolves-to")
+		graph.enrich_resolutions(g)
+		self.assertFalse(g.nodes["associated:pallet:source:Router"]["unresolved"])
+		self.assertTrue(any(edge["kind"] == "resolved-call" and edge["target"] == "pallet:router"
+			for edge in g.edges))
+
+	def test_bounded_paths_should_include_resolved_multi_hop_evm_path(self):
+		edges = [
+			{"source": "pallet:router", "target": "pallet:hsm"},
+			{"source": "pallet:hsm", "target": "boundary:evm-execution"},
+		]
+		self.assertIn(
+			["pallet:router", "pallet:hsm", "boundary:evm-execution"],
+			graph.bounded_paths(edges, {"boundary:evm-execution"}),
+		)
+
+	def test_query_packs_should_bound_traces_per_entrypoint(self):
+		g = graph.Graph()
+		for start in ("a", "z"):
+			entrypoint = f"entrypoint:{start}"
+			g.node(entrypoint, "entrypoint")
+			for index in range(11):
+				boundary = f"boundary:{start}:{index:02}"
+				g.node(boundary, "execution-boundary")
+				g.edge(entrypoint, boundary, "enters-function")
+		projections = {name: [] for name in graph.EDGE_PROJECTIONS}
+		projections["execution"] = g.edges
+		result = graph.query_packs(g, [], projections, [], [], {}, [])
+		self.assertEqual(result["schema_version"], 1)
+		traces = result["entrypoint_execution_traces"]
+		self.assertEqual(sum(trace[0] == "entrypoint:a" for trace in traces), 10)
+		self.assertEqual(sum(trace[0] == "entrypoint:z" for trace in traces), 10)
+		self.assertEqual(result["entrypoint_trace_search"]["limit_truncated_entrypoints"],
+			["entrypoint:a", "entrypoint:z"])
+
+	def test_query_packs_should_exclude_inventory_only_edges_and_entrypoints(self):
+		g = graph.Graph()
+		g.node("function:active", "function")
+		g.node("function:inactive", "function", runtime_active=False)
+		g.node("entrypoint:active", "entrypoint", entrypoint_kind="runtime-hook", function="function:active")
+		g.node("entrypoint:inactive", "entrypoint", entrypoint_kind="runtime-hook",
+			function="function:inactive")
+		g.node("origin:root", "origin")
+		g.node("asset-operation:transfer", "asset-operation")
+		g.edge("origin:root", "function:active", "authorizes-entry")
+		g.edge("origin:root", "function:inactive", "authorizes-entry")
+		g.edge("function:active", "asset-operation:transfer", "asset-operation")
+		g.edge("function:inactive", "asset-operation:transfer", "asset-operation")
+		projections = {name: [] for name in graph.EDGE_PROJECTIONS}
+		projections["authorization"] = graph.projected_edges(g, "authorization")
+		projections["asset"] = graph.projected_edges(g, "asset")
+		result = graph.query_packs(g, [], projections, [], [], {}, [])
+		self.assertEqual([edge["target"] for edge in result["privileged_entries"]], ["function:active"])
+		self.assertEqual([edge["source"] for edge in result["token_backend_edges"]], ["function:active"])
+		self.assertEqual([node["id"] for node in result["lifecycle_entrypoints"]], ["entrypoint:active"])
+
+	def test_configured_migration_should_activate_source_local_helpers(self):
+		g = graph.Graph()
+		migration_file = "external/pallet_example/migration.rs"
+		g.node("function:migration", "function", name="on_runtime_upgrade", file=migration_file,
+			local_pallet_calls=[{"method": "migrate_data", "line": 10}])
+		g.node("function:helper", "function", name="migrate_data", file=migration_file,
+			local_pallet_calls=[])
+		g.node("function:unused", "function", name="unused", file=migration_file,
+			local_pallet_calls=[])
+		g.node("entrypoint:migration", "entrypoint", entrypoint_kind="runtime-migration")
+		g.edge("entrypoint:migration", "function:migration", "enters-function")
+		graph.enrich_migration_calls(g)
+		graph.classify_runtime_activity(g, set(), {}, True)
+		self.assertTrue(g.nodes["function:migration"]["runtime_active"])
+		self.assertTrue(g.nodes["function:helper"]["runtime_active"])
+		self.assertFalse(g.nodes["function:unused"]["runtime_active"])
+		self.assertTrue(any(edge["source"] == "function:migration" and edge["target"] == "function:helper"
+			and edge.get("resolution") == "source-local-migration" for edge in g.edges))
+
+	def test_rapx_output_should_merge_internal_and_evm_calls(self):
+		g = graph.Graph()
+		g.node("function:entry", "function", name="entry", owner="pallet:hsm")
+		g.node("function:helper", "function", name="helper", owner="pallet:hsm")
+		output = """  <impl pallet::Pallet<T>>::entry calls:
+    -> <impl pallet::Pallet<T>>::helper
+    -> hydradx_traits::evm::EVM::call
+"""
+		with tempfile.TemporaryDirectory() as directory:
+			path = Path(directory) / "rapx.txt"
+			path.write_text(output)
+			self.assertEqual(graph.merge_rapx(g, path, "pallet:hsm"), 2)
+			self.assertTrue(any(edge["target"] == "function:helper" for edge in g.edges))
+			self.assertTrue(any(edge["target"] == "boundary:evm-execution" for edge in g.edges))
+			self.assertEqual({edge["rapx_output"] for edge in g.edges}, {"rapx.txt"})
+
+	def test_runtime_rapx_should_use_module_identity_for_same_named_functions(self):
+		g = graph.Graph()
+		root_call = "function:runtime/hydradx/src/lib.rs:call"
+		executor_call = "function:runtime/hydradx/src/evm/executor.rs:call"
+		g.node(root_call, "function", name="call", owner="runtime:hydradx",
+			file="runtime/hydradx/src/lib.rs")
+		g.node(executor_call, "function", name="call", owner="component:evm:executor",
+			file="runtime/hydradx/src/evm/executor.rs")
+		output = """  <evm::executor::Executor<T> as EVM<Result>>::call calls:
+    -> pallet_dispatcher::Pallet::<T>::extra_gas
+"""
+		with tempfile.TemporaryDirectory() as directory:
+			path = Path(directory) / "runtime.callgraph.txt"
+			path.write_text(output)
+			self.assertEqual(graph.merge_rapx(g, path, "runtime:hydradx"), 1)
+		edge = next(edge for edge in g.edges if edge["kind"] == "rapx-call")
+		self.assertEqual(edge["source"], executor_call)
+		self.assertEqual(edge["target"], "pallet:dispatcher")
+
+	def test_rapx_manifest_should_merge_successful_packages_only(self):
+		g = graph.Graph()
+		g.node("function:entry", "function", name="entry", owner="pallet:hsm")
+		with tempfile.TemporaryDirectory() as directory:
+			root = Path(directory)
+			artifact = root / "hsm.callgraph.txt"
+			artifact.write_text(
+				"  <impl pallet::Pallet<T>>::entry calls:\n    -> hydradx_traits::evm::EVM::call\n")
+			package = {"package": "pallet-hsm", "owner": "pallet:hsm",
+				"manifest": "pallets/hsm/Cargo.toml"}
+			provenance = semantic_provenance("rapx")
+			command = graph.collect_rapx.analysis_command(package, "callgraph", 300)
+			fingerprint = graph.analysis_provenance.command_fingerprint(
+				provenance, {**package, "analysis": "callgraph"}, command)
+			manifest = {"schema_version": 2, "tool": "rapx", "toolchain": graph.collect_rapx.TOOLCHAIN,
+				"timeout_seconds": 300, "requested_packages": ["pallet-hsm"],
+				"requested_analyses": ["callgraph"],
+				"provenance": provenance,
+				"packages": [{**package, "analyses": {
+					"callgraph": {"status": "ok", "path": artifact.name,
+						"command": command, "input_fingerprint": fingerprint,
+						"artifact_sha256": graph.hashlib.sha256(artifact.read_bytes()).hexdigest()}}}]}
+			(root / "manifest.json").write_text(graph.json.dumps(manifest))
+			self.assertEqual(graph.merge_rapx_manifest(g, root / "manifest.json"), 1)
+
+	def test_semantic_manifest_should_fail_when_source_fingerprint_is_stale(self):
+		with tempfile.TemporaryDirectory() as directory:
+			root = Path(directory)
+			cargo = root / "Cargo.toml"
+			cargo.write_text("[workspace]\n")
+			manifest = {"schema_version": 2, "tool": "rustc-mir",
+				"toolchain": graph.collect_mir.TOOLCHAIN, "timeout_seconds": 900,
+				"requested_packages": [], "packages": [],
+				"provenance": semantic_provenance(
+					"rustc-mir", graph.analysis_provenance.tree_fingerprint(root))}
+			path = root / "manifest.json"
+			graph.validate_semantic_manifest(manifest, path, "rustc-mir", root)
+			cargo.write_text("[workspace]\nmembers = []\n")
+			with self.assertRaisesRegex(ValueError, "source fingerprint is stale"):
+				graph.validate_semantic_manifest(manifest, path, "rustc-mir", root)
+
+	def test_semantic_manifest_should_reject_escaping_artifact_paths(self):
+		package = {"package": "p", "owner": "pallet:p", "manifest": "pallets/p/Cargo.toml"}
+		provenance = semantic_provenance("rustc-mir")
+		command = graph.collect_mir.mir_command(package)
+		manifest = {"schema_version": 2, "tool": "rustc-mir",
+			"toolchain": graph.collect_mir.TOOLCHAIN, "timeout_seconds": 900,
+			"requested_packages": ["p"], "provenance": provenance,
+			"packages": [{**package, "status": "ok", "artifact": "../outside.mir",
+				"command": command, "input_fingerprint": graph.analysis_provenance.command_fingerprint(
+					provenance, package, command), "artifact_sha256": "3" * 64}]}
+		with tempfile.TemporaryDirectory() as directory:
+			path = Path(directory) / "manifest.json"
+			with self.assertRaisesRegex(ValueError, "stay inside"):
+				graph.validate_semantic_manifest(manifest, path, "rustc-mir")
+
+	def test_rapx_manifest_should_require_every_requested_analysis(self):
+		manifest = {"schema_version": 2, "tool": "rapx", "toolchain": graph.collect_rapx.TOOLCHAIN,
+			"timeout_seconds": 300, "requested_packages": ["p"],
+			"requested_analyses": ["callgraph", "dataflow"],
+			"provenance": semantic_provenance("rapx"),
+			"packages": [{"package": "p", "owner": "pallet:p", "manifest": "pallets/p/Cargo.toml",
+				"analyses": {"callgraph": {"status": "timeout", "path": "p.txt",
+					"input_fingerprint": "2" * 64}}}]}
+		with tempfile.TemporaryDirectory() as directory:
+			with self.assertRaisesRegex(ValueError, "analysis inventory is incomplete"):
+				graph.validate_semantic_manifest(manifest, Path(directory) / "manifest.json", "rapx")
+
+	def test_semantic_manifest_should_bind_artifact_to_exact_command(self):
+		package = {"package": "p", "owner": "pallet:p", "manifest": "pallets/p/Cargo.toml"}
+		provenance = semantic_provenance("rustc-mir")
+		command = graph.collect_mir.mir_command(package)
+		manifest = {"schema_version": 2, "tool": "rustc-mir",
+			"toolchain": graph.collect_mir.TOOLCHAIN, "timeout_seconds": 900,
+			"requested_packages": ["p"], "provenance": provenance,
+			"packages": [{**package, "status": "timeout", "artifact": "p.mir",
+				"command": [*command, "--tampered"],
+				"input_fingerprint": graph.analysis_provenance.command_fingerprint(
+					provenance, package, command)}]}
+		with tempfile.TemporaryDirectory() as directory:
+			with self.assertRaisesRegex(ValueError, "artifact command is invalid"):
+				graph.validate_semantic_manifest(manifest, Path(directory) / "manifest.json", "rustc-mir")
+
+	def test_semantic_manifest_should_reject_tampered_tool_input_aggregate(self):
+		provenance = semantic_provenance("rustc-mir")
+		provenance["tool_inputs"] = {**provenance["tool_inputs"],
+			"files": {**provenance["tool_inputs"]["files"], "collect_mir.py": "f" * 64}}
+		manifest = {"schema_version": 2, "tool": "rustc-mir",
+			"toolchain": graph.collect_mir.TOOLCHAIN, "timeout_seconds": 900,
+			"requested_packages": [], "packages": [], "provenance": provenance}
+		with self.assertRaisesRegex(ValueError, "verified source provenance"):
+			graph.validate_semantic_manifest(manifest, Path("manifest.json"), "rustc-mir")
+
+	def test_semantic_manifest_should_bind_package_metadata_to_workspace(self):
+		with tempfile.TemporaryDirectory() as directory:
+			root = Path(directory)
+			package = {"package": "p", "owner": "pallet:wrong", "manifest": "pallets/p/Cargo.toml"}
+			provenance = semantic_provenance("rustc-mir", graph.analysis_provenance.tree_fingerprint(root))
+			command = graph.collect_mir.mir_command(package)
+			manifest = {"schema_version": 2, "tool": "rustc-mir",
+				"toolchain": graph.collect_mir.TOOLCHAIN, "timeout_seconds": 900,
+				"requested_packages": ["p"], "provenance": provenance,
+				"packages": [{**package, "status": "timeout", "artifact": "p.mir",
+					"command": command, "input_fingerprint": graph.analysis_provenance.command_fingerprint(
+						provenance, package, command)}]}
+			workspace = [{"package": "p", "owner": "pallet:p", "manifest": "pallets/p/Cargo.toml"}]
+			with mock.patch.object(graph.collect_rapx, "workspace_packages", return_value=workspace):
+				with self.assertRaisesRegex(ValueError, "does not match the workspace"):
+					graph.validate_semantic_manifest(manifest, root / "manifest.json", "rustc-mir", root)
+
+	def test_rustc_mir_should_attach_cfg_ordering_to_matching_function(self):
+		g = graph.Graph()
+		g.node("function:trade", "function", name="trade", owner="pallet:hsm",
+			file="pallets/hsm/src/pallet.rs", line=2)
+		output = """fn <impl at pallets/hsm/src/pallet.rs:1:1: 1:20>::trade(_1: &T, _2: impl FnOnce(A) -> B) -> Result<(), E> {
+    bb0: {
+        _3 = StorageMap::<Prefix, Blake2, K, V>::insert(copy _1, copy _2) -> [return: bb1, unwind: bb3];
+    }
+    bb1: {
+        _4 = <Currency as Mutate<Account>>::transfer(copy _1, copy _2) -> [return: bb2, unwind: bb3];
+    }
+    bb2: {
+        _5 = StorageValue::<Other>::put(copy _4) -> [return: bb3, unwind: bb3];
+    }
+    bb3: { return; }
+}
+"""
+		with tempfile.TemporaryDirectory() as directory:
+			path = Path(directory) / "hsm.mir"
+			path.write_text(output)
+			self.assertEqual(graph.merge_rustc_mir(g, path, "pallet:hsm"), 3)
+		self.assertTrue(g.nodes["function:trade"]["mir_write_before_external"])
+		self.assertTrue(g.nodes["function:trade"]["mir_write_after_external"])
+		self.assertEqual(g.nodes["semantic-analysis:rustc-mir:pallet:hsm"]["matched_functions"], 1)
+		mir_edges = [edge for edge in g.edges if edge["kind"].startswith("mir-")]
+		self.assertTrue(any(edge["kind"] == "mir-control-flow" for edge in mir_edges))
+		self.assertTrue(any(edge["kind"] == "mir-unwind-flow" for edge in mir_edges))
+		self.assertTrue(any(edge["target"] == "boundary:external-execution" for edge in mir_edges))
+
+	def test_rustc_mir_should_reuse_exact_source_config_identity(self):
+		g = graph.Graph()
+		function = "function:request_fund"
+		targets = {f"associated:pallet:liquidity-mining:Instance{index}:MultiCurrency" for index in (1, 2)}
+		g.node(function, "function", name="request_fund", owner="pallet:liquidity-mining")
+		for target in targets:
+			instance = target.split(":")[-2]
+			g.node(target, "associated-type", associated_type="MultiCurrency",
+				config_trait="pallet_liquidity_mining::Config", config_instance=instance,
+				runtime_instance=f"runtime-instance:{instance}", unresolved=False)
+			g.edge(function, target, "dynamic-call", method="transfer",
+				config_trait="pallet_liquidity_mining::Config", config_instance=instance)
+		output = """fn request_fund() -> Result<(), E> {
+    bb0: {
+        _1 = <<T as pallet::Config<I>>::MultiCurrency as Currency<A>>::transfer(_2, _3) -> [return: bb1, unwind: bb2];
+    }
+    bb1: { return; }
+    bb2: { resume; }
+}
+"""
+		with tempfile.TemporaryDirectory() as directory:
+			path = Path(directory) / "dispenser.mir"
+			path.write_text(output)
+			graph.merge_rustc_mir(g, path, "pallet:liquidity-mining")
+		mir_edges = [edge for edge in g.edges if edge["kind"] == "mir-dynamic-call"]
+		self.assertEqual({edge["target"] for edge in mir_edges}, targets)
+		self.assertTrue(all(edge["config_trait"] == "pallet_liquidity_mining::Config"
+			for edge in mir_edges))
+
+	def test_rustc_mir_generic_fallback_should_exclude_unconfigured_declaration_node(self):
+		g = graph.Graph()
+		function = "function:adjust"
+		g.node(function, "function", name="adjust", owner="pallet:liquidity-mining")
+		g.node("associated:pallet:liquidity-mining:PriceAdjustment", "associated-type",
+			associated_type="PriceAdjustment", config_trait="pallet_liquidity_mining::Config",
+			config_instance=None, unresolved=False)
+		targets = set()
+		for index in (1, 2):
+			instance = f"Instance{index}"
+			target = f"associated:pallet:liquidity-mining:{instance}:PriceAdjustment"
+			targets.add(target)
+			g.node(target, "associated-type", associated_type="PriceAdjustment",
+				config_trait="pallet_liquidity_mining::Config", config_instance=instance,
+				runtime_instance=f"runtime-instance:{instance}", unresolved=False)
+		output = """fn adjust() -> Result<(), E> {
+    bb0: {
+        _1 = <<T as pallet::Config<I>>::PriceAdjustment as Adjustment<A>>::get(_2) -> [return: bb1, unwind: bb2];
+    }
+    bb1: { return; }
+    bb2: { resume; }
+}
+"""
+		with tempfile.TemporaryDirectory() as directory:
+			path = Path(directory) / "liquidity-mining.mir"
+			path.write_text(output)
+			graph.merge_rustc_mir(g, path, "pallet:liquidity-mining")
+		self.assertEqual({edge["target"] for edge in g.edges if edge["kind"] == "mir-dynamic-call"}, targets)
+
+	def test_runtime_mir_should_require_exact_source_file_for_same_named_functions(self):
+		g = graph.Graph()
+		root_call = "function:runtime/hydradx/src/lib.rs:call"
+		runner_call = "function:runtime/hydradx/src/evm/runner.rs:call"
+		g.node(root_call, "function", name="call", owner="runtime:hydradx",
+			file="runtime/hydradx/src/lib.rs", line=100)
+		g.node(runner_call, "function", name="call", owner="component:evm:runner",
+			file="runtime/hydradx/src/evm/runner.rs", line=20)
+		output = """fn <impl at runtime/hydradx/src/evm/runner.rs:10:1: 10:20>::call() -> Result<(), E> {
+    bb0: {
+        _1 = <Evm as hydradx_traits::evm::EVM<Result>>::call(_2) -> [return: bb1, unwind: bb2];
+    }
+    bb1: { return; }
+    bb2: { resume; }
+}
+"""
+		with tempfile.TemporaryDirectory() as directory:
+			path = Path(directory) / "runtime.mir"
+			path.write_text(output)
+			graph.merge_rustc_mir(g, path, "runtime:hydradx")
+		self.assertTrue(any(edge["source"] == runner_call and edge["kind"] == "has-mir-instance"
+			for edge in g.edges))
+		self.assertFalse(any(edge["source"] == root_call and edge["kind"] == "has-mir-instance"
+			for edge in g.edges))
+		instance = next(node for node in g.nodes.values() if node["kind"] == "mir-instance")
+		self.assertEqual(instance["owner"], "component:evm:runner")
+
+	def test_mir_ordering_should_follow_branches_without_conflating_paths(self):
+		blocks = {
+			0: {"operations": [], "successors": [1, 2]},
+			1: {"operations": [{"kind": "storage-write"}], "successors": [3]},
+			2: {"operations": [{"kind": "external-call"}], "successors": [3]},
+			3: {"operations": [{"kind": "storage-write"}], "successors": []},
+		}
+		self.assertEqual(graph.mir_order_flags(blocks), (False, True))
+
+	def test_mir_operations_should_cover_storage_nmap_and_evm(self):
+		self.assertEqual(graph.mir_operation("StorageNMap::<Prefix, Keys, V>::insert(_1, _2)"), "storage-write")
+		self.assertEqual(graph.mir_operation(
+			"<T::Evm as hydradx_traits::evm::EVM<Result>>::call(_1, _2)"), "evm-call")
+		self.assertEqual(graph.mir_operation("frame_support::storage::with_transaction::<(), E, F>(_1)"),
+			"transaction-start")
+
+	def test_contract_manifest_should_merge_aliases_abi_and_runtime_links(self):
+		g = graph.Graph()
+		graph.ensure_evm_selector(g, "supply(address,uint256)")
+		payload = {"substrate_snapshot": {"block_hash": "0xabc"}, "contracts": [{"project": "aave-v3-deploy", "network": "hydration",
+			"name": "Pool-Proxy-Hydration", "address": "0x1111111111111111111111111111111111111111",
+			"artifact": "deployments/hydration/pool.json", "abi_signatures": ["supply(address,uint256)"]}],
+			"runtime_configurations": [{"component": "pallet:liquidation", "storage": "liquidation.borrowingContract",
+				"address": "0x1111111111111111111111111111111111111111"}],
+			"observations": [{"project": "aave-v3-deploy", "network": "hydration",
+				"address": "0x1111111111111111111111111111111111111111", "has_code": True,
+				"implementation": "0x2222222222222222222222222222222222222222", "embedded_addresses": []}]}
+		with tempfile.TemporaryDirectory() as directory:
+			path = Path(directory) / "contracts.json"
+			path.write_text(__import__("json").dumps(payload))
+			self.assertEqual(graph.merge_contracts(g, path), 1)
+		contract = "deployed-contract:aave-v3-deploy:hydration:0x1111111111111111111111111111111111111111"
+		self.assertEqual(g.nodes[contract]["network"], "hydration")
+		self.assertTrue(any(edge["source"] == "component:evm:aave_trade_executor" and edge["target"] == contract
+			for edge in g.edges))
+		self.assertTrue(any(node.get("signature") == "supply(address,uint256)" for node in g.nodes.values()))
+		self.assertTrue(any(edge["kind"] == "selector-matches-contract-function" for edge in g.edges))
+		self.assertTrue(g.nodes[contract]["has_code"])
+		self.assertTrue(any(edge["source"] == "pallet:liquidation" and edge["target"] == contract
+			and edge["kind"] == "runtime-configures-contract" for edge in g.edges))
+		self.assertTrue(any(edge["source"] == contract and edge["kind"] == "proxy-implementation" for edge in g.edges))
+
+	def test_contract_snapshot_diff_should_report_proxy_and_code_changes(self):
+		before = {"observations": [{"project": "p", "network": "n", "address": "0x1",
+			"bytecode_sha256": "old", "implementation": "0xa"}]}
+		after = {"observations": [{"project": "p", "network": "n", "address": "0x1",
+			"bytecode_sha256": "new", "implementation": "0xb"}]}
+		result = snapshot_diff.diff(before, after)
+		self.assertEqual(len(result["changed"]), 1)
+		self.assertEqual(set(result["changed"][0]["changes"]), {"bytecode_sha256", "implementation"})
+
+	def test_graph_diff_should_report_added_nodes_and_edges(self):
+		before = {"nodes": [{"id": "a"}], "edges": []}
+		after = {"nodes": [{"id": "a"}, {"id": "b"}],
+			"edges": [{"source": "a", "target": "b", "kind": "calls"}]}
+		result = graph_diff.diff(before, after)
+		self.assertEqual(result["nodes_added"], ["b"])
+		self.assertEqual({key: result["edges_added"][0][key] for key in ("source", "target", "kind")},
+			{"source": "a", "target": "b", "kind": "calls"})
+		self.assertEqual(result["nodes_changed"], [])
+		self.assertEqual(result["edges_changed"], [])
+
+	def test_graph_diff_should_prioritize_added_and_removed_security_edges(self):
+		before = {"nodes": [], "edges": [
+			{"source": "precompile:assets", "target": "boundary:external-execution",
+				"kind": "external-execution"},
+		]}
+		after = {"nodes": [], "edges": [
+			{"source": "origin:root", "target": "function:x", "kind": "authorizes-entry"},
+			{"source": "a", "target": "b", "kind": "contains"},
+		]}
+		result = graph_diff.diff(before, after)
+		self.assertEqual(len(result["review_edges_added"]), 1)
+		self.assertEqual(len(result["review_edges_removed"]), 1)
+		markdown = graph_diff.markdown(result)
+		self.assertIn("New review-priority edges", markdown)
+		self.assertIn("Removed review-priority edges", markdown)
+
+	def test_graph_diff_should_collapse_line_variants_without_type_error(self):
+		before = {"nodes": [], "edges": []}
+		after = {"nodes": [], "edges": [
+			{"source": "a", "target": "b", "kind": "binding-resolves-to", "line": 10},
+			{"source": "a", "target": "b", "kind": "binding-resolves-to"},
+			{"source": "a", "target": "b", "kind": "binding-resolves-to", "method": "resolve"},
+		]}
+		result = graph_diff.diff(before, after)
+		self.assertEqual(len(result["edges_added"]), 2)
+		self.assertEqual(next(edge["location"]["line"] for edge in result["edges_added"]
+			if edge.get("method") is None), 10)
+
+	def test_graph_diff_should_ignore_location_only_changes(self):
+		before = {"nodes": [{"id": "a", "kind": "function", "file": "old.rs", "line": 1}], "edges": [
+			{"source": "a", "target": "b", "kind": "calls", "method": "run",
+				"file": "old.rs", "line": 10},
+		]}
+		after = {"nodes": [{"id": "a", "kind": "function", "file": "new.rs", "line": 2}], "edges": [
+			{"source": "a", "target": "b", "kind": "calls", "method": "run",
+				"file": "new.rs", "line": 20},
+		]}
+		result = graph_diff.diff(before, after)
+		self.assertEqual(result["edges_added"], [])
+		self.assertEqual(result["edges_removed"], [])
+		self.assertEqual(result["edges_changed"], [])
+		self.assertEqual(result["nodes_changed"], [])
+
+	def test_graph_diff_should_report_node_metadata_changes(self):
+		before = {"nodes": [{"id": "a", "kind": "function", "transactional": False, "line": 1}],
+			"edges": []}
+		after = {"nodes": [{"id": "a", "kind": "function", "transactional": True, "line": 2}],
+			"edges": []}
+		result = graph_diff.diff(before, after)
+		self.assertEqual(len(result["nodes_changed"]), 1)
+		self.assertFalse(result["nodes_changed"][0]["before"]["transactional"])
+		self.assertTrue(result["nodes_changed"][0]["after"]["transactional"])
+		self.assertIn("Changed nodes", graph_diff.markdown(result))
+
+	def test_graph_diff_should_preserve_semantic_edge_variants(self):
+		before = {"nodes": [], "edges": [
+			{"source": "function:a", "target": "storage:x", "kind": "storage-access",
+				"operation": "get", "line": 10},
+			{"source": "function:a", "target": "storage:x", "kind": "storage-access",
+				"operation": "put", "value": "old", "enforcement": "observation", "line": 20},
+		]}
+		after = {"nodes": [], "edges": [
+			{"source": "function:a", "target": "storage:x", "kind": "storage-access",
+				"operation": "get", "line": 11},
+			{"source": "function:a", "target": "storage:x", "kind": "storage-access",
+				"operation": "mutate", "value": "new", "enforcement": "runtime", "line": 21},
+		]}
+		result = graph_diff.diff(before, after)
+		self.assertEqual(result["edges_added"], [])
+		self.assertEqual(result["edges_removed"], [])
+		self.assertEqual(len(result["edges_changed"]), 1)
+		self.assertEqual([edge["operation"] for edge in result["edges_changed"][0]["before"]], ["put"])
+		self.assertEqual([edge["operation"] for edge in result["edges_changed"][0]["after"]], ["mutate"])
+		self.assertEqual(result["edges_changed"][0]["before"][0]["value"], "old")
+		self.assertEqual(result["edges_changed"][0]["after"][0]["value"], "new")
+		self.assertEqual(result["edges_changed"][0]["before"][0]["enforcement"], "observation")
+		self.assertEqual(result["edges_changed"][0]["after"][0]["enforcement"], "runtime")
+
+	def test_graph_diff_should_describe_changed_priority_edge_semantics(self):
+		before = {"nodes": [], "edges": [{
+			"source": "operation:withdraw", "target": "invariant:shares", "kind": "enforces",
+			"enforcement": "observation",
+		}]}
+		after = {"nodes": [], "edges": [{
+			"source": "operation:withdraw", "target": "invariant:shares", "kind": "enforces",
+			"enforcement": "runtime",
+		}]}
+		result = graph_diff.diff(before, after)
+		self.assertEqual(len(result["review_edges_changed"]), 1)
+		markdown = graph_diff.markdown(result)
+		self.assertIn("Changed review-priority edges", markdown)
+		self.assertIn("before: enforcement=observation", markdown)
+		self.assertIn("after: enforcement=runtime", markdown)
+
+	def test_coverage_comparison_should_enforce_regression_budgets(self):
+		thresholds = {"regression": {
+			"maximum_drop": {"entrypoints": 2},
+			"maximum_increase": {"unresolved_targets": 1},
+		}}
+		result = graph_diff.compare_coverage(
+			{"entrypoints": 100, "unresolved_targets": 10},
+			{"entrypoints": 97, "unresolved_targets": 12},
+			thresholds,
+		)
+		self.assertEqual(len(result["regressions"]), 2)
+		self.assertEqual(result["changes"], {"entrypoints": -3, "unresolved_targets": 2})
+
+	def test_coverage_comparison_should_enforce_absolute_thresholds(self):
+		result = graph_diff.compare_coverage(
+			{"nodes": 100, "unresolved_targets": 5},
+			{"nodes": 99, "unresolved_targets": 6},
+			{"minimum": {"nodes": 100}, "maximum": {"unresolved_targets": 5}},
+		)
+		self.assertEqual(len(result["regressions"]), 2)
+
+	def test_coverage_comparison_should_enforce_exact_inventory_classification(self):
+		expected = {"migration-not-configured": 2}
+		result = graph_diff.compare_coverage(
+			{"inventory_only_targets_by_reason": expected},
+			{"inventory_only_targets_by_reason": {"migration-not-configured": 3}},
+			{"exact": {"inventory_only_targets_by_reason": expected}},
+		)
+		self.assertEqual(len(result["regressions"]), 1)
+
+	def test_dangerous_rules_should_detect_evm_frame_and_state_ordering(self):
+		g = graph.Graph()
+		g.node("function:f", "function", operations=[
+			{"kind": "storage-write"}, {"kind": "external-call"}, {"kind": "storage-write"},
+		])
+		items = graph.dangerous_interactions(g, [], [[
+			"boundary:evm-execution", "precompile:dispatch", "boundary:frame-dispatch",
+		]])
+		self.assertEqual({item["rule"] for item in items},
+			{"evm-precompile-frame-dispatch", "state-write-around-external-call"})
+
+
+class HydrationRuntimeGraphTests(unittest.TestCase):
+	@classmethod
+	def setUpClass(cls):
+		cls.graph = graph.scan(MODULE.parents[2])
+		cls.components = graph.resolved_component_edges(cls.graph, graph.component_edges(cls.graph))
+
+	def test_route_executor_should_reach_evm_through_hsm(self):
+		paths = graph.bounded_paths(self.components, {"boundary:evm-execution"})
+		self.assertIn(
+			["pallet:route-executor", "pallet:hsm", "boundary:evm-execution"],
+			paths,
+		)
+
+	def test_evm_should_reach_frame_dispatch_precompile(self):
+		paths = graph.bounded_paths(self.components, {"boundary:frame-dispatch"})
+		self.assertIn(
+			["boundary:evm-execution", "precompile:dispatch", "boundary:frame-dispatch"],
+			paths,
+		)
+
+	def test_runtime_evm_selectors_should_be_first_class_nodes(self):
+		signatures = {node["signature"] for node in self.graph.nodes.values() if node["kind"] == "evm-signature"}
+		self.assertTrue({"supply(address,uint256,address,uint16)", "withdraw(address,uint256,address)",
+			"balanceOf(address)"}.issubset(signatures))
+		precompile_entrypoints = [node for node in self.graph.nodes.values()
+			if node.get("entrypoint_kind") == "precompile-selector"]
+		selector_targets = {edge["source"]: edge["target"] for edge in self.graph.edges
+			if edge["kind"] == "dispatches-evm-selector"}
+		self.assertTrue(precompile_entrypoints)
+		self.assertTrue(all(entrypoint["id"] in selector_targets for entrypoint in precompile_entrypoints))
+		self.assertTrue(all(selector_targets[entrypoint["id"]].startswith("evm-selector:0x")
+			for entrypoint in precompile_entrypoints))
+
+	def test_internal_executor_calls_should_reach_evm_boundary(self):
+		edges = {(edge["source"], edge["target"], edge["kind"], edge.get("method"))
+			for edge in self.components}
+		self.assertIn(("component:runtime:gigahdx", "component:evm:executor", "direct-call", "call"), edges)
+		self.assertIn(("component:evm:erc20_currency", "component:evm:executor", "direct-call", "call"), edges)
+		self.assertIn(("component:evm:erc20_currency", "component:evm:executor", "direct-call", "view"), edges)
+		self.assertIn(("component:evm:executor", "boundary:evm-execution", "enters-evm", None), edges)
+
+	def test_generated_selector_aliases_should_link_actual_evm_callsites(self):
+		def encoded(owner: str) -> set[str]:
+			return {signature for edge in self.graph.edges
+				if self.graph.nodes[edge["source"]].get("owner") == owner
+				and edge["kind"] == "encodes-evm-selector"
+				for signature in self.graph.nodes[edge["target"]].get("signatures", [])}
+
+		self.assertTrue({"supply(address,uint256,address,uint16)", "withdraw(address,uint256,address)"}
+			.issubset(encoded("component:runtime:gigahdx")))
+		self.assertTrue({"flashLoan(address,address,uint256,bytes)", "maxFlashLoan(address)",
+			"getFacilitatorBucket(address)"}.issubset(encoded("pallet:hsm")))
+
+	def test_chainlink_precompile_should_have_one_canonical_dynamic_identity(self):
+		chainlink = [node for node in self.graph.nodes.values()
+			if node["id"].startswith("precompile:runtime:chainlink")]
+		self.assertEqual([node["id"] for node in chainlink], ["precompile:runtime:chainlink_adapter"])
+		self.assertTrue(chainlink[0]["dynamic_address"])
+		self.assertEqual(chainlink[0]["address_predicate"], "is_oracle_address")
+		self.assertTrue(any(node.get("owner") == chainlink[0]["id"]
+			for node in self.graph.nodes.values() if node["kind"] == "function"))
+		execute = next(node for node in self.graph.nodes.values()
+			if node.get("owner") == chainlink[0]["id"] and node.get("name") == "execute")
+		dispatched = {self.graph.nodes[edge["target"]]["signatures"][0] for edge in self.graph.edges
+			if edge["kind"] == "dispatches-evm-selector"
+			and self.graph.nodes[edge["source"]].get("entrypoint_kind") == "precompile-selector"
+			and any(link["kind"] == "enters-function" and link["source"] == edge["source"]
+				and link["target"] == execute["id"] for link in self.graph.edges)}
+		self.assertEqual(dispatched, {"getAnswer(uint256)", "latestAnswer()", "decimals()"})
+		self.assertFalse(any(edge["source"] == execute["id"] and edge["kind"] == "encodes-evm-selector"
+			for edge in self.graph.edges))
+
+	def test_multicurrency_precompile_should_link_imported_erc20_selectors(self):
+		execute = next(node for node in self.graph.nodes.values()
+			if node.get("owner") == "precompile:runtime:multicurrency" and node.get("name") == "execute")
+		entrypoints = {edge["source"] for edge in self.graph.edges
+			if edge["kind"] == "enters-function" and edge["target"] == execute["id"]
+			and self.graph.nodes[edge["source"]].get("entrypoint_kind") == "precompile-selector"}
+		self.assertEqual(len(entrypoints), 11)
+		selectors = {self.graph.nodes[entrypoint]["signature"] for entrypoint in entrypoints}
+		self.assertTrue({"balanceOf(address)", "transfer(address,uint256)", "transferFrom(address,address,uint256)",
+			"mint(address,uint256)", "burn(uint256)"}.issubset(selectors))
+		self.assertEqual({edge["source"] for edge in self.graph.edges
+			if edge["kind"] == "dispatches-evm-selector" and edge["source"] in entrypoints}, entrypoints)
+		self.assertFalse(any(edge["source"] == execute["id"] and edge["kind"] == "encodes-evm-selector"
+			for edge in self.graph.edges))
+
+	def test_precompile_utilities_and_build_helpers_should_not_be_runtime_entrypoints(self):
+		self.assertFalse(any(node.get("owner") == "precompile:utils" and node.get("entrypoint_kind")
+			for node in self.graph.nodes.values()))
+		self.assertFalse(any(node["id"].startswith("component:evm:evm-utility")
+			for node in self.graph.nodes.values()))
+		self.assertFalse(any(node.get("file") == "runtime/hydradx/src/helpers.rs"
+			for node in self.graph.nodes.values()))
+		self.assertFalse(any(node.get("file") == "runtime/hydradx/src/lib.rs"
+			and node.get("name") in {"benchmark_metadata", "dispatch_benchmark"}
+			for node in self.graph.nodes.values()))
+
+	def test_external_test_and_test_utility_modules_should_not_be_scanned(self):
+		excluded = {
+			"external/pallet_message_queue/integration_test.rs",
+			"external/pallet_xcm/xcm_helpers.rs",
+		}
+		self.assertFalse(any(node.get("file") in excluded for node in self.graph.nodes.values()))
+
+	def test_benchmark_runtime_bindings_should_not_replace_production_bindings(self):
+		bindings = [(edge["source"], self.graph.nodes[edge["target"]].get("value", ""))
+			for edge in self.graph.edges if edge["kind"] == "config-binding"]
+		self.assertFalse(any(source == "pallet:message-queue" and "NoopMessageProcessor" in value
+			for source, value in bindings))
+		self.assertTrue(any(source == "pallet:message-queue" and "ProcessXcmWithBreaker" in value
+			for source, value in bindings))
+
+	def test_active_runtime_associated_targets_should_all_resolve(self):
+		self.assertFalse(any(node.get("unresolved") for node in self.graph.nodes.values()))
+		associated_edge_kinds = {"dynamic-call", "configured-origin", "runtime-config-read",
+			"runtime-config-type-reference", "weight-evaluation"}
+		active_edges = [edge for edge in self.graph.edges if edge["kind"] in associated_edge_kinds
+			and self.graph.nodes.get(edge["target"], {}).get("associated_type")
+			and graph.edge_runtime_active(self.graph, edge)]
+		self.assertGreater(len(active_edges), 100)
+		self.assertFalse([(edge["source"], edge["target"], edge["kind"]) for edge in active_edges
+			if not edge.get("config_trait") or not self.graph.nodes[edge["target"]].get("config_trait")])
+		self.assertFalse(any(node["id"].startswith(("associated:component:evm:runner:",
+			"associated:component:evm:executor:", "associated:component:evm:aave_trade_executor:"))
+			for node in self.graph.nodes.values()))
+		evm_files = {
+			"runtime/hydradx/src/evm/runner.rs",
+			"runtime/hydradx/src/evm/executor.rs",
+			"runtime/hydradx/src/evm/aave_trade_executor.rs",
+		}
+		evm_edges = [edge for edge in self.graph.edges if edge["kind"] in associated_edge_kinds
+			and edge.get("file") in evm_files and self.graph.nodes[edge["target"]].get("associated_type")
+			in {"AccountProvider", "AddressMapping", "BlockGasLimit", "ChainId", "FeeCalculator",
+				"GasWeightMapping", "PrecompilesValue"}]
+		self.assertGreater(len(evm_edges), 10)
+		self.assertTrue(all(edge.get("config_trait") == "pallet_evm::Config"
+			and self.graph.nodes[edge["target"]].get("config_trait") == "pallet_evm::Config"
+			for edge in evm_edges))
+
+	def test_runtime_and_generic_evm_ufcs_calls_should_resolve_exactly(self):
+		files = {
+			"runtime/hydradx/src/lib.rs",
+			"runtime/hydradx/src/gigahdx.rs",
+			"runtime/hydradx/src/evm/permit.rs",
+		}
+		for source in files:
+			edges = [edge for edge in self.graph.edges if edge.get("file") == source
+				and edge.get("config_trait") == "pallet_evm::Config"
+				and self.graph.nodes.get(edge["target"], {}).get("associated_type")]
+			self.assertGreater(len(edges), 0, source)
+			self.assertTrue(all(self.graph.nodes[edge["target"]].get("config_trait") == "pallet_evm::Config"
+				for edge in edges), source)
+
+	def test_explicit_child_config_should_not_resolve_to_redeclared_parent_type(self):
+		edges = [edge for edge in self.graph.edges if edge.get("file") == "pallets/dispenser/src/lib.rs"
+			and edge.get("method") in {"balance", "transfer"}
+			and edge["target"].startswith("associated:")
+			and self.graph.nodes.get(edge["target"], {}).get("associated_type") == "Currency"]
+		self.assertGreater(len(edges), 0)
+		self.assertEqual({edge["target"] for edge in edges}, {"associated:pallet:dispenser:Currency"})
+
+	def test_collective_config_should_resolve_to_exact_runtime_instance(self):
+		self.assertNotIn("pallet:collective-technical-committee", self.graph.nodes)
+		for associated_type in ("Consideration", "DefaultVote", "DisapproveOrigin", "KillOrigin",
+			"SetMembersOrigin"):
+			node = self.graph.nodes[f"associated:pallet:collective:Instance2:{associated_type}"]
+			self.assertFalse(node["unresolved"])
+			self.assertEqual(node["config_trait"], "pallet_collective::Config")
+			self.assertEqual(node["config_instance"], "Instance2")
+			self.assertEqual(node["runtime_instance"], "runtime-instance:TechnicalCommittee")
+
+	def test_gat_runtime_binding_should_resolve_try_call_currency(self):
+		target = "associated:pallet:transaction-multi-payment:TryCallCurrency"
+		node = self.graph.nodes[target]
+		self.assertFalse(node["unresolved"])
+		self.assertIn("TryConvert<&'a", node["trait_bounds"])
+		self.assertTrue(any(edge["source"] == target and edge["target"] == "component:runtime:assets"
+			and edge["kind"] == "binding-resolves-to" for edge in self.graph.edges))
+
+	def test_inventory_only_associated_targets_should_be_explicit_and_excluded(self):
+		expected = {
+			"associated:pallet:aura:PalletPrefix": "migration-not-configured",
+			"associated:pallet:cumulus-pallet-xcmp-queue:ChannelList": "migration-not-configured",
+			"associated:pallet:nft:Permissions": "component-not-instantiated",
+			"associated:pallet:session:historical:FullIdentificationOf": "config-trait-not-implemented",
+			"associated:pallet:xcm-rate-limiter:CurrencyIdConvert": "component-not-instantiated",
+			"associated:pallet:xcm-rate-limiter:RelayBlockNumberProvider": "component-not-instantiated",
+		}
+		inventory_only = {node["id"]: node.get("runtime_activity_reason") for node in self.graph.nodes.values()
+			if node.get("runtime_active") is False and node.get("kind") == "associated-type"}
+		self.assertEqual(inventory_only, expected)
+		for projection in ("execution", "callback"):
+			self.assertFalse(any(edge["source"] in expected or edge["target"] in expected
+				for edge in graph.projected_edges(self.graph, projection)))
+
+	def test_configured_xcm_migration_helper_should_remain_runtime_active(self):
+		migration_file = "external/pallet_xcm/migration.rs"
+		helper = next(node for node in self.graph.nodes.values()
+			if node.get("kind") == "function" and node.get("file") == migration_file
+			and node.get("name") == "migrate_data_to_xcm_version")
+		self.assertTrue(helper["runtime_active"])
+		calls = [edge for edge in self.graph.edges if edge["target"] == helper["id"]
+			and edge.get("resolution") == "source-local-migration"]
+		self.assertEqual(len(calls), 1)
+		self.assertTrue(self.graph.nodes[calls[0]["source"]]["runtime_active"])
+		self.assertTrue(graph.edge_runtime_active(self.graph, calls[0]))
+
+	def test_active_nested_module_functions_should_not_inherit_phantom_configs(self):
+		active = [node for node in self.graph.nodes.values() if node.get("kind") == "function" and (
+			node.get("file") == "external/cumulus_pallet_aura_ext/consensus_hook.rs"
+			or node.get("file") == "pallets/broadcast/src/types.rs")]
+		self.assertGreaterEqual(len(active), 4)
+		self.assertTrue(all(node.get("runtime_active") is not False for node in active))
+		self.assertTrue(all(node.get("source_config_trait") in {
+			"cumulus_pallet_aura_ext::Config", "pallet_broadcast::Config"} for node in active))
+
+	def test_call_permit_should_record_nonce_write_before_evm_subcall(self):
+		candidates = [node for node in self.graph.nodes.values()
+			if node["kind"] == "audit-candidate" and "precompiles/call-permit/src/lib.rs" in node["id"]]
+		self.assertEqual(len(candidates), 1)
+		self.assertTrue(candidates[0]["storage_before"])
+		self.assertFalse(candidates[0]["storage_after"])
+
+	def test_asset_registry_should_define_runtime_asset_kinds(self):
+		for kind in ("Token", "XYK", "StableSwap", "Bond", "External", "Erc20"):
+			self.assertEqual(self.graph.nodes[f"asset-kind:{kind}"]["source"],
+				"pallets/asset-registry/src/types.rs")
+
+	def test_route_executor_should_resolve_all_runtime_amm_backends(self):
+		targets = {edge["target"] for edge in self.components
+			if edge["source"] == "pallet:route-executor" and edge["kind"] == "resolved-call"}
+		self.assertTrue({"pallet:omnipool", "pallet:stableswap", "pallet:xyk", "pallet:lbp", "pallet:hsm",
+			"component:evm:aave_trade_executor"}.issubset(targets))
+
+	def test_evm_runner_binding_should_only_resolve_to_outer_callback(self):
+		targets = {edge["target"] for edge in self.graph.edges
+			if edge["source"] == "associated:pallet:evm:Runner"
+			and edge["kind"] == "binding-resolves-to"}
+		self.assertEqual(targets, {"component:evm:runner"})
+
+	def test_warehouse_liquidity_mining_instances_should_share_canonical_owner(self):
+		expected = {"runtime-instance:OmnipoolWarehouseLM", "runtime-instance:XYKWarehouseLM"}
+		instances = {edge["source"] for edge in self.graph.edges
+			if edge["kind"] == "instantiates" and edge["target"] == "pallet:liquidity-mining"}
+		self.assertTrue(expected.issubset(instances))
+		self.assertTrue(all(self.graph.nodes[instance]["owner"] == "pallet:liquidity-mining"
+			for instance in expected))
+		self.assertNotIn("pallet:warehouse-liquidity-mining", self.graph.nodes)
+
+	def test_asset_components_should_cover_balances_orml_tokens_and_erc20(self):
+		edges = {(edge["source"], edge["target"], edge["kind"]) for edge in self.components}
+		self.assertIn(("pallet:balances", "asset-backend:balances", "uses-asset-backend"), edges)
+		self.assertIn(("pallet:orml-tokens", "asset-backend:tokens", "uses-asset-backend"), edges)
+		self.assertNotIn("pallet:tokens", self.graph.nodes)
+		self.assertIn(("component:evm:erc20_currency", "asset-backend:erc20", "uses-asset-backend"), edges)
+		self.assertIn(("pallet:stableswap", "asset-kind:StableSwap", "issues-asset-kind"), edges)
+
+	def test_xcm_should_connect_message_and_asset_boundaries(self):
+		edges = {(edge["source"], edge["target"], edge["kind"]) for edge in self.components}
+		self.assertIn(("component:xcm:router", "boundary:xcm-outbound", "sends-xcm"), edges)
+		self.assertIn(("boundary:xcm-inbound", "component:xcm:executor", "receives-xcm"), edges)
+		self.assertIn(("component:xcm:asset-transactor", "asset-backend:xcm", "uses-asset-backend"), edges)
+
+	def test_runtime_entrypoints_should_include_extrinsics_hooks_callbacks_and_evm(self):
+		kinds = {node.get("entrypoint_kind") for node in self.graph.nodes.values() if node["kind"] == "entrypoint"}
+		self.assertTrue({"extrinsic", "runtime-hook", "runtime-callback", "precompile-selector",
+			"precompile-dispatch", "evm-adapter", "xcm-inbound", "runtime-api", "unsigned-validation",
+			"offchain-worker", "runtime-migration", "try-runtime"}.issubset(kinds))
+		signatures = {node.get("signature") for node in self.graph.nodes.values()
+			if node.get("entrypoint_kind") == "precompile-selector"}
+		self.assertIn("DOMAIN_SEPARATOR()", signatures)
+		entrypoints = [node for node in self.graph.nodes.values() if node["kind"] == "entrypoint"]
+		self.assertFalse(any("/weights.rs:" in node["id"] or "/weights/" in node["id"] for node in entrypoints))
+		self.assertFalse(any(node.get("method") in {"setup_set_code_requirements", "verify_set_code"}
+			for node in entrypoints))
+		self.assertFalse(any(node.get("method") == "init_omnipool" for node in entrypoints))
+
+	def test_associated_type_resolution_should_not_cross_pallet_scopes(self):
+		g = graph.Graph()
+		g.node("associated:pallet:a:Handler", "associated-type", associated_type="Handler", unresolved=True)
+		g.node("associated:pallet:b:Handler", "associated-type", associated_type="Handler", unresolved=True)
+		g.edge("associated:pallet:a:Handler", "pallet:target", "binding-resolves-to")
+		graph.enrich_unique_type_resolutions(g)
+		inferred = [edge for edge in g.edges if edge["source"] == "associated:pallet:b:Handler"]
+		self.assertEqual(inferred, [])
+		self.assertTrue(g.nodes["associated:pallet:b:Handler"]["unresolved"])
+
+	def test_unresolved_targets_should_retain_ambiguity_and_candidates(self):
+		g = graph.Graph()
+		g.node("associated:pallet:a:Handler", "associated-type", associated_type="Handler", unresolved=True)
+		g.node("pallet:first", "pallet")
+		g.node("pallet:second", "pallet")
+		g.edge("associated:pallet:a:Handler", "pallet:first", "binding-resolves-to")
+		g.edge("associated:pallet:a:Handler", "pallet:second", "binding-resolves-to")
+		graph.classify_unresolved(g)
+		node = g.nodes["associated:pallet:a:Handler"]
+		self.assertEqual(node["ambiguity_reason"], "multiple-runtime-targets")
+		self.assertEqual(node["candidate_targets"], ["pallet:first", "pallet:second"])
+
+	def test_inventory_only_associated_calls_should_remain_in_raw_graph_but_not_callback_projection(self):
+		g = graph.Graph()
+		g.node("pallet:inactive", "pallet", runtime_active=False)
+		g.node("function:inactive", "function", owner="pallet:inactive", runtime_active=False)
+		g.node("associated:pallet:inactive:Handler", "associated-type", owner="pallet:inactive",
+			associated_type="Handler", unresolved=True, runtime_active=False,
+			runtime_activity_reason="component-not-instantiated")
+		g.edge("function:inactive", "associated:pallet:inactive:Handler", "dynamic-call", method="call")
+		graph.classify_unresolved(g)
+		self.assertEqual(len(g.edges), 1)
+		self.assertEqual(graph.projected_edges(g, "callback"), [])
+		self.assertEqual(len(graph.projected_edges(g, "callback", active_only=False)), 1)
+		self.assertFalse(g.nodes["associated:pallet:inactive:Handler"]["unresolved"])
+		self.assertEqual(g.nodes["associated:pallet:inactive:Handler"]["resolution"], "inventory-only")
+
+	def test_incomplete_runtime_inventory_should_not_guess_that_config_is_inactive(self):
+		g = graph.Graph()
+		g.node("pallet:unknown", "pallet")
+		g.node("function:unknown", "function", owner="pallet:unknown",
+			source_config_trait="pallet_unknown::Config")
+		g.node("associated:pallet:unknown:Handler", "associated-type", owner="pallet:unknown",
+			associated_type="Handler", config_trait="pallet_unknown::Config", unresolved=True)
+		g.edge("function:unknown", "associated:pallet:unknown:Handler", "dynamic-call", method="call")
+		graph.classify_runtime_activity(g, set(), {}, False)
+		graph.classify_unresolved(g)
+		self.assertTrue(g.nodes["associated:pallet:unknown:Handler"]["unresolved"])
+		self.assertNotIn("runtime_active", g.nodes["associated:pallet:unknown:Handler"])
+
+	def test_associated_getters_should_be_config_values_not_callbacks(self):
+		g = graph.Graph()
+		g.node("associated:pallet:a:DbWeight", "associated-type", associated_type="DbWeight", unresolved=True,
+			associated_role="config-value", trait_bounds="Get<RuntimeDbWeight>")
+		g.edge("function:a", "associated:pallet:a:DbWeight", "dynamic-call", method="get")
+		graph.normalize_config_value_calls(g)
+		self.assertEqual(g.nodes["associated:pallet:a:DbWeight"]["kind"], "runtime-config-value")
+		self.assertEqual(g.edges[0]["kind"], "runtime-config-read")
+
+	def test_config_value_normalization_should_rewrite_edges_added_after_first_pass(self):
+		g = graph.Graph()
+		target = "associated:pallet:a:DbWeight"
+		g.node(target, "associated-type", associated_type="DbWeight", unresolved=True,
+			associated_role="config-value", trait_bounds="Get<RuntimeDbWeight>")
+		g.edge("function:source", target, "dynamic-call", method="get")
+		graph.normalize_config_value_calls(g)
+		g.edge("mir-operation:read", target, "mir-dynamic-call", method="get")
+		graph.normalize_config_value_calls(g)
+		self.assertEqual(g.nodes[target]["kind"], "runtime-config-value")
+		self.assertEqual([edge["kind"] for edge in g.edges],
+			["runtime-config-read", "runtime-config-read"])
+
+	def test_layered_visualizations_should_be_deterministic(self):
+		with tempfile.TemporaryDirectory() as directory:
+			out = Path(directory)
+			graph.write_outputs(self.graph, out)
+			paths = [out / "graph-scale.svg"] + [out / "focused" / name for name in
+				("component-dependencies.svg", "execution-boundaries.svg", "token-flows.svg")]
+			first = [path.read_bytes() for path in paths]
+			graph.write_outputs(self.graph, out)
+			self.assertEqual(first, [path.read_bytes() for path in paths])
+
+	def test_historical_component_paths_should_remain_reachable(self):
+		fixtures = __import__("json").loads(MODULE.with_name("historical-interactions.json").read_text())
+		paths = graph.bounded_paths(self.components,
+			{"boundary:evm-execution", "boundary:frame-dispatch"})
+		for required in fixtures["required_component_paths"]:
+			self.assertIn(required, paths)
+		properties = graph.historical_property_status(self.graph, self.components)
+		for required in fixtures["required_runtime_properties"]:
+			self.assertIn(required, properties)
+			self.assertTrue(properties[required], required)
+
+	def test_state_and_asset_semantics_should_be_first_class(self):
+		kinds = {node["kind"] for node in self.graph.nodes.values()}
+		self.assertIn("state-invariant", kinds)
+		self.assertIn("asset-operation", kinds)
+		self.assertTrue(any(edge["kind"] == "affects-invariant" for edge in self.graph.edges))
+		self.assertTrue(any(edge["kind"] == "asset-operation" for edge in self.graph.edges))
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/scripts/runtime-interaction-graph/test_runtime_interaction_graph.py
+++ b/scripts/runtime-interaction-graph/test_runtime_interaction_graph.py
@@ -1103,10 +1103,12 @@ class HydrationRuntimeGraphTests(unittest.TestCase):
 		entrypoints = {edge["source"] for edge in self.graph.edges
 			if edge["kind"] == "enters-function" and edge["target"] == execute["id"]
 			and self.graph.nodes[edge["source"]].get("entrypoint_kind") == "precompile-selector"}
-		self.assertEqual(len(entrypoints), 11)
 		selectors = {self.graph.nodes[entrypoint]["signature"] for entrypoint in entrypoints}
-		self.assertTrue({"balanceOf(address)", "transfer(address,uint256)", "transferFrom(address,address,uint256)",
-			"mint(address,uint256)", "burn(uint256)"}.issubset(selectors))
+		expected = set(graph.generated_selector_enums(
+			(MODULE.parents[2] / "runtime/hydradx/src/evm/erc20_currency.rs").read_text())["Function"].values())
+		self.assertEqual(selectors, expected)
+		self.assertTrue({"balanceOf(address)", "transfer(address,uint256)",
+			"transferFrom(address,address,uint256)"}.issubset(selectors))
 		self.assertEqual({edge["source"] for edge in self.graph.edges
 			if edge["kind"] == "dispatches-evm-selector" and edge["source"] in entrypoints}, entrypoints)
 		self.assertFalse(any(edge["source"] == execute["id"] and edge["kind"] == "encodes-evm-selector"

--- a/scripts/runtime-interaction-graph/test_runtime_inventory.py
+++ b/scripts/runtime-interaction-graph/test_runtime_inventory.py
@@ -1,0 +1,76 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE = Path(__file__).with_name("runtime_inventory.py")
+SPEC = importlib.util.spec_from_file_location("runtime_inventory", MODULE)
+inventory = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(inventory)
+
+
+class RuntimeInventoryTests(unittest.TestCase):
+	def test_construct_runtime_entries_should_not_cross_lines(self):
+		text = """
+		EVM: pallet_evm = 90,
+		Ethereum: pallet_ethereum = 92,
+		TechnicalCommittee: pallet_collective::<Instance2> exclude_parts { Config } = 25,
+		"""
+		self.assertEqual(inventory.construct_runtime_entries(text), [
+			{"alias": "EVM", "crate": "pallet_evm", "instance": None, "index": 90, "excluded_parts": []},
+			{"alias": "Ethereum", "crate": "pallet_ethereum", "instance": None, "index": 92,
+				"excluded_parts": []},
+			{"alias": "TechnicalCommittee", "crate": "pallet_collective", "instance": "Instance2",
+				"index": 25, "excluded_parts": ["Config"]},
+		])
+
+	def test_precompile_inventory_should_include_static_and_dynamic_routes(self):
+		text = """
+		pub const ECRECOVER: H160 = H160(hex!(\"0000000000000000000000000000000000000001\"));
+		pub const DISPATCH_ADDR: H160 = addr(1025);
+		if address == ECRECOVER { Some(ECRecover::execute(handle))
+		} else if address == DISPATCH_ADDR { Some(Dispatch::<R>::execute(handle))
+		} else if is_asset_address(address) { Some(MultiCurrencyPrecompile::<R>::execute(handle))
+		} else if is_oracle_address(address) { Some(ChainlinkOraclePrecompile::<R>::execute(handle))
+		}
+		"""
+		routes = inventory.precompile_inventory(text)
+		by_route = {route["route"]: route for route in routes}
+		self.assertEqual(by_route["ecrecover"]["address"], "0x" + "0" * 39 + "1")
+		self.assertEqual(by_route["dispatch-addr"]["address"], "0x" + "0" * 36 + "0401")
+		self.assertEqual(by_route["asset-address"]["predicate"], "is_asset_address")
+		self.assertTrue(by_route["oracle-address"]["dynamic"])
+
+	def test_active_external_sources_should_follow_file_and_module_cfgs(self):
+		with tempfile.TemporaryDirectory() as directory:
+			root = Path(directory)
+			(root / "lib.rs").write_text('''
+mod live;
+mod integration_test;
+#[cfg(any(test, feature = "test-utils"))]
+pub mod xcm_helpers;
+#[cfg(feature = "enabled")]
+mod enabled;
+#[cfg(not(feature = "std"))]
+mod wasm;
+''')
+			(root / "live.rs").write_text("pub fn live() {}\n")
+			(root / "integration_test.rs").write_text("#![cfg(test)]\npub fn test_only() {}\n")
+			(root / "xcm_helpers.rs").write_text("mod nested;\npub fn helper() {}\n")
+			(root / "xcm_helpers").mkdir()
+			(root / "xcm_helpers/nested.rs").write_text("pub fn nested() {}\n")
+			(root / "enabled.rs").write_text("pub fn enabled() {}\n")
+			(root / "wasm.rs").write_text("pub fn wasm() {}\n")
+			paths = {path.name for path in inventory.active_external_sources(root)}
+			self.assertEqual(paths, {"lib.rs", "live.rs", "enabled.rs", "wasm.rs"})
+
+	def test_cfg_value_should_retain_unknown_target_conditions_conservatively(self):
+		self.assertFalse(inventory.cfg_value('any(test, feature = "test-utils")'))
+		self.assertTrue(inventory.cfg_value('not(feature = "runtime-benchmarks")'))
+		self.assertIsNone(inventory.cfg_value('feature = "std"'))
+		self.assertIsNone(inventory.cfg_value('target_os = "linux"'))
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/scripts/runtime-interaction-graph/test_semantic_inventory.py
+++ b/scripts/runtime-interaction-graph/test_semantic_inventory.py
@@ -1,0 +1,120 @@
+import copy
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE = Path(__file__).with_name("semantic_inventory.py")
+INVENTORY = Path(__file__).with_name("semantic-inventory.json")
+SCHEMA = Path(__file__).with_name("semantic-inventory.schema.json")
+SPEC = importlib.util.spec_from_file_location("semantic_inventory", MODULE)
+semantic_inventory = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(semantic_inventory)
+
+
+class SemanticInventoryTests(unittest.TestCase):
+	@classmethod
+	def setUpClass(cls):
+		cls.payload = json.loads(INVENTORY.read_text(encoding="utf-8"))
+
+	def test_inventory_should_validate_against_local_rust_sources(self):
+		result = semantic_inventory.validate_inventory(copy.deepcopy(self.payload), ROOT)
+		self.assertGreaterEqual(result["coverage"]["node_count"], 30)
+		self.assertGreaterEqual(result["coverage"]["edge_count"], 35)
+		self.assertEqual(result["coverage"]["domains"], [
+			"asset-routing",
+			"circuit-breaker",
+			"omnipool",
+			"stableswap",
+			"xyk",
+		])
+		for item in result["nodes"] + result["edges"]:
+			self.assertEqual(item["semantic_source"], "explicit-inventory")
+			for evidence in item["evidence"]:
+				self.assertGreater(evidence["line"], 0)
+				self.assertRegex(evidence["source_sha256"], r"^[0-9a-f]{64}$")
+
+	def test_inventory_should_cover_requested_ledger_and_pool_semantics(self):
+		result = semantic_inventory.validate_inventory(copy.deepcopy(self.payload), ROOT)
+		edges = {(edge["source"], edge["kind"], edge["target"]) for edge in result["edges"]}
+		required = {
+			("router:currencies", "routes-to", "ledger:native-balances"),
+			("router:currencies", "routes-to", "ledger:orml-tokens"),
+			("router:currencies", "routes-to", "ledger:erc20-contracts"),
+			("operation:stableswap-add-liquidity", "mints", "ledger:stableswap-shares"),
+			("operation:stableswap-remove-liquidity", "burns", "ledger:stableswap-shares"),
+			("operation:stableswap-add-liquidity", "enforces", "invariant:stableswap-add-liquidity"),
+			("operation:stableswap-remove-liquidity", "enforces", "invariant:stableswap-remove-liquidity"),
+			("operation:stableswap-add-liquidity", "reads", "state:stableswap-share-issuance"),
+			("operation:stableswap-remove-liquidity", "reads", "state:stableswap-share-issuance"),
+			("state:stableswap-share-issuance", "tracks", "ledger:stableswap-shares"),
+			("invariant:stableswap-share-issuance-sync", "reads", "state:stableswap-share-issuance"),
+			("invariant:stableswap-share-issuance-sync", "reads", "ledger:stableswap-shares"),
+			("state:xyk-total-liquidity", "must-equal", "ledger:xyk-shares"),
+			("ledger:xyk-reserves", "backs", "ledger:xyk-shares"),
+			("state:omnipool-positions", "must-equal", "state:omnipool-lp-shares"),
+			("state:omnipool-assets", "must-equal", "ledger:omnipool-hub-reserve"),
+			("guard:issuance-increase-fuse", "reads", "router:routed-total-issuance"),
+			("operation:orml-token-deposit", "invokes", "guard:issuance-increase-fuse"),
+		}
+		self.assertTrue(required.issubset(edges), required - edges)
+
+	def test_schema_should_match_loader_enumerations(self):
+		schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+		self.assertEqual(set(schema["$defs"]["node"]["properties"]["kind"]["enum"]),
+			set(semantic_inventory.ALLOWED_NODE_KINDS))
+		self.assertEqual(set(schema["$defs"]["node"]["properties"]["domain"]["enum"]),
+			set(semantic_inventory.ALLOWED_DOMAINS))
+		self.assertEqual(set(schema["$defs"]["edge"]["properties"]["kind"]["enum"]),
+			set(semantic_inventory.ALLOWED_EDGE_KINDS))
+		self.assertEqual(set(schema["$defs"]["edge"]["properties"]["enforcement"]["enum"]),
+			set(semantic_inventory.ALLOWED_ENFORCEMENT))
+
+	def test_validation_should_fail_when_evidence_symbol_is_missing(self):
+		payload = copy.deepcopy(self.payload)
+		payload["nodes"][0]["evidence"][0]["symbol"] = "symbol that cannot exist"
+		with self.assertRaisesRegex(semantic_inventory.InventoryError, "symbol was not found"):
+			semantic_inventory.validate_inventory(payload, ROOT)
+
+	def test_validation_should_fail_when_node_id_is_duplicated(self):
+		payload = copy.deepcopy(self.payload)
+		payload["nodes"].append(copy.deepcopy(payload["nodes"][0]))
+		with self.assertRaisesRegex(semantic_inventory.InventoryError, "duplicate node id"):
+			semantic_inventory.validate_inventory(payload, ROOT)
+
+	def test_validation_should_fail_when_edge_is_dangling(self):
+		payload = copy.deepcopy(self.payload)
+		payload["edges"][0]["target"] = "ledger:missing"
+		with self.assertRaisesRegex(semantic_inventory.InventoryError, "unknown node"):
+			semantic_inventory.validate_inventory(payload, ROOT)
+
+	def test_validation_should_fail_when_evidence_traverses_root(self):
+		payload = copy.deepcopy(self.payload)
+		payload["nodes"][0]["evidence"][0]["file"] = "../outside.rs"
+		with self.assertRaisesRegex(semantic_inventory.InventoryError, "cannot traverse"):
+			semantic_inventory.validate_inventory(payload, ROOT)
+
+	def test_cli_should_write_normalized_inventory(self):
+		with tempfile.TemporaryDirectory() as directory:
+			output = Path(directory) / "semantic.json"
+			subprocess.run([
+				sys.executable,
+				str(MODULE),
+				"--root",
+				str(ROOT),
+				"--inventory",
+				str(INVENTORY),
+				"--output",
+				str(output),
+			], check=True, capture_output=True, text=True)
+			written = json.loads(output.read_text(encoding="utf-8"))
+			self.assertEqual(written["coverage"]["node_count"], len(written["nodes"]))
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/scripts/runtime-interaction-graph/test_serve_graph.py
+++ b/scripts/runtime-interaction-graph/test_serve_graph.py
@@ -1,0 +1,198 @@
+import gzip
+import http.client
+import json
+import socket
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIRECTORY = Path(__file__).resolve().parent
+if str(SCRIPT_DIRECTORY) not in sys.path:
+	sys.path.insert(0, str(SCRIPT_DIRECTORY))
+import query_graph
+import serve_graph
+
+
+class GraphServerTest(unittest.TestCase):
+	def setUp(self) -> None:
+		self.temporary = tempfile.TemporaryDirectory()
+		self.root = Path(self.temporary.name)
+		graph = {
+			"schema_version": 2,
+			"nodes": [
+				{"id": "component:a", "kind": "component", "runtime_active": True},
+				{"id": "component:b", "kind": "component", "runtime_active": True},
+			],
+			"edges": [{"source": "component:a", "target": "component:b", "kind": "calls"}],
+		}
+		self._write_json("interaction-graph.json", graph)
+		self._write_json("component-graph.json", {
+			"schema_version": 2,
+			"projection": "execution",
+			"edges": graph["edges"],
+		})
+		self._write_json("coverage.json", {"nodes": 2, "edges": 1, "unresolved_targets": 0})
+		self._write_json("completeness.json", {"schema_version": 1})
+		self._write_json("query-packs.json", {"schema_version": 1, "sample": []})
+		self.root.joinpath("interaction-graph.html").write_text("<!doctype html><title>graph</title>")
+		self.root.joinpath("graph-scale.svg").write_text("<svg xmlns='http://www.w3.org/2000/svg'/>")
+		html = self.root.joinpath("interaction-graph.html").read_bytes()
+		self.root.joinpath("interaction-graph.html.gz").write_bytes(gzip.compress(html, mtime=0))
+		self.state = serve_graph.load_state(self.root, max_body_bytes=256,
+			max_records=20, max_tokens=2_000, max_expansions=50)
+		self.server = serve_graph.create_server(self.state, "127.0.0.1", 0,
+			max_concurrency=2, socket_timeout=0.5)
+		self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+		self.thread.start()
+
+	def tearDown(self) -> None:
+		self.server.shutdown()
+		self.server.server_close()
+		self.thread.join(timeout=2)
+		self.temporary.cleanup()
+
+	def _write_json(self, name: str, value: object) -> None:
+		self.root.joinpath(name).write_text(json.dumps(value, sort_keys=True))
+
+	def request(self, method: str, path: str, body: bytes | None = None,
+		headers: dict[str, str] | None = None) -> tuple[int, dict[str, str], bytes]:
+		connection = http.client.HTTPConnection(*self.server.server_address, timeout=2)
+		connection.request(method, path, body=body, headers=headers or {})
+		response = connection.getresponse()
+		data = response.read()
+		result = response.status, {key.casefold(): value for key, value in response.getheaders()}, data
+		connection.close()
+		return result
+
+	def raw_request(self, request: bytes) -> bytes:
+		with socket.create_connection(self.server.server_address, timeout=2) as connection:
+			connection.sendall(request)
+			connection.shutdown(socket.SHUT_WR)
+			chunks = []
+			while chunk := connection.recv(64 * 1024):
+				chunks.append(chunk)
+		return b"".join(chunks)
+
+	def test_health_readiness_metadata_and_root(self) -> None:
+		status, headers, body = self.request("GET", "/")
+		self.assertEqual(status, 302)
+		self.assertEqual(headers["location"], "/interaction-graph.html")
+		status, _, body = self.request("GET", "/healthz")
+		self.assertEqual(status, 200)
+		self.assertEqual(json.loads(body)["status"], "ok")
+		status, _, body = self.request("GET", "/readyz")
+		ready = json.loads(body)
+		self.assertEqual(status, 200)
+		self.assertEqual(ready["graph"]["nodes"], 2)
+		self.assertEqual(set(ready["graph"]["companions"]),
+			{"coverage", "completeness", "query_packs", "component_graph"})
+		status, _, body = self.request("GET", "/api/v1")
+		metadata = json.loads(body)
+		self.assertEqual(status, 200)
+		self.assertEqual(metadata["limits"]["max_records"], 20)
+		self.assertIn("paths", metadata["operations"])
+
+	def test_static_gzip_head_etag_and_conditional_get(self) -> None:
+		status, identity_headers, identity = self.request("GET", "/interaction-graph.html",
+			headers={"Accept-Encoding": "gzip;q=0, *;q=0"})
+		self.assertEqual(status, 200)
+		self.assertNotIn("content-encoding", identity_headers)
+		self.assertEqual(identity, self.root.joinpath("interaction-graph.html").read_bytes())
+		self.assertIn("etag", identity_headers)
+
+		status, gzip_headers, compressed = self.request("GET", "/interaction-graph.html",
+			headers={"Accept-Encoding": "br, gzip;q=0.8"})
+		self.assertEqual(status, 200)
+		self.assertEqual(gzip_headers["content-encoding"], "gzip")
+		self.assertEqual(gzip.decompress(compressed), identity)
+		self.assertNotEqual(gzip_headers["etag"], identity_headers["etag"])
+
+		status, head_headers, head_body = self.request("HEAD", "/interaction-graph.html",
+			headers={"Accept-Encoding": "gzip"})
+		self.assertEqual(status, 200)
+		self.assertEqual(head_body, b"")
+		self.assertEqual(head_headers["content-length"], str(len(compressed)))
+
+		status, conditional_headers, conditional_body = self.request("GET", "/interaction-graph.html",
+			headers={"Accept-Encoding": "gzip", "If-None-Match": gzip_headers["etag"]})
+		self.assertEqual(status, 304)
+		self.assertEqual(conditional_headers["etag"], gzip_headers["etag"])
+		self.assertEqual(conditional_body, b"")
+
+	def test_static_routes_are_an_explicit_allowlist(self) -> None:
+		self.root.joinpath("secret.txt").write_text("not public")
+		for path in ("/secret.txt", "/../secret.txt", "/%2e%2e/secret.txt",
+			"/%252e%252e/secret.txt", "/interaction-graph.html/extra", "/.hidden"):
+			with self.subTest(path=path):
+				status, _, body = self.request("GET", path)
+				self.assertEqual(status, 404)
+				self.assertEqual(json.loads(body)["error"], "not-found")
+		status, _, body = self.request("HEAD", "/secret.txt")
+		self.assertEqual(status, 404)
+		self.assertEqual(body, b"")
+
+	def test_query_endpoint_and_server_side_limits(self) -> None:
+		request = json.dumps({"operation": "summary", "max_records": 5, "max_tokens": 1_000}).encode()
+		status, headers, body = self.request("POST", "/api/v1/query", request,
+			headers={"Content-Type": "application/json; charset=utf-8"})
+		response = json.loads(body)
+		self.assertEqual(status, 200)
+		self.assertEqual(headers["access-control-allow-origin"], "*")
+		self.assertEqual(response["schema_version"], 1)
+		self.assertEqual(response["query"]["operation"], "summary")
+
+		request = json.dumps({"operation": "summary", "max_records": 21}).encode()
+		status, _, body = self.request("POST", "/api/v1/query", request,
+			headers={"Content-Type": "application/json"})
+		self.assertEqual(status, 400)
+		self.assertEqual(json.loads(body)["result"]["metadata"]["error"], "invalid-query")
+
+	def test_post_rejects_unsupported_or_ambiguous_framing(self) -> None:
+		body = b'{"operation":"summary"}'
+		status, _, response = self.request("POST", "/api/v1/query", body,
+			headers={"Content-Type": "text/plain"})
+		self.assertEqual(status, 415)
+		self.assertEqual(json.loads(response)["result"]["metadata"]["error"],
+			"unsupported-content-type")
+
+		status, _, response = self.request("POST", "/api/v1/query", body,
+			headers={"Content-Type": "application/json", "Content-Encoding": "gzip"})
+		self.assertEqual(status, 400)
+		self.assertEqual(json.loads(response)["result"]["metadata"]["error"], "invalid-request")
+
+		response = self.raw_request(
+			b"POST /api/v1/query HTTP/1.1\r\nHost: localhost\r\n"
+			b"Content-Type: application/json\r\nContent-Length: 2\r\nContent-Length: 2\r\n\r\n{}")
+		self.assertIn(b" 400 ", response.split(b"\r\n", 1)[0])
+		response = self.raw_request(
+			b"POST /api/v1/query HTTP/1.1\r\nHost: localhost\r\n"
+			b"Content-Type: application/json\r\nContent-Length: 300\r\n\r\n{}")
+		self.assertIn(b" 413 ", response.split(b"\r\n", 1)[0])
+		response = self.raw_request(
+			b"POST /api/v1/query HTTP/1.1\r\nHost: localhost\r\n"
+			b"Content-Type: application/json\r\nContent-Length: 20\r\n\r\n{}")
+		self.assertIn(b" 400 ", response.split(b"\r\n", 1)[0])
+
+	def test_load_state_rejects_stale_or_missing_artifacts(self) -> None:
+		self._write_json("coverage.json", {"nodes": 2, "edges": 999})
+		with self.assertRaisesRegex(query_graph.QueryFailure, "coverage edges count"):
+			serve_graph.load_state(self.root)
+		self._write_json("coverage.json", {"nodes": 2, "edges": 1})
+		self.root.joinpath("graph-scale.svg").unlink()
+		with self.assertRaisesRegex(query_graph.QueryFailure, "required static artifact"):
+			serve_graph.load_state(self.root)
+
+	def test_accepts_gzip_honors_quality(self) -> None:
+		self.assertTrue(serve_graph.accepts_gzip("br, gzip;q=0.5"))
+		self.assertTrue(serve_graph.accepts_gzip("*;q=1"))
+		self.assertFalse(serve_graph.accepts_gzip("gzip;q=0, *;q=0"))
+		self.assertFalse(serve_graph.accepts_gzip("gzip;q=0, *;q=1"))
+		self.assertFalse(serve_graph.accepts_gzip("gzip;q=invalid"))
+		self.assertFalse(serve_graph.accepts_gzip("gzip;q=2"))
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
## summary

- add a deterministic, evidence-backed interaction graph for runtime pallets, adapters, storage, lifecycle hooks, XCM, token backends, EVM/precompiles, and deployed contracts
- combine source inventory with RAPx callgraphs and genuine rustc MIR while preserving evidence provenance and exact runtime/config-trait resolution
- add raw and operational projections, activity classification, cycles, bounded boundary paths, state/external ordering candidates, integration-test linkage, and regression thresholds
- add dependency-free HTML/SVG visualizations and a bounded AI-facing CLI/JSONL query interface
- package the dashboard and query API in one non-root, read-only-compatible container with health/readiness endpoints and deterministic gzip assets
- add CI generation, coverage-policy checks, graph diffs, and artifact publication

## generated graph

Generated from this clean `origin/master`-based branch against runtime spec `432`:

| metric | value |
| --- | ---: |
| nodes | 18,178 |
| edges | 49,426 |
| components | 560 |
| entrypoints / kinds | 897 / 13 |
| deployed contracts | 117 |
| runtime contract configurations | 27 |
| MIR packages | 46/46 (0 failed) |
| MIR functions / instances | 1,745 / 3,459 |
| relevant MIR operations | 3,786 |
| state invariants / asset operations | 18 / 17 |
| unresolved runtime targets | 0 |
| inventory-only targets | 6 |
| linked integration tests | 950 |
| linked components / entrypoints | 63 / 189 |

Graph SHA-256: `990aace9812a27b6703e4a7b13ee601231a1fa4213f206ddb614121d65c5dcfe`.

The complete generated directory is about 126 MiB under ignored `target/`; generated graph artifacts are not committed.

## container

The public image serves the static dashboard and bounded query API on one port:

- `galacticcouncil/hydration-runtime-graph:graph-990aace9812a`
- `galacticcouncil/hydration-runtime-graph:latest`
- OCI index digest: `sha256:30f216ff68894a52102dbf316304351848e376e8a6514f4f306907b8e0e80db1`
- platform: `linux/amd64`

```sh
docker run --rm --read-only --cap-drop=ALL --security-opt=no-new-privileges \
  -p 8080:8080 galacticcouncil/hydration-runtime-graph:latest
```

Endpoints: `/`, `/healthz`, `/readyz`, `/api/v1`, and `POST /api/v1/query`.

## validation

- `python3 -m unittest discover -s scripts/runtime-interaction-graph -p 'test_*.py'` — 167 passed
- `node --test scripts/runtime-interaction-graph/collect_runtime_contracts.test.mjs` — passed
- current-source compiler evidence — RAPx 46/46 and rustc MIR 46/46
- full graph generation with `coverage-thresholds-full.json` — passed
- hardened container smoke — healthy as UID 10001, read-only root, all capabilities dropped
- dashboard, gzip/HEAD/ETag, traversal rejection, readiness fingerprints, and bounded StableSwap semantic query — passed

## reviewer notes

- default views are operational: explicit/inherited inactive inventory stays in raw projections but is excluded from operational paths, cycles, query packs, visualizations, and integration linkage; missing activity remains `unclassified`
- the six inventory-only targets are pinned by exact IDs and reasons
- integration-test linkage is static source-reference/co-occurrence evidence, not proof of observed behavioral coverage
- deployment evidence intentionally includes public mainnet contract addresses and source provenance
- the AI API validates graph/companion schemas and fingerprints and enforces record, token, expansion, body, concurrency, and static-file limits
- this branch is based directly on `origin/master`; unrelated NTT commits from the development branch are not included
