### PR TITLE
test: integration coverage for untested extrinsics across 8 pallets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13900,7 +13900,7 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "runtime-integration-tests"
-version = "1.104.1"
+version = "1.104.2"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -13955,6 +13955,7 @@ dependencies = [
  "pallet-currencies-rpc-runtime-api",
  "pallet-dca",
  "pallet-dispatcher",
+ "pallet-dispenser",
  "pallet-duster",
  "pallet-duster-rpc-runtime-api",
  "pallet-dynamic-evm-fee",
@@ -13983,6 +13984,7 @@ dependencies = [
  "pallet-route-executor",
  "pallet-scheduler",
  "pallet-session",
+ "pallet-signet",
  "pallet-stableswap",
  "pallet-staking 5.1.0",
  "pallet-timestamp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13900,7 +13900,7 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "runtime-integration-tests"
-version = "1.104.0"
+version = "1.104.1"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "1.104.1"
+version = "1.104.2"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"
@@ -64,6 +64,8 @@ pallet-conviction-voting = { workspace = true }
 pallet-dispatcher = { workspace = true }
 pallet-proxy = { workspace = true }
 pallet-hsm = { workspace = true }
+pallet-signet = { workspace = true }
+pallet-dispenser = { workspace = true }
 
 # collator support
 pallet-collator-selection = { workspace = true }
@@ -238,6 +240,8 @@ std = [
     "pallet-broadcast/std",
     "pallet-dispatcher/std",
     "pallet-hsm/std",
+    "pallet-signet/std",
+    "pallet-dispenser/std",
     "ethereum/std",
     "pallet-ethereum/std",
     "fp-self-contained/std",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "1.104.0"
+version = "1.104.1"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/src/admin_misc_extra.rs
+++ b/integration-tests/src/admin_misc_extra.rs
@@ -1,0 +1,364 @@
+// Integration coverage for admin / utility extrinsics that had no
+// integration-test coverage:
+//   - `pallet-dispatcher::dispatch_as_treasury`
+//   - `pallet-transaction-multi-payment::reset_payment_currency`
+//   - `pallet-gigahdx::set_pool_contract`
+//   - the `pallet-dispenser` surface: `set_config`, `pause`, `unpause`,
+//     and `request_fund` guard rejections.
+//
+// These are origin-gated administrative calls, so the assertions focus on the
+// authority gate, the specific error variants, and the observable storage /
+// balance effect.
+
+#![cfg(test)]
+
+use crate::polkadot_test_net::*;
+use frame_support::{assert_noop, assert_ok};
+use hex_literal::hex;
+use hydradx_runtime::*;
+use orml_traits::MultiCurrency;
+use pretty_assertions::assert_eq;
+use primitives::EvmAddress;
+use xcm_emulator::TestExt;
+
+// ------------------------- pallet-dispatcher -------------------------
+
+#[test]
+fn dispatch_as_treasury_should_transfer_from_treasury_when_root() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		let treasury = TreasuryAccount::get();
+
+		// Fund the treasury so the inner transfer has something to move.
+		assert_ok!(Currencies::update_balance(
+			RuntimeOrigin::root(),
+			treasury.clone(),
+			HDX,
+			1_000 * UNITS as i128,
+		));
+
+		let treasury_before = Currencies::free_balance(HDX, &treasury);
+		let bob_before = Currencies::free_balance(HDX, &AccountId::from(BOB));
+
+		let inner = RuntimeCall::Currencies(pallet_currencies::Call::transfer {
+			dest: BOB.into(),
+			currency_id: HDX,
+			amount: 100 * UNITS,
+		});
+
+		assert_ok!(Dispatcher::dispatch_as_treasury(RuntimeOrigin::root(), Box::new(inner),));
+
+		// The inner call runs as a Signed origin from the treasury account.
+		assert_eq!(
+			Currencies::free_balance(HDX, &AccountId::from(BOB)),
+			bob_before + 100 * UNITS
+		);
+		assert_eq!(Currencies::free_balance(HDX, &treasury), treasury_before - 100 * UNITS);
+	});
+}
+
+#[test]
+fn dispatch_as_treasury_should_fail_when_origin_not_authorized() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		let inner = RuntimeCall::System(frame_system::Call::remark { remark: vec![1, 2, 3] });
+
+		assert_noop!(
+			Dispatcher::dispatch_as_treasury(RuntimeOrigin::signed(ALICE.into()), Box::new(inner)),
+			sp_runtime::DispatchError::BadOrigin
+		);
+	});
+}
+
+// ------------------- pallet-transaction-multi-payment -------------------
+
+#[test]
+fn reset_payment_currency_should_clear_account_currency_when_root() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		let alice: AccountId = ALICE.into();
+
+		// DAI is an accepted currency at genesis, so a non-EVM account can set it.
+		assert_ok!(MultiTransactionPayment::set_currency(
+			RuntimeOrigin::signed(alice.clone()),
+			DAI,
+		));
+		assert_eq!(MultiTransactionPayment::get_currency(&alice), Some(DAI));
+
+		// Reset of a non-EVM account removes the override entirely (defaults to HDX).
+		assert_ok!(MultiTransactionPayment::reset_payment_currency(
+			RuntimeOrigin::root(),
+			alice.clone(),
+		));
+		assert_eq!(MultiTransactionPayment::get_currency(&alice), None);
+	});
+}
+
+#[test]
+fn reset_payment_currency_should_fail_when_origin_not_authorized() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		assert_noop!(
+			MultiTransactionPayment::reset_payment_currency(RuntimeOrigin::signed(ALICE.into()), BOB.into()),
+			sp_runtime::DispatchError::BadOrigin
+		);
+	});
+}
+
+// ------------------------- pallet-gigahdx -------------------------
+
+fn pool_addr_a() -> EvmAddress {
+	hex!["1111111111111111111111111111111111111111"].into()
+}
+
+fn pool_addr_b() -> EvmAddress {
+	hex!["2222222222222222222222222222222222222222"].into()
+}
+
+#[test]
+fn set_pool_contract_should_update_stored_address_when_root_and_no_stake() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		// No stHDX has been minted on the vanilla test net, so the pool is settable.
+		assert_eq!(GigaHdx::total_gigahdx_supply(), 0);
+
+		assert_ok!(GigaHdx::set_pool_contract(RuntimeOrigin::root(), pool_addr_a()));
+		assert_eq!(
+			pallet_gigahdx::GigaHdxPoolContract::<Runtime>::get(),
+			Some(pool_addr_a())
+		);
+
+		// Idempotent-friendly: a second set with a different address overwrites it.
+		assert_ok!(GigaHdx::set_pool_contract(RuntimeOrigin::root(), pool_addr_b()));
+		assert_eq!(
+			pallet_gigahdx::GigaHdxPoolContract::<Runtime>::get(),
+			Some(pool_addr_b())
+		);
+	});
+}
+
+#[test]
+fn set_pool_contract_should_fail_when_stake_outstanding() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		let sthdx: AssetId = <Runtime as pallet_gigahdx::Config>::StHdxAssetId::get();
+
+		// Simulate outstanding stHDX supply — the pool must not be swapped while
+		// aTokens are in circulation.
+		orml_tokens::TotalIssuance::<Runtime>::insert(sthdx, 1_000 * UNITS);
+		assert_eq!(GigaHdx::total_gigahdx_supply(), 1_000 * UNITS);
+
+		assert_noop!(
+			GigaHdx::set_pool_contract(RuntimeOrigin::root(), pool_addr_a()),
+			pallet_gigahdx::Error::<Runtime>::OutstandingStake
+		);
+	});
+}
+
+#[test]
+fn set_pool_contract_should_fail_when_origin_not_authority() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		assert_noop!(
+			GigaHdx::set_pool_contract(RuntimeOrigin::signed(ALICE.into()), pool_addr_a()),
+			sp_runtime::DispatchError::BadOrigin
+		);
+	});
+}
+
+// ------------------------- pallet-dispenser -------------------------
+
+fn faucet_addr() -> EvmAddress {
+	hex!["00000000000000000000000000000000000000ff"].into()
+}
+
+fn configure_dispenser() {
+	assert_ok!(EthDispenser::set_config(
+		RuntimeOrigin::root(),
+		faucet_addr(),
+		1_000,      // min_faucet_threshold
+		10,         // min_request
+		1_000_000,  // max_dispense
+		5 * UNITS,  // dispenser_fee
+		10_000_000, // faucet_balance_wei
+	));
+}
+
+fn dummy_tx() -> pallet_dispenser::EvmTransactionParams {
+	pallet_dispenser::EvmTransactionParams {
+		value: 0,
+		gas_limit: 21_000,
+		max_fee_per_gas: 1_000_000_000,
+		max_priority_fee_per_gas: 1_000_000_000,
+		nonce: 0,
+		chain_id: 1,
+	}
+}
+
+#[test]
+fn set_config_should_store_config_when_update_origin() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		assert!(EthDispenser::dispenser_config().is_none());
+
+		configure_dispenser();
+
+		let cfg = EthDispenser::dispenser_config().expect("dispenser must be configured");
+		assert_eq!(cfg.faucet_address, faucet_addr());
+		assert_eq!(cfg.min_faucet_threshold, 1_000);
+		assert_eq!(cfg.min_request, 10);
+		assert_eq!(cfg.max_dispense, 1_000_000);
+		assert_eq!(cfg.dispenser_fee, 5 * UNITS);
+		assert_eq!(cfg.faucet_balance_wei, 10_000_000);
+		// First configuration starts unpaused.
+		assert!(!cfg.paused);
+	});
+}
+
+#[test]
+fn set_config_should_fail_when_origin_not_update_origin() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		assert_noop!(
+			EthDispenser::set_config(
+				RuntimeOrigin::signed(ALICE.into()),
+				faucet_addr(),
+				1_000,
+				10,
+				1_000_000,
+				5 * UNITS,
+				10_000_000,
+			),
+			sp_runtime::DispatchError::BadOrigin
+		);
+	});
+}
+
+#[test]
+fn set_config_should_fail_when_faucet_address_is_zero() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		assert_noop!(
+			EthDispenser::set_config(
+				RuntimeOrigin::root(),
+				EvmAddress::zero(),
+				1_000,
+				10,
+				1_000_000,
+				5 * UNITS,
+				10_000_000,
+			),
+			pallet_dispenser::Error::<Runtime>::InvalidAddress
+		);
+	});
+}
+
+#[test]
+fn set_config_should_fail_when_max_dispense_is_zero() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		assert_noop!(
+			EthDispenser::set_config(
+				RuntimeOrigin::root(),
+				faucet_addr(),
+				1_000,
+				0,
+				0, // max_dispense == 0
+				5 * UNITS,
+				10_000_000,
+			),
+			pallet_dispenser::Error::<Runtime>::InvalidConfig
+		);
+	});
+}
+
+#[test]
+fn pause_should_set_paused_flag_when_configured() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		configure_dispenser();
+		assert!(!EthDispenser::dispenser_config().unwrap().paused);
+
+		assert_ok!(EthDispenser::pause(RuntimeOrigin::root()));
+
+		assert!(EthDispenser::dispenser_config().unwrap().paused);
+	});
+}
+
+#[test]
+fn pause_should_fail_when_not_configured() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		assert_noop!(
+			EthDispenser::pause(RuntimeOrigin::root()),
+			pallet_dispenser::Error::<Runtime>::NotConfigured
+		);
+	});
+}
+
+#[test]
+fn pause_should_fail_when_origin_not_update_origin() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		// Origin is checked before the configured-state check.
+		assert_noop!(
+			EthDispenser::pause(RuntimeOrigin::signed(ALICE.into())),
+			sp_runtime::DispatchError::BadOrigin
+		);
+	});
+}
+
+#[test]
+fn unpause_should_clear_paused_flag_when_paused() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		configure_dispenser();
+		assert_ok!(EthDispenser::pause(RuntimeOrigin::root()));
+		assert!(EthDispenser::dispenser_config().unwrap().paused);
+
+		assert_ok!(EthDispenser::unpause(RuntimeOrigin::root()));
+
+		assert!(!EthDispenser::dispenser_config().unwrap().paused);
+	});
+}
+
+#[test]
+fn unpause_should_fail_when_not_configured() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		assert_noop!(
+			EthDispenser::unpause(RuntimeOrigin::root()),
+			pallet_dispenser::Error::<Runtime>::NotConfigured
+		);
+	});
+}
+
+#[test]
+fn request_fund_should_fail_when_not_configured() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		let to: EvmAddress = hex!["0000000000000000000000000000000000000001"].into();
+
+		assert_noop!(
+			EthDispenser::request_fund(RuntimeOrigin::signed(ALICE.into()), to, 100, [0u8; 32], dummy_tx()),
+			pallet_dispenser::Error::<Runtime>::NotConfigured
+		);
+	});
+}
+
+#[test]
+fn request_fund_should_fail_when_paused() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		configure_dispenser();
+		assert_ok!(EthDispenser::pause(RuntimeOrigin::root()));
+
+		let to: EvmAddress = hex!["0000000000000000000000000000000000000001"].into();
+
+		// Paused is enforced before any parameter / request-id validation.
+		assert_noop!(
+			EthDispenser::request_fund(RuntimeOrigin::signed(ALICE.into()), to, 100, [0u8; 32], dummy_tx()),
+			pallet_dispenser::Error::<Runtime>::Paused
+		);
+	});
+}

--- a/integration-tests/src/amm_misc_extra.rs
+++ b/integration-tests/src/amm_misc_extra.rs
@@ -1,0 +1,241 @@
+// Integration coverage for value-moving extrinsics that the suite otherwise
+// exercises only at the pallet level: `bonds::redeem`, `lbp::add_liquidity`,
+// `lbp::remove_liquidity`, and `currencies::transfer_native_currency`.
+
+use crate::driver::HydrationTestDriver;
+use crate::polkadot_test_net::*;
+use frame_support::{assert_noop, assert_ok};
+use hydradx_runtime::*;
+use orml_traits::MultiCurrency;
+use pallet_lbp::WeightCurveType;
+use pretty_assertions::assert_eq;
+use primitives::constants::time::unix_time::MONTH;
+
+const LBP_ASSET_A: AssetId = 4700;
+const LBP_ASSET_B: AssetId = 4701;
+
+const LBP_INIT_A: Balance = 100 * UNITS;
+const LBP_INIT_B: Balance = 200 * UNITS;
+const LBP_ENDOWMENT: Balance = 1_000 * UNITS;
+
+fn lbp_pool() -> HydrationTestDriver {
+	let driver = HydrationTestDriver::default()
+		.register_asset(LBP_ASSET_A, b"exLBA", 12, None)
+		.register_asset(LBP_ASSET_B, b"exLBB", 12, None);
+	driver
+		.endow_account(BOB.into(), LBP_ASSET_A, LBP_ENDOWMENT)
+		.endow_account(BOB.into(), LBP_ASSET_B, LBP_ENDOWMENT)
+		.execute(|| {
+			// BOB owns the pool; CHARLIE is the fee collector.
+			assert_ok!(LBP::create_pool(
+				RuntimeOrigin::root(),
+				BOB.into(),
+				LBP_ASSET_A,
+				LBP_INIT_A,
+				LBP_ASSET_B,
+				LBP_INIT_B,
+				20_000_000,
+				80_000_000,
+				WeightCurveType::Linear,
+				(2, 1_000),
+				CHARLIE.into(),
+				0,
+			));
+		});
+	driver
+}
+
+fn lbp_pair_account() -> AccountId {
+	LBP::pair_account_from_assets(LBP_ASSET_A, LBP_ASSET_B)
+}
+
+// ---------------------------------------------------------------------------
+// bonds::redeem
+// ---------------------------------------------------------------------------
+
+#[test]
+fn redeem_should_return_underlying_asset_when_bond_is_mature() {
+	HydrationTestDriver::default().execute(|| {
+		let treasury = Treasury::account_id();
+		let amount = 100 * UNITS;
+
+		// Keep the issuer account well above ED so it retains its provider ref
+		// after the underlying is debited during `issue`.
+		assert_ok!(Balances::force_set_balance(
+			RuntimeOrigin::root(),
+			treasury.clone(),
+			3_000_000 * UNITS,
+		));
+
+		Timestamp::set_timestamp(NOW);
+		let maturity = NOW + MONTH;
+
+		let bond_id = AssetRegistry::next_asset_id().unwrap();
+		assert_ok!(Bonds::issue(RuntimeOrigin::root(), HDX, amount, maturity));
+
+		// Bonds are credited 1:1 to the issuer (treasury).
+		assert_eq!(Currencies::free_balance(bond_id, &treasury), amount);
+
+		// Advance time past maturity.
+		Timestamp::set_timestamp(maturity);
+
+		let hdx_before = Currencies::free_balance(HDX, &treasury);
+
+		assert_ok!(Bonds::redeem(RuntimeOrigin::signed(treasury.clone()), bond_id, amount,));
+
+		// Bonds are burned and the underlying is returned 1:1.
+		assert_eq!(Currencies::free_balance(bond_id, &treasury), 0);
+		assert_eq!(Currencies::free_balance(HDX, &treasury), hdx_before + amount);
+	});
+}
+
+#[test]
+fn redeem_should_fail_when_bond_is_not_mature() {
+	HydrationTestDriver::default().execute(|| {
+		let treasury = Treasury::account_id();
+		let amount = 100 * UNITS;
+
+		assert_ok!(Balances::force_set_balance(
+			RuntimeOrigin::root(),
+			treasury.clone(),
+			3_000_000 * UNITS,
+		));
+
+		Timestamp::set_timestamp(NOW);
+		let maturity = NOW + MONTH;
+
+		let bond_id = AssetRegistry::next_asset_id().unwrap();
+		assert_ok!(Bonds::issue(RuntimeOrigin::root(), HDX, amount, maturity));
+
+		// Time has not advanced to maturity.
+		assert_noop!(
+			Bonds::redeem(RuntimeOrigin::signed(treasury), bond_id, amount),
+			pallet_bonds::Error::<Runtime>::NotMature
+		);
+	});
+}
+
+// ---------------------------------------------------------------------------
+// lbp::add_liquidity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn add_liquidity_should_credit_pool_and_debit_owner_when_called_by_owner() {
+	lbp_pool().execute(|| {
+		let bob: AccountId = BOB.into();
+		let pool = lbp_pair_account();
+
+		let add_a = 10 * UNITS;
+		let add_b = 20 * UNITS;
+
+		let pool_a_before = Tokens::free_balance(LBP_ASSET_A, &pool);
+		let pool_b_before = Tokens::free_balance(LBP_ASSET_B, &pool);
+		let bob_a_before = Tokens::free_balance(LBP_ASSET_A, &bob);
+		let bob_b_before = Tokens::free_balance(LBP_ASSET_B, &bob);
+
+		assert_ok!(LBP::add_liquidity(
+			RuntimeOrigin::signed(bob.clone()),
+			(LBP_ASSET_A, add_a),
+			(LBP_ASSET_B, add_b),
+		));
+
+		assert_eq!(Tokens::free_balance(LBP_ASSET_A, &pool) - pool_a_before, add_a);
+		assert_eq!(Tokens::free_balance(LBP_ASSET_B, &pool) - pool_b_before, add_b);
+		assert_eq!(bob_a_before - Tokens::free_balance(LBP_ASSET_A, &bob), add_a);
+		assert_eq!(bob_b_before - Tokens::free_balance(LBP_ASSET_B, &bob), add_b);
+	});
+}
+
+#[test]
+fn add_liquidity_should_fail_when_caller_is_not_pool_owner() {
+	lbp_pool().execute(|| {
+		assert_noop!(
+			LBP::add_liquidity(
+				RuntimeOrigin::signed(ALICE.into()),
+				(LBP_ASSET_A, 10 * UNITS),
+				(LBP_ASSET_B, 20 * UNITS),
+			),
+			pallet_lbp::Error::<Runtime>::NotOwner
+		);
+	});
+}
+
+// ---------------------------------------------------------------------------
+// lbp::remove_liquidity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn remove_liquidity_should_return_all_assets_and_destroy_pool_when_called_by_owner() {
+	lbp_pool().execute(|| {
+		let bob: AccountId = BOB.into();
+		let pool = lbp_pair_account();
+
+		// Pool holds the liquidity provided at creation.
+		assert_eq!(Tokens::free_balance(LBP_ASSET_A, &pool), LBP_INIT_A);
+		assert_eq!(Tokens::free_balance(LBP_ASSET_B, &pool), LBP_INIT_B);
+
+		let bob_a_before = Tokens::free_balance(LBP_ASSET_A, &bob);
+		let bob_b_before = Tokens::free_balance(LBP_ASSET_B, &bob);
+
+		// Sale window was never set (start/end are None) so the pool is not
+		// running and can be torn down immediately.
+		assert_ok!(LBP::remove_liquidity(RuntimeOrigin::signed(bob.clone()), pool.clone()));
+
+		assert!(LBP::pool_data(pool.clone()).is_none(), "pool should be destroyed");
+		assert_eq!(Tokens::free_balance(LBP_ASSET_A, &pool), 0);
+		assert_eq!(Tokens::free_balance(LBP_ASSET_B, &pool), 0);
+		assert_eq!(Tokens::free_balance(LBP_ASSET_A, &bob) - bob_a_before, LBP_INIT_A);
+		assert_eq!(Tokens::free_balance(LBP_ASSET_B, &bob) - bob_b_before, LBP_INIT_B);
+	});
+}
+
+#[test]
+fn remove_liquidity_should_fail_when_caller_is_not_pool_owner() {
+	lbp_pool().execute(|| {
+		let pool = lbp_pair_account();
+		assert_noop!(
+			LBP::remove_liquidity(RuntimeOrigin::signed(ALICE.into()), pool),
+			pallet_lbp::Error::<Runtime>::NotOwner
+		);
+	});
+}
+
+// ---------------------------------------------------------------------------
+// currencies::transfer_native_currency
+// ---------------------------------------------------------------------------
+
+#[test]
+fn transfer_native_currency_should_move_hdx_between_accounts() {
+	HydrationTestDriver::default().execute(|| {
+		let alice: AccountId = ALICE.into();
+		let bob: AccountId = BOB.into();
+		let amount = 10 * UNITS;
+
+		let alice_before = Currencies::free_balance(HDX, &alice);
+		let bob_before = Currencies::free_balance(HDX, &bob);
+
+		assert_ok!(Currencies::transfer_native_currency(
+			RuntimeOrigin::signed(alice.clone()),
+			bob.clone(),
+			amount,
+		));
+
+		assert_eq!(Currencies::free_balance(HDX, &alice), alice_before - amount);
+		assert_eq!(Currencies::free_balance(HDX, &bob), bob_before + amount);
+	});
+}
+
+#[test]
+fn transfer_native_currency_should_fail_when_balance_is_insufficient() {
+	HydrationTestDriver::default().execute(|| {
+		let alice: AccountId = ALICE.into();
+		let bob: AccountId = BOB.into();
+
+		let alice_balance = Currencies::free_balance(HDX, &alice);
+
+		assert_noop!(
+			Currencies::transfer_native_currency(RuntimeOrigin::signed(alice), bob, alice_balance + UNITS,),
+			sp_runtime::TokenError::FundsUnavailable
+		);
+	});
+}

--- a/integration-tests/src/hsm_admin_extra.rs
+++ b/integration-tests/src/hsm_admin_extra.rs
@@ -1,0 +1,156 @@
+// Integration coverage for the authority-gated HSM admin extrinsics that the
+// suite otherwise leaves untested: `update_collateral_asset` and
+// `remove_collateral_asset`. Buy/sell already have coverage in `hsm.rs`; these
+// tests exercise only the collateral-config lifecycle (mutate/remove + guards)
+// and therefore need no EVM/Hollar-minting setup.
+
+use crate::driver::HydrationTestDriver;
+use frame_support::dispatch::RawOrigin;
+use frame_support::{assert_noop, assert_ok, BoundedVec};
+use hydradx_runtime::*;
+use pallet_asset_registry::AssetType;
+use pretty_assertions::assert_eq;
+use primitives::{AssetId, Balance};
+use sp_runtime::traits::One;
+use sp_runtime::{Perbill, Permill};
+
+const PATH_TO_SNAPSHOT: &str = "snapshots/hsm/SNAPSHOT";
+
+// Hollar and DAI already exist in the HSM snapshot; the stableswap share asset
+// id is drawn from the reserved 4500-4559 range to avoid collisions.
+const HOLLAR: AssetId = 222;
+const COLLATERAL: AssetId = 2;
+const POOL_ID: AssetId = 4542;
+
+const ONE: Balance = 1_000_000_000_000_000_000;
+
+// Creates a fresh stableswap pool holding Hollar + collateral and registers the
+// collateral in HSM. Returns the driver so callers can keep operating on the
+// same externalities.
+fn setup_with_collateral() -> HydrationTestDriver {
+	let driver = HydrationTestDriver::with_snapshot(PATH_TO_SNAPSHOT);
+	driver.execute(|| {
+		assert_ok!(AssetRegistry::register(
+			RawOrigin::Root.into(),
+			Some(POOL_ID),
+			Some(b"admpool".to_vec().try_into().unwrap()),
+			AssetType::StableSwap,
+			Some(1u128),
+			None,
+			None,
+			None,
+			None,
+			true,
+		));
+		assert_ok!(Stableswap::create_pool(
+			RuntimeOrigin::root(),
+			POOL_ID,
+			BoundedVec::truncate_from(vec![HOLLAR, COLLATERAL]),
+			100u16,
+			Permill::from_percent(1),
+		));
+		assert_ok!(HSM::add_collateral_asset(
+			RuntimeOrigin::root(),
+			COLLATERAL,
+			POOL_ID,
+			Permill::zero(),
+			FixedU128::one(),
+			Permill::zero(),
+			Perbill::from_percent(70),
+			None,
+		));
+	});
+	driver
+}
+
+#[test]
+fn update_collateral_asset_should_change_config_when_called_by_authority() {
+	let driver = setup_with_collateral();
+	driver.execute(|| {
+		let before = HSM::collaterals(COLLATERAL).expect("collateral was registered in setup");
+		assert_eq!(before.purchase_fee, Permill::zero());
+		assert_eq!(before.buy_back_fee, Permill::zero());
+		assert_eq!(before.buyback_rate, Perbill::from_percent(70));
+		assert_eq!(before.max_in_holding, None);
+
+		assert_ok!(HSM::update_collateral_asset(
+			RuntimeOrigin::root(),
+			COLLATERAL,
+			Some(Permill::from_percent(2)),
+			None,
+			Some(Permill::from_percent(3)),
+			Some(Perbill::from_percent(50)),
+			Some(Some(1_000 * ONE)),
+		));
+
+		let after = HSM::collaterals(COLLATERAL).expect("collateral still registered after update");
+		// Provided parameters changed.
+		assert_eq!(after.purchase_fee, Permill::from_percent(2));
+		assert_eq!(after.buy_back_fee, Permill::from_percent(3));
+		assert_eq!(after.buyback_rate, Perbill::from_percent(50));
+		assert_eq!(after.max_in_holding, Some(1_000 * ONE));
+		// Omitted parameters preserved.
+		assert_eq!(after.pool_id, POOL_ID);
+		assert_eq!(after.max_buy_price_coefficient, before.max_buy_price_coefficient);
+	});
+}
+
+#[test]
+fn update_collateral_asset_should_fail_when_asset_not_collateral() {
+	HydrationTestDriver::with_snapshot(PATH_TO_SNAPSHOT).execute(|| {
+		assert_noop!(
+			HSM::update_collateral_asset(
+				RuntimeOrigin::root(),
+				COLLATERAL,
+				Some(Permill::from_percent(1)),
+				None,
+				None,
+				None,
+				None,
+			),
+			pallet_hsm::Error::<hydradx_runtime::Runtime>::AssetNotApproved
+		);
+	});
+}
+
+#[test]
+fn remove_collateral_asset_should_clear_config_when_hsm_holding_is_empty() {
+	let driver = setup_with_collateral();
+	driver.execute(|| {
+		// Ensure the HSM account holds none of the collateral so removal is allowed.
+		assert_ok!(Tokens::set_balance(
+			RawOrigin::Root.into(),
+			HSM::account_id(),
+			COLLATERAL,
+			0,
+			0,
+		));
+		assert!(HSM::collaterals(COLLATERAL).is_some());
+
+		assert_ok!(HSM::remove_collateral_asset(RuntimeOrigin::root(), COLLATERAL));
+
+		assert_eq!(HSM::collaterals(COLLATERAL), None);
+	});
+}
+
+#[test]
+fn remove_collateral_asset_should_fail_when_hsm_still_holds_collateral() {
+	let driver = setup_with_collateral();
+	driver.execute(|| {
+		assert_ok!(Tokens::set_balance(
+			RawOrigin::Root.into(),
+			HSM::account_id(),
+			COLLATERAL,
+			ONE,
+			0,
+		));
+
+		assert_noop!(
+			HSM::remove_collateral_asset(RuntimeOrigin::root(), COLLATERAL),
+			pallet_hsm::Error::<hydradx_runtime::Runtime>::CollateralNotEmpty
+		);
+
+		// Config must remain intact after the rejected removal.
+		assert!(HSM::collaterals(COLLATERAL).is_some());
+	});
+}

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -45,6 +45,7 @@ mod router;
 mod sessions;
 mod stableswap;
 mod stableswap_curve_comparison;
+mod stableswap_extra;
 mod staking;
 mod transact_call_filter;
 mod utility;

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -2,6 +2,8 @@
 // DCA pallet uses dummy router for benchmarks and some tests fail when benchmarking feature is enabled
 #![cfg(not(feature = "runtime-benchmarks"))]
 mod aave_router;
+mod admin_misc_extra;
+mod amm_misc_extra;
 mod asset_registry;
 mod bonds;
 mod call_filter;
@@ -25,11 +27,14 @@ mod gigahdx;
 mod gigahdx_rewards;
 mod global_withdraw_limit;
 mod hsm;
+mod hsm_admin_extra;
 mod insufficient_assets_ed;
 mod liquidation;
+mod liquidity_mining_extra;
 mod multi_payment;
 mod non_native_fee;
 mod omnipool_add_all_liquidity;
+mod omnipool_extra;
 mod omnipool_fixed_fees;
 mod omnipool_init;
 mod omnipool_liquidity_mining;
@@ -43,6 +48,7 @@ mod polkadot_test_net;
 mod referrals;
 mod router;
 mod sessions;
+mod signet;
 mod stableswap;
 mod stableswap_curve_comparison;
 mod stableswap_extra;
@@ -54,6 +60,7 @@ mod vesting;
 mod xcm;
 mod xcm_aliasers;
 mod xyk;
+mod xyk_extra;
 mod xyk_liquidity_mining;
 
 #[macro_export]

--- a/integration-tests/src/liquidity_mining_extra.rs
+++ b/integration-tests/src/liquidity_mining_extra.rs
@@ -1,0 +1,613 @@
+// This file is part of HydraDX-node.
+
+// Copyright (C) 2020-2023  Intergalactic, Limited (GIB).
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration coverage for the yield-farm lifecycle admin extrinsics of both liquidity-mining
+//! pallets: `stop_yield_farm`, `resume_yield_farm`, `update_yield_farm`, `terminate_yield_farm`,
+//! `terminate_global_farm` (and `update_global_farm` for xyk).
+
+#![cfg(test)]
+
+use crate::polkadot_test_net::*;
+use frame_support::{assert_noop, assert_ok};
+use hydradx_runtime::{
+	Balances, OmnipoolLiquidityMining, OmnipoolWarehouseLM, Runtime, RuntimeOrigin, XYKLiquidityMining, XYKWarehouseLM,
+	XYK,
+};
+use hydradx_traits::AMM;
+use pallet_xyk::types::AssetPair;
+use sp_runtime::{traits::One, FixedU128, Permill, Perquintill};
+use warehouse_liquidity_mining::{GlobalFarmId, Instance1, Instance2, LoyaltyCurve, YieldFarmId};
+use xcm_emulator::TestExt;
+
+// ---------------------------------------------------------------------------
+// Omnipool liquidity mining
+// ---------------------------------------------------------------------------
+
+mod omnipool {
+	use super::*;
+
+	/// Creates a running omnipool yield farm and returns `(global_farm_id, yield_farm_id)`.
+	fn setup_running_farm() -> (GlobalFarmId, YieldFarmId) {
+		init_omnipool();
+
+		// The farm asset must be an omnipool token; `init_omnipool` only seeds HDX and DAI.
+		assert_ok!(hydradx_runtime::Omnipool::add_token(
+			RuntimeOrigin::root(),
+			DOT,
+			FixedU128::from_inner(25_650_000_000_000_000_000),
+			Permill::from_percent(100),
+			AccountId::from(BOB),
+		));
+
+		go_to_block(100);
+		let owner = Treasury::account_id();
+		let total_rewards = 1_000_000 * UNITS;
+		assert_ok!(Balances::force_set_balance(
+			RuntimeOrigin::root(),
+			owner.clone(),
+			total_rewards,
+		));
+		assert_ok!(OmnipoolLiquidityMining::create_global_farm(
+			RuntimeOrigin::root(),
+			total_rewards,
+			1_000_000,
+			10,
+			HDX,
+			owner.clone(),
+			Perquintill::from_parts(570_776_255_707),
+			1_000,
+			FixedU128::one(),
+		));
+
+		go_to_block(200);
+		assert_ok!(OmnipoolLiquidityMining::create_yield_farm(
+			RuntimeOrigin::signed(owner),
+			1,
+			DOT,
+			FixedU128::one(),
+			Some(LoyaltyCurve::default()),
+		));
+
+		(1, 2)
+	}
+
+	#[test]
+	fn stop_yield_farm_should_deactivate_yield_farm_when_called_by_owner() {
+		TestNet::reset();
+
+		Hydra::execute_with(|| {
+			let (global_farm_id, yield_farm_id) = setup_running_farm();
+			assert_eq!(
+				OmnipoolWarehouseLM::active_yield_farm(DOT, global_farm_id),
+				Some(yield_farm_id)
+			);
+
+			go_to_block(300);
+			assert_ok!(OmnipoolLiquidityMining::stop_yield_farm(
+				RuntimeOrigin::signed(Treasury::account_id()),
+				global_farm_id,
+				DOT,
+			));
+
+			assert_eq!(OmnipoolWarehouseLM::active_yield_farm(DOT, global_farm_id), None);
+			expect_hydra_events(vec![pallet_omnipool_liquidity_mining::Event::YieldFarmStopped {
+				global_farm_id,
+				yield_farm_id,
+				asset_id: DOT,
+				who: Treasury::account_id(),
+			}
+			.into()]);
+		});
+	}
+
+	#[test]
+	fn resume_yield_farm_should_reactivate_yield_farm_when_previously_stopped() {
+		TestNet::reset();
+
+		Hydra::execute_with(|| {
+			let (global_farm_id, yield_farm_id) = setup_running_farm();
+
+			go_to_block(300);
+			assert_ok!(OmnipoolLiquidityMining::stop_yield_farm(
+				RuntimeOrigin::signed(Treasury::account_id()),
+				global_farm_id,
+				DOT,
+			));
+			assert_eq!(OmnipoolWarehouseLM::active_yield_farm(DOT, global_farm_id), None);
+
+			go_to_block(400);
+			let multiplier = FixedU128::from(2);
+			assert_ok!(OmnipoolLiquidityMining::resume_yield_farm(
+				RuntimeOrigin::signed(Treasury::account_id()),
+				global_farm_id,
+				yield_farm_id,
+				DOT,
+				multiplier,
+			));
+
+			assert_eq!(
+				OmnipoolWarehouseLM::active_yield_farm(DOT, global_farm_id),
+				Some(yield_farm_id)
+			);
+			expect_hydra_events(vec![pallet_omnipool_liquidity_mining::Event::YieldFarmResumed {
+				global_farm_id,
+				yield_farm_id,
+				asset_id: DOT,
+				who: Treasury::account_id(),
+				multiplier,
+			}
+			.into()]);
+		});
+	}
+
+	#[test]
+	fn update_yield_farm_should_change_multiplier_when_called_by_owner() {
+		TestNet::reset();
+
+		Hydra::execute_with(|| {
+			let (global_farm_id, yield_farm_id) = setup_running_farm();
+
+			go_to_block(300);
+			let new_multiplier = FixedU128::from(5);
+			assert_ok!(OmnipoolLiquidityMining::update_yield_farm(
+				RuntimeOrigin::signed(Treasury::account_id()),
+				global_farm_id,
+				DOT,
+				new_multiplier,
+			));
+
+			expect_hydra_events(vec![pallet_omnipool_liquidity_mining::Event::YieldFarmUpdated {
+				global_farm_id,
+				yield_farm_id,
+				asset_id: DOT,
+				who: Treasury::account_id(),
+				multiplier: new_multiplier,
+			}
+			.into()]);
+		});
+	}
+
+	#[test]
+	fn terminate_yield_farm_should_remove_yield_farm_when_stopped_and_empty() {
+		TestNet::reset();
+
+		Hydra::execute_with(|| {
+			let (global_farm_id, yield_farm_id) = setup_running_farm();
+
+			go_to_block(300);
+			assert_ok!(OmnipoolLiquidityMining::stop_yield_farm(
+				RuntimeOrigin::signed(Treasury::account_id()),
+				global_farm_id,
+				DOT,
+			));
+
+			go_to_block(400);
+			assert_ok!(OmnipoolLiquidityMining::terminate_yield_farm(
+				RuntimeOrigin::signed(Treasury::account_id()),
+				global_farm_id,
+				yield_farm_id,
+				DOT,
+			));
+
+			// Empty yield farm is removed from storage immediately.
+			assert!(warehouse_liquidity_mining::YieldFarm::<Runtime, Instance1>::get((
+				DOT,
+				global_farm_id,
+				yield_farm_id
+			))
+			.is_none());
+			expect_hydra_events(vec![pallet_omnipool_liquidity_mining::Event::YieldFarmTerminated {
+				global_farm_id,
+				yield_farm_id,
+				asset_id: DOT,
+				who: Treasury::account_id(),
+			}
+			.into()]);
+		});
+	}
+
+	#[test]
+	fn terminate_global_farm_should_remove_global_farm_when_all_yield_farms_terminated() {
+		TestNet::reset();
+
+		Hydra::execute_with(|| {
+			let (global_farm_id, yield_farm_id) = setup_running_farm();
+
+			go_to_block(300);
+			assert_ok!(OmnipoolLiquidityMining::stop_yield_farm(
+				RuntimeOrigin::signed(Treasury::account_id()),
+				global_farm_id,
+				DOT,
+			));
+			assert_ok!(OmnipoolLiquidityMining::terminate_yield_farm(
+				RuntimeOrigin::signed(Treasury::account_id()),
+				global_farm_id,
+				yield_farm_id,
+				DOT,
+			));
+
+			go_to_block(400);
+			assert_ok!(OmnipoolLiquidityMining::terminate_global_farm(
+				RuntimeOrigin::signed(Treasury::account_id()),
+				global_farm_id,
+			));
+
+			assert!(OmnipoolWarehouseLM::global_farm(global_farm_id).is_none());
+			expect_hydra_events(vec![pallet_omnipool_liquidity_mining::Event::GlobalFarmTerminated {
+				global_farm_id,
+				who: Treasury::account_id(),
+				reward_currency: HDX,
+				undistributed_rewards: 1_000_000 * UNITS,
+			}
+			.into()]);
+		});
+	}
+
+	#[test]
+	fn terminate_global_farm_should_fail_when_yield_farm_still_exists() {
+		TestNet::reset();
+
+		Hydra::execute_with(|| {
+			let (global_farm_id, _) = setup_running_farm();
+
+			go_to_block(300);
+			assert_noop!(
+				OmnipoolLiquidityMining::terminate_global_farm(
+					RuntimeOrigin::signed(Treasury::account_id()),
+					global_farm_id,
+				),
+				warehouse_liquidity_mining::Error::<Runtime, Instance1>::GlobalFarmIsNotEmpty
+			);
+		});
+	}
+
+	#[test]
+	fn terminate_yield_farm_should_fail_when_yield_farm_is_still_active() {
+		TestNet::reset();
+
+		Hydra::execute_with(|| {
+			let (global_farm_id, yield_farm_id) = setup_running_farm();
+
+			go_to_block(300);
+			assert_noop!(
+				OmnipoolLiquidityMining::terminate_yield_farm(
+					RuntimeOrigin::signed(Treasury::account_id()),
+					global_farm_id,
+					yield_farm_id,
+					DOT,
+				),
+				warehouse_liquidity_mining::Error::<Runtime, Instance1>::LiquidityMiningIsActive
+			);
+		});
+	}
+}
+
+// ---------------------------------------------------------------------------
+// XYK liquidity mining
+// ---------------------------------------------------------------------------
+
+mod xyk {
+	use super::*;
+
+	fn create_xyk_pool(asset_a: AssetId, amount_a: Balance, asset_b: AssetId, amount_b: Balance) {
+		assert_ok!(Currencies::update_balance(
+			RuntimeOrigin::root(),
+			DAVE.into(),
+			asset_a,
+			(amount_a + UNITS) as i128,
+		));
+		assert_ok!(Currencies::update_balance(
+			RuntimeOrigin::root(),
+			DAVE.into(),
+			asset_b,
+			(amount_b + UNITS) as i128,
+		));
+
+		assert_ok!(XYK::create_pool(
+			RuntimeOrigin::signed(DAVE.into()),
+			asset_a,
+			amount_a,
+			asset_b,
+			amount_b,
+		));
+	}
+
+	/// Creates a running xyk yield farm and returns `(global_farm_id, yield_farm_id, asset_pair, amm_pool_id)`.
+	fn setup_running_farm() -> (GlobalFarmId, YieldFarmId, AssetPair, AccountId) {
+		let asset_pair = AssetPair {
+			asset_in: PEPE,
+			asset_out: ACA,
+		};
+		let amm_pool_id = <Runtime as pallet_xyk_liquidity_mining::Config>::AMM::get_pair_id(asset_pair);
+
+		go_to_block(100);
+		let owner = Treasury::account_id();
+		let total_rewards = 1_000_000 * UNITS;
+		assert_ok!(Currencies::update_balance(
+			RuntimeOrigin::root(),
+			owner.clone(),
+			HDX,
+			total_rewards as i128 + 1_000,
+		));
+		assert_ok!(XYKLiquidityMining::create_global_farm(
+			RuntimeOrigin::root(),
+			total_rewards,
+			1_000_000,
+			10,
+			PEPE,
+			HDX,
+			owner.clone(),
+			Perquintill::from_parts(570_776_255_707),
+			1_000,
+			FixedU128::one(),
+		));
+
+		create_xyk_pool(
+			asset_pair.asset_in,
+			1_000_000 * UNITS,
+			asset_pair.asset_out,
+			10_000_000 * UNITS,
+		);
+
+		go_to_block(200);
+		assert_ok!(XYKLiquidityMining::create_yield_farm(
+			RuntimeOrigin::signed(owner),
+			1,
+			asset_pair,
+			FixedU128::one(),
+			Some(LoyaltyCurve::default()),
+		));
+
+		(1, 2, asset_pair, amm_pool_id)
+	}
+
+	#[test]
+	fn stop_yield_farm_should_deactivate_yield_farm_when_called_by_owner() {
+		TestNet::reset();
+
+		Hydra::execute_with(|| {
+			let (global_farm_id, yield_farm_id, asset_pair, amm_pool_id) = setup_running_farm();
+			assert_eq!(
+				XYKWarehouseLM::active_yield_farm(amm_pool_id.clone(), global_farm_id),
+				Some(yield_farm_id)
+			);
+
+			go_to_block(300);
+			assert_ok!(XYKLiquidityMining::stop_yield_farm(
+				RuntimeOrigin::signed(Treasury::account_id()),
+				global_farm_id,
+				asset_pair,
+			));
+
+			assert_eq!(XYKWarehouseLM::active_yield_farm(amm_pool_id, global_farm_id), None);
+			expect_hydra_events(vec![pallet_xyk_liquidity_mining::Event::YieldFarmStopped {
+				global_farm_id,
+				yield_farm_id,
+				who: Treasury::account_id(),
+				asset_pair,
+			}
+			.into()]);
+		});
+	}
+
+	#[test]
+	fn resume_yield_farm_should_reactivate_yield_farm_when_previously_stopped() {
+		TestNet::reset();
+
+		Hydra::execute_with(|| {
+			let (global_farm_id, yield_farm_id, asset_pair, amm_pool_id) = setup_running_farm();
+
+			go_to_block(300);
+			assert_ok!(XYKLiquidityMining::stop_yield_farm(
+				RuntimeOrigin::signed(Treasury::account_id()),
+				global_farm_id,
+				asset_pair,
+			));
+			assert_eq!(
+				XYKWarehouseLM::active_yield_farm(amm_pool_id.clone(), global_farm_id),
+				None
+			);
+
+			go_to_block(400);
+			let multiplier = FixedU128::from(2);
+			assert_ok!(XYKLiquidityMining::resume_yield_farm(
+				RuntimeOrigin::signed(Treasury::account_id()),
+				global_farm_id,
+				yield_farm_id,
+				asset_pair,
+				multiplier,
+			));
+
+			assert_eq!(
+				XYKWarehouseLM::active_yield_farm(amm_pool_id, global_farm_id),
+				Some(yield_farm_id)
+			);
+			expect_hydra_events(vec![pallet_xyk_liquidity_mining::Event::YieldFarmResumed {
+				global_farm_id,
+				yield_farm_id,
+				who: Treasury::account_id(),
+				asset_pair,
+				multiplier,
+			}
+			.into()]);
+		});
+	}
+
+	#[test]
+	fn update_yield_farm_should_change_multiplier_when_called_by_owner() {
+		TestNet::reset();
+
+		Hydra::execute_with(|| {
+			let (global_farm_id, yield_farm_id, asset_pair, _) = setup_running_farm();
+
+			go_to_block(300);
+			let new_multiplier = FixedU128::from(5);
+			assert_ok!(XYKLiquidityMining::update_yield_farm(
+				RuntimeOrigin::signed(Treasury::account_id()),
+				global_farm_id,
+				asset_pair,
+				new_multiplier,
+			));
+
+			expect_hydra_events(vec![pallet_xyk_liquidity_mining::Event::YieldFarmUpdated {
+				global_farm_id,
+				yield_farm_id,
+				who: Treasury::account_id(),
+				asset_pair,
+				multiplier: new_multiplier,
+			}
+			.into()]);
+		});
+	}
+
+	#[test]
+	fn update_global_farm_should_change_price_adjustment_when_called_by_owner() {
+		TestNet::reset();
+
+		Hydra::execute_with(|| {
+			let (global_farm_id, _, _, _) = setup_running_farm();
+
+			go_to_block(300);
+			let price_adjustment = FixedU128::from(3);
+			assert_ok!(XYKLiquidityMining::update_global_farm(
+				RuntimeOrigin::signed(Treasury::account_id()),
+				global_farm_id,
+				price_adjustment,
+			));
+
+			expect_hydra_events(vec![pallet_xyk_liquidity_mining::Event::GlobalFarmUpdated {
+				id: global_farm_id,
+				price_adjustment,
+			}
+			.into()]);
+		});
+	}
+
+	#[test]
+	fn terminate_yield_farm_should_remove_yield_farm_when_stopped_and_empty() {
+		TestNet::reset();
+
+		Hydra::execute_with(|| {
+			let (global_farm_id, yield_farm_id, asset_pair, amm_pool_id) = setup_running_farm();
+
+			go_to_block(300);
+			assert_ok!(XYKLiquidityMining::stop_yield_farm(
+				RuntimeOrigin::signed(Treasury::account_id()),
+				global_farm_id,
+				asset_pair,
+			));
+
+			go_to_block(400);
+			assert_ok!(XYKLiquidityMining::terminate_yield_farm(
+				RuntimeOrigin::signed(Treasury::account_id()),
+				global_farm_id,
+				yield_farm_id,
+				asset_pair,
+			));
+
+			// Empty yield farm is removed from storage immediately.
+			assert!(warehouse_liquidity_mining::YieldFarm::<Runtime, Instance2>::get((
+				amm_pool_id,
+				global_farm_id,
+				yield_farm_id
+			))
+			.is_none());
+			expect_hydra_events(vec![pallet_xyk_liquidity_mining::Event::YieldFarmTerminated {
+				global_farm_id,
+				yield_farm_id,
+				who: Treasury::account_id(),
+				asset_pair,
+			}
+			.into()]);
+		});
+	}
+
+	#[test]
+	fn terminate_global_farm_should_remove_global_farm_when_all_yield_farms_terminated() {
+		TestNet::reset();
+
+		Hydra::execute_with(|| {
+			let (global_farm_id, yield_farm_id, asset_pair, _) = setup_running_farm();
+
+			go_to_block(300);
+			assert_ok!(XYKLiquidityMining::stop_yield_farm(
+				RuntimeOrigin::signed(Treasury::account_id()),
+				global_farm_id,
+				asset_pair,
+			));
+			assert_ok!(XYKLiquidityMining::terminate_yield_farm(
+				RuntimeOrigin::signed(Treasury::account_id()),
+				global_farm_id,
+				yield_farm_id,
+				asset_pair,
+			));
+
+			go_to_block(400);
+			assert_ok!(XYKLiquidityMining::terminate_global_farm(
+				RuntimeOrigin::signed(Treasury::account_id()),
+				global_farm_id,
+			));
+
+			assert!(XYKWarehouseLM::global_farm(global_farm_id).is_none());
+			expect_hydra_events(vec![pallet_xyk_liquidity_mining::Event::GlobalFarmTerminated {
+				global_farm_id,
+				who: Treasury::account_id(),
+				reward_currency: HDX,
+				undistributed_rewards: 1_000_000 * UNITS,
+			}
+			.into()]);
+		});
+	}
+
+	#[test]
+	fn terminate_global_farm_should_fail_when_yield_farm_still_exists() {
+		TestNet::reset();
+
+		Hydra::execute_with(|| {
+			let (global_farm_id, _, _, _) = setup_running_farm();
+
+			go_to_block(300);
+			assert_noop!(
+				XYKLiquidityMining::terminate_global_farm(
+					RuntimeOrigin::signed(Treasury::account_id()),
+					global_farm_id,
+				),
+				warehouse_liquidity_mining::Error::<Runtime, Instance2>::GlobalFarmIsNotEmpty
+			);
+		});
+	}
+
+	#[test]
+	fn terminate_yield_farm_should_fail_when_yield_farm_is_still_active() {
+		TestNet::reset();
+
+		Hydra::execute_with(|| {
+			let (global_farm_id, yield_farm_id, asset_pair, _) = setup_running_farm();
+
+			go_to_block(300);
+			assert_noop!(
+				XYKLiquidityMining::terminate_yield_farm(
+					RuntimeOrigin::signed(Treasury::account_id()),
+					global_farm_id,
+					yield_farm_id,
+					asset_pair,
+				),
+				warehouse_liquidity_mining::Error::<Runtime, Instance2>::LiquidityMiningIsActive
+			);
+		});
+	}
+}

--- a/integration-tests/src/omnipool_extra.rs
+++ b/integration-tests/src/omnipool_extra.rs
@@ -1,0 +1,217 @@
+#![cfg(test)]
+
+// Integration coverage for omnipool extrinsics the suite otherwise exercises only
+// at the pallet level: the slippage-protected `remove_liquidity_with_limit` and the
+// authority-gated `refund_refused_asset`.
+
+use crate::omnipool_init::hydra_run_to_block;
+use crate::polkadot_test_net::LRNA;
+use crate::polkadot_test_net::*;
+
+use frame_support::{assert_noop, assert_ok};
+use hydradx_runtime::*;
+use orml_traits::MultiCurrency;
+use pallet_omnipool::types::Tradability;
+use pretty_assertions::assert_eq;
+use sp_runtime::{FixedU128, Permill};
+use xcm_emulator::TestExt;
+
+const DOT_PRICE: FixedU128 = FixedU128::from_inner(25_650_000_000_000_000_000);
+
+// Add DOT to the omnipool with `owner` holding the initial LP position, then advance
+// a few blocks and enable removals. Returns the position id created by `add_token`.
+fn add_dot_position(owner: AccountId) -> u128 {
+	let position_id = Omnipool::next_position_id();
+
+	assert_ok!(Omnipool::add_token(
+		RuntimeOrigin::root(),
+		DOT,
+		DOT_PRICE,
+		Permill::from_percent(100),
+		owner,
+	));
+
+	hydra_run_to_block(10);
+
+	assert_ok!(Omnipool::set_asset_tradable_state(
+		RuntimeOrigin::root(),
+		DOT,
+		Tradability::ADD_LIQUIDITY | Tradability::REMOVE_LIQUIDITY,
+	));
+
+	position_id
+}
+
+#[test]
+fn remove_liquidity_with_limit_should_return_asset_and_reduce_shares_when_limit_satisfied() {
+	TestNet::reset();
+
+	Hydra::execute_with(|| {
+		init_omnipool();
+
+		let lp = AccountId::from(BOB);
+		let position_id = add_dot_position(lp.clone());
+
+		let position =
+			pallet_omnipool::Pallet::<hydradx_runtime::Runtime>::load_position(position_id, lp.clone()).unwrap();
+		let remove_shares = position.shares / 2;
+		assert!(remove_shares > 0, "position must hold enough shares to halve");
+
+		let dot_before = Tokens::free_balance(DOT, &lp);
+
+		assert_ok!(Omnipool::remove_liquidity_with_limit(
+			RuntimeOrigin::signed(lp.clone()),
+			position_id,
+			remove_shares,
+			1, // a real, satisfiable min-out limit
+		));
+
+		// The withdrawn asset was credited to the LP.
+		assert!(Tokens::free_balance(DOT, &lp) > dot_before);
+
+		// Partial removal leaves the position in place with exactly `remove_shares` fewer shares.
+		let updated =
+			pallet_omnipool::Pallet::<hydradx_runtime::Runtime>::load_position(position_id, lp.clone()).unwrap();
+		assert_eq!(updated.shares, position.shares - remove_shares);
+	});
+}
+
+#[test]
+fn remove_liquidity_with_limit_should_fail_when_min_limit_exceeds_amount_out() {
+	TestNet::reset();
+
+	Hydra::execute_with(|| {
+		init_omnipool();
+
+		let lp = AccountId::from(BOB);
+		let position_id = add_dot_position(lp.clone());
+
+		let position =
+			pallet_omnipool::Pallet::<hydradx_runtime::Runtime>::load_position(position_id, lp.clone()).unwrap();
+
+		assert_noop!(
+			Omnipool::remove_liquidity_with_limit(
+				RuntimeOrigin::signed(lp),
+				position_id,
+				position.shares,
+				u128::MAX, // impossible min-out limit
+			),
+			pallet_omnipool::Error::<hydradx_runtime::Runtime>::SlippageLimit
+		);
+	});
+}
+
+#[test]
+fn refund_refused_asset_should_transfer_to_recipient_when_called_by_authority() {
+	TestNet::reset();
+
+	Hydra::execute_with(|| {
+		init_omnipool();
+
+		// DOT is registered but not added to the omnipool. Simulate a refused add: the initial
+		// liquidity was already transferred to the pool account and now has to be refunded.
+		let protocol = Omnipool::protocol_account();
+		let recipient = AccountId::from(CHARLIE);
+		let refund_amount = 100 * UNITS;
+
+		assert_ok!(Currencies::transfer(
+			RuntimeOrigin::signed(AccountId::from(ALICE)),
+			protocol.clone(),
+			DOT,
+			refund_amount,
+		));
+
+		let recipient_before = Tokens::free_balance(DOT, &recipient);
+		let protocol_before = Tokens::free_balance(DOT, &protocol);
+
+		assert_ok!(Omnipool::refund_refused_asset(
+			RuntimeOrigin::root(),
+			DOT,
+			refund_amount,
+			recipient.clone(),
+		));
+
+		assert_eq!(Tokens::free_balance(DOT, &recipient), recipient_before + refund_amount);
+		assert_eq!(Tokens::free_balance(DOT, &protocol), protocol_before - refund_amount);
+	});
+}
+
+#[test]
+fn refund_refused_asset_should_fail_when_origin_not_authority() {
+	TestNet::reset();
+
+	Hydra::execute_with(|| {
+		init_omnipool();
+
+		let protocol = Omnipool::protocol_account();
+		let refund_amount = 100 * UNITS;
+		assert_ok!(Currencies::transfer(
+			RuntimeOrigin::signed(AccountId::from(ALICE)),
+			protocol,
+			DOT,
+			refund_amount,
+		));
+
+		assert_noop!(
+			Omnipool::refund_refused_asset(
+				RuntimeOrigin::signed(AccountId::from(CHARLIE)),
+				DOT,
+				refund_amount,
+				AccountId::from(CHARLIE),
+			),
+			sp_runtime::DispatchError::BadOrigin
+		);
+	});
+}
+
+#[test]
+fn refund_refused_asset_should_fail_when_asset_already_in_pool() {
+	TestNet::reset();
+
+	Hydra::execute_with(|| {
+		init_omnipool();
+
+		// Once DOT is a live omnipool asset it can no longer be treated as a refused refund.
+		assert_ok!(Omnipool::add_token(
+			RuntimeOrigin::root(),
+			DOT,
+			DOT_PRICE,
+			Permill::from_percent(100),
+			AccountId::from(BOB),
+		));
+
+		assert_noop!(
+			Omnipool::refund_refused_asset(RuntimeOrigin::root(), DOT, UNITS, AccountId::from(CHARLIE),),
+			pallet_omnipool::Error::<hydradx_runtime::Runtime>::AssetAlreadyAdded
+		);
+	});
+}
+
+#[test]
+fn refund_refused_asset_should_fail_when_asset_is_hub_asset() {
+	TestNet::reset();
+
+	Hydra::execute_with(|| {
+		init_omnipool();
+
+		assert_noop!(
+			Omnipool::refund_refused_asset(RuntimeOrigin::root(), LRNA, UNITS, AccountId::from(CHARLIE),),
+			pallet_omnipool::Error::<hydradx_runtime::Runtime>::AssetRefundNotAllowed
+		);
+	});
+}
+
+#[test]
+fn refund_refused_asset_should_fail_when_protocol_balance_insufficient() {
+	TestNet::reset();
+
+	Hydra::execute_with(|| {
+		init_omnipool();
+
+		// DOT is registered and not in the pool, but the protocol account holds none of it.
+		assert_noop!(
+			Omnipool::refund_refused_asset(RuntimeOrigin::root(), DOT, 100 * UNITS, AccountId::from(CHARLIE),),
+			pallet_omnipool::Error::<hydradx_runtime::Runtime>::InsufficientBalance
+		);
+	});
+}

--- a/integration-tests/src/signet.rs
+++ b/integration-tests/src/signet.rs
@@ -1,0 +1,392 @@
+#![cfg(test)]
+
+use crate::polkadot_test_net::*;
+use frame_support::{assert_noop, assert_ok, BoundedVec};
+use hydradx_runtime::*;
+use pretty_assertions::assert_eq;
+use xcm_emulator::TestExt;
+
+const DEPOSIT: Balance = 100 * UNITS;
+const CHAIN_ID: &[u8] = b"eip155:11155111";
+const MAX_CHAIN_ID_LENGTH: u32 = 128;
+const MAX_EVM_DATA_LENGTH: u32 = 100_000;
+
+type SignetError = pallet_signet::Error<hydradx_runtime::Runtime>;
+
+fn configure_signet(deposit: Balance) {
+	assert_ok!(Signet::set_config(
+		RuntimeOrigin::root(),
+		deposit,
+		MAX_CHAIN_ID_LENGTH,
+		MAX_EVM_DATA_LENGTH,
+		BoundedVec::truncate_from(CHAIN_ID.to_vec()),
+	));
+}
+
+fn test_signature() -> pallet_signet::Signature {
+	pallet_signet::Signature {
+		big_r: pallet_signet::AffinePoint {
+			x: [1u8; 32],
+			y: [2u8; 32],
+		},
+		s: [3u8; 32],
+		recovery_id: 0,
+	}
+}
+
+fn sign_call(who: [u8; 32]) -> frame_support::pallet_prelude::DispatchResult {
+	Signet::sign(
+		RuntimeOrigin::signed(who.into()),
+		[42u8; 32],
+		1,
+		BoundedVec::truncate_from(b"path".to_vec()),
+		BoundedVec::truncate_from(b"ecdsa".to_vec()),
+		BoundedVec::truncate_from(b"dest".to_vec()),
+		BoundedVec::truncate_from(b"{}".to_vec()),
+	)
+}
+
+// -----------------------------------------------------------------------------
+// set_config
+// -----------------------------------------------------------------------------
+
+#[test]
+fn set_config_should_store_configuration_when_called_by_root() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		assert_eq!(Signet::signet_config(), None);
+
+		configure_signet(DEPOSIT);
+
+		let config = Signet::signet_config().unwrap();
+		assert_eq!(config.signature_deposit, DEPOSIT);
+		assert_eq!(config.max_chain_id_length, MAX_CHAIN_ID_LENGTH);
+		assert_eq!(config.max_evm_data_length, MAX_EVM_DATA_LENGTH);
+		assert_eq!(config.chain_id.to_vec(), CHAIN_ID.to_vec());
+		assert!(!config.paused);
+	});
+}
+
+#[test]
+fn set_config_should_fail_when_called_by_non_authority() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		assert_noop!(
+			Signet::set_config(
+				RuntimeOrigin::signed(ALICE.into()),
+				DEPOSIT,
+				MAX_CHAIN_ID_LENGTH,
+				MAX_EVM_DATA_LENGTH,
+				BoundedVec::truncate_from(CHAIN_ID.to_vec()),
+			),
+			sp_runtime::DispatchError::BadOrigin
+		);
+	});
+}
+
+#[test]
+fn set_config_should_preserve_paused_flag_when_reconfigured() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		configure_signet(DEPOSIT);
+		assert_ok!(Signet::pause(RuntimeOrigin::root()));
+		assert!(Signet::signet_config().unwrap().paused);
+
+		configure_signet(2 * DEPOSIT);
+
+		let config = Signet::signet_config().unwrap();
+		assert_eq!(config.signature_deposit, 2 * DEPOSIT);
+		assert!(config.paused);
+	});
+}
+
+// -----------------------------------------------------------------------------
+// pause / unpause
+// -----------------------------------------------------------------------------
+
+#[test]
+fn pause_should_set_paused_flag_when_called_by_root() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		configure_signet(DEPOSIT);
+
+		assert_ok!(Signet::pause(RuntimeOrigin::root()));
+
+		assert!(Signet::signet_config().unwrap().paused);
+	});
+}
+
+#[test]
+fn unpause_should_clear_paused_flag_when_called_by_root() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		configure_signet(DEPOSIT);
+		assert_ok!(Signet::pause(RuntimeOrigin::root()));
+
+		assert_ok!(Signet::unpause(RuntimeOrigin::root()));
+
+		assert!(!Signet::signet_config().unwrap().paused);
+	});
+}
+
+#[test]
+fn pause_should_fail_when_called_by_non_authority() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		configure_signet(DEPOSIT);
+
+		assert_noop!(
+			Signet::pause(RuntimeOrigin::signed(ALICE.into())),
+			sp_runtime::DispatchError::BadOrigin
+		);
+	});
+}
+
+#[test]
+fn unpause_should_fail_when_called_by_non_authority() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		configure_signet(DEPOSIT);
+		assert_ok!(Signet::pause(RuntimeOrigin::root()));
+
+		assert_noop!(
+			Signet::unpause(RuntimeOrigin::signed(ALICE.into())),
+			sp_runtime::DispatchError::BadOrigin
+		);
+	});
+}
+
+// -----------------------------------------------------------------------------
+// sign
+// -----------------------------------------------------------------------------
+
+#[test]
+fn sign_should_fail_when_not_configured() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		assert_noop!(sign_call(ALICE), SignetError::NotConfigured);
+	});
+}
+
+#[test]
+fn sign_should_fail_when_paused() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		configure_signet(DEPOSIT);
+		assert_ok!(Signet::pause(RuntimeOrigin::root()));
+
+		assert_noop!(sign_call(ALICE), SignetError::Paused);
+	});
+}
+
+#[test]
+fn sign_should_transfer_deposit_to_pallet_account_when_configured() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		configure_signet(DEPOSIT);
+
+		let requester: AccountId = ALICE.into();
+		let pallet_account = Signet::account_id();
+		let requester_before = Balances::free_balance(&requester);
+		let pallet_before = Balances::free_balance(&pallet_account);
+
+		assert_ok!(sign_call(ALICE));
+
+		assert_eq!(Balances::free_balance(&requester), requester_before - DEPOSIT);
+		assert_eq!(Balances::free_balance(&pallet_account), pallet_before + DEPOSIT);
+	});
+}
+
+// -----------------------------------------------------------------------------
+// sign_bidirectional
+// -----------------------------------------------------------------------------
+
+#[test]
+fn sign_bidirectional_should_fail_when_transaction_is_empty() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		configure_signet(DEPOSIT);
+
+		assert_noop!(
+			Signet::sign_bidirectional(
+				RuntimeOrigin::signed(ALICE.into()),
+				BoundedVec::truncate_from(vec![]),
+				BoundedVec::truncate_from(CHAIN_ID.to_vec()),
+				1,
+				BoundedVec::truncate_from(b"path".to_vec()),
+				BoundedVec::truncate_from(b"ecdsa".to_vec()),
+				BoundedVec::truncate_from(b"dest".to_vec()),
+				BoundedVec::truncate_from(b"{}".to_vec()),
+				BoundedVec::truncate_from(vec![]),
+				BoundedVec::truncate_from(vec![]),
+			),
+			SignetError::InvalidTransaction
+		);
+	});
+}
+
+#[test]
+fn sign_bidirectional_should_fail_when_not_configured() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		assert_noop!(
+			Signet::sign_bidirectional(
+				RuntimeOrigin::signed(ALICE.into()),
+				BoundedVec::truncate_from(b"tx".to_vec()),
+				BoundedVec::truncate_from(CHAIN_ID.to_vec()),
+				1,
+				BoundedVec::truncate_from(b"path".to_vec()),
+				BoundedVec::truncate_from(b"ecdsa".to_vec()),
+				BoundedVec::truncate_from(b"dest".to_vec()),
+				BoundedVec::truncate_from(b"{}".to_vec()),
+				BoundedVec::truncate_from(vec![]),
+				BoundedVec::truncate_from(vec![]),
+			),
+			SignetError::NotConfigured
+		);
+	});
+}
+
+// -----------------------------------------------------------------------------
+// withdraw_funds
+// -----------------------------------------------------------------------------
+
+#[test]
+fn withdraw_funds_should_fail_when_called_by_non_authority() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		assert_noop!(
+			Signet::withdraw_funds(RuntimeOrigin::signed(ALICE.into()), BOB.into(), DEPOSIT),
+			sp_runtime::DispatchError::BadOrigin
+		);
+	});
+}
+
+#[test]
+fn withdraw_funds_should_fail_when_insufficient_funds() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		assert_noop!(
+			Signet::withdraw_funds(RuntimeOrigin::root(), BOB.into(), DEPOSIT),
+			SignetError::InsufficientFunds
+		);
+	});
+}
+
+#[test]
+fn withdraw_funds_should_transfer_to_recipient_when_funds_available() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		configure_signet(DEPOSIT);
+		// Fund the pallet account deterministically by making a signature request.
+		assert_ok!(sign_call(ALICE));
+
+		let recipient: AccountId = BOB.into();
+		let pallet_account = Signet::account_id();
+		let recipient_before = Balances::free_balance(&recipient);
+		let pallet_before = Balances::free_balance(&pallet_account);
+		assert!(pallet_before >= DEPOSIT);
+
+		assert_ok!(Signet::withdraw_funds(
+			RuntimeOrigin::root(),
+			recipient.clone(),
+			DEPOSIT
+		));
+
+		assert_eq!(Balances::free_balance(&recipient), recipient_before + DEPOSIT);
+		assert_eq!(Balances::free_balance(&pallet_account), pallet_before - DEPOSIT);
+	});
+}
+
+// -----------------------------------------------------------------------------
+// respond / respond_error / respond_bidirectional
+// -----------------------------------------------------------------------------
+
+#[test]
+fn respond_should_emit_response_event_when_signed() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		let responder: AccountId = ALICE.into();
+		let request_id = [99u8; 32];
+		let signature = test_signature();
+
+		assert_ok!(Signet::respond(
+			RuntimeOrigin::signed(responder.clone()),
+			BoundedVec::truncate_from(vec![request_id]),
+			BoundedVec::truncate_from(vec![signature.clone()]),
+		));
+
+		expect_hydra_events(vec![pallet_signet::Event::SignatureResponded {
+			request_id,
+			responder,
+			signature,
+		}
+		.into()]);
+	});
+}
+
+#[test]
+fn respond_should_fail_when_arrays_length_mismatch() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		assert_noop!(
+			Signet::respond(
+				RuntimeOrigin::signed(ALICE.into()),
+				BoundedVec::truncate_from(vec![[1u8; 32], [2u8; 32]]),
+				BoundedVec::truncate_from(vec![test_signature()]),
+			),
+			SignetError::InvalidInputLength
+		);
+	});
+}
+
+#[test]
+fn respond_error_should_emit_error_event_when_signed() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		let responder: AccountId = ALICE.into();
+		let request_id = [7u8; 32];
+		let message = b"signature generation failed".to_vec();
+
+		assert_ok!(Signet::respond_error(
+			RuntimeOrigin::signed(responder.clone()),
+			BoundedVec::truncate_from(vec![pallet_signet::ErrorResponse {
+				request_id,
+				error_message: BoundedVec::truncate_from(message.clone()),
+			}]),
+		));
+
+		expect_hydra_events(vec![pallet_signet::Event::SignatureError {
+			request_id,
+			responder,
+			error: message,
+		}
+		.into()]);
+	});
+}
+
+#[test]
+fn respond_bidirectional_should_emit_event_when_signed() {
+	TestNet::reset();
+	Hydra::execute_with(|| {
+		let responder: AccountId = ALICE.into();
+		let request_id = [11u8; 32];
+		let output = b"read_output".to_vec();
+		let signature = test_signature();
+
+		assert_ok!(Signet::respond_bidirectional(
+			RuntimeOrigin::signed(responder.clone()),
+			request_id,
+			BoundedVec::truncate_from(output.clone()),
+			signature.clone(),
+		));
+
+		expect_hydra_events(vec![pallet_signet::Event::RespondBidirectionalEvent {
+			request_id,
+			responder,
+			serialized_output: output,
+			signature,
+		}
+		.into()]);
+	});
+}

--- a/integration-tests/src/stableswap_extra.rs
+++ b/integration-tests/src/stableswap_extra.rs
@@ -1,0 +1,249 @@
+// Integration coverage for stableswap extrinsics that the suite exercises only
+// at the pallet level: `buy`, `remove_liquidity`, `withdraw_asset_amount`, and
+// the authority-gated `update_amplification`, `update_asset_peg_source`, and
+// `update_pool_max_peg_update`.
+
+use crate::driver::HydrationTestDriver;
+use crate::polkadot_test_net::*;
+use frame_support::{assert_noop, assert_ok, BoundedVec};
+use hydradx_runtime::*;
+use hydradx_traits::stableswap::AssetAmount;
+use orml_traits::MultiCurrency;
+use pallet_stableswap::types::{BoundedPegSources, PegSource};
+use pretty_assertions::assert_eq;
+use sp_runtime::{Perbill, Permill};
+
+const ASSET_A: AssetId = 4200;
+const ASSET_B: AssetId = 4201;
+const POOL_ID: AssetId = 4242;
+
+const PEG_A: AssetId = 4300;
+const PEG_B: AssetId = 4301;
+const PEG_POOL: AssetId = 4342;
+
+const DEC: u8 = 18;
+const ONE: Balance = 1_000_000_000_000_000_000;
+const ENDOWMENT: Balance = 1_000_000 * ONE;
+const INITIAL_LIQUIDITY: Balance = 1_000 * ONE;
+
+fn balance(who: [u8; 32], asset: AssetId) -> Balance {
+	Tokens::free_balance(asset, &who.into())
+}
+
+fn plain_pool() -> HydrationTestDriver {
+	let driver = HydrationTestDriver::default()
+		.register_asset(ASSET_A, b"exSSA", DEC, None)
+		.register_asset(ASSET_B, b"exSSB", DEC, None)
+		.register_asset(POOL_ID, b"exSSP", DEC, None);
+	driver
+		.new_block()
+		.endow_account(ALICE.into(), ASSET_A, ENDOWMENT)
+		.endow_account(ALICE.into(), ASSET_B, ENDOWMENT)
+		.endow_account(BOB.into(), ASSET_A, ENDOWMENT)
+		.endow_account(BOB.into(), ASSET_B, ENDOWMENT)
+		.execute(|| {
+			assert_ok!(Stableswap::create_pool(
+				RuntimeOrigin::root(),
+				POOL_ID,
+				BoundedVec::truncate_from(vec![ASSET_A, ASSET_B]),
+				100,
+				Permill::from_percent(1),
+			));
+			assert_ok!(Stableswap::add_assets_liquidity(
+				RuntimeOrigin::signed(ALICE.into()),
+				POOL_ID,
+				BoundedVec::truncate_from(vec![
+					AssetAmount::new(ASSET_A, INITIAL_LIQUIDITY),
+					AssetAmount::new(ASSET_B, INITIAL_LIQUIDITY),
+				]),
+				0,
+			));
+		});
+	driver
+}
+
+fn peg_pool() -> HydrationTestDriver {
+	let driver = HydrationTestDriver::default()
+		.register_asset(PEG_A, b"exPGA", DEC, None)
+		.register_asset(PEG_B, b"exPGB", DEC, None)
+		.register_asset(PEG_POOL, b"exPGP", DEC, None);
+	driver
+		.new_block()
+		.endow_account(ALICE.into(), PEG_A, ENDOWMENT)
+		.endow_account(ALICE.into(), PEG_B, ENDOWMENT)
+		.execute(|| {
+			assert_ok!(Stableswap::create_pool_with_pegs(
+				RuntimeOrigin::root(),
+				PEG_POOL,
+				BoundedVec::truncate_from(vec![PEG_A, PEG_B]),
+				100,
+				Permill::from_percent(0),
+				BoundedPegSources::truncate_from(vec![PegSource::Value((1, 1)), PegSource::Value((1, 1))]),
+				Perbill::from_percent(100),
+			));
+			assert_ok!(Stableswap::add_assets_liquidity(
+				RuntimeOrigin::signed(ALICE.into()),
+				PEG_POOL,
+				BoundedVec::truncate_from(vec![
+					AssetAmount::new(PEG_A, INITIAL_LIQUIDITY),
+					AssetAmount::new(PEG_B, INITIAL_LIQUIDITY),
+				]),
+				0,
+			));
+		});
+	driver
+}
+
+#[test]
+fn buy_should_credit_exact_amount_out_and_charge_within_max_when_pool_has_liquidity() {
+	plain_pool().execute(|| {
+		let amount_out = 10 * ONE;
+		let max_sell = 20 * ONE;
+
+		let a_before = balance(BOB, ASSET_A);
+		let b_before = balance(BOB, ASSET_B);
+
+		assert_ok!(Stableswap::buy(
+			RuntimeOrigin::signed(BOB.into()),
+			POOL_ID,
+			ASSET_A,
+			ASSET_B,
+			amount_out,
+			max_sell,
+		));
+
+		let a_after = balance(BOB, ASSET_A);
+		let b_after = balance(BOB, ASSET_B);
+
+		assert_eq!(a_after - a_before, amount_out);
+		let spent = b_before - b_after;
+		assert!(spent > 0, "buy must charge the input asset");
+		assert!(spent <= max_sell, "spent {spent} exceeded max_sell {max_sell}");
+	});
+}
+
+#[test]
+fn buy_should_fail_when_required_amount_in_exceeds_max_sell_limit() {
+	plain_pool().execute(|| {
+		assert_noop!(
+			Stableswap::buy(
+				RuntimeOrigin::signed(BOB.into()),
+				POOL_ID,
+				ASSET_A,
+				ASSET_B,
+				10 * ONE,
+				ONE, // far below the ~10 units the buy needs
+			),
+			pallet_stableswap::Error::<hydradx_runtime::Runtime>::SellLimitExceeded
+		);
+	});
+}
+
+#[test]
+fn remove_liquidity_should_return_underlying_assets_when_burning_all_shares() {
+	plain_pool().execute(|| {
+		let shares = balance(ALICE, POOL_ID);
+		assert!(shares > 0, "setup should have issued shares to ALICE");
+
+		let a_before = balance(ALICE, ASSET_A);
+		let b_before = balance(ALICE, ASSET_B);
+
+		assert_ok!(Stableswap::remove_liquidity(
+			RuntimeOrigin::signed(ALICE.into()),
+			POOL_ID,
+			shares,
+			BoundedVec::truncate_from(vec![AssetAmount::new(ASSET_A, 0), AssetAmount::new(ASSET_B, 0),]),
+		));
+
+		assert_eq!(balance(ALICE, POOL_ID), 0, "all shares should be burned");
+		assert!(balance(ALICE, ASSET_A) > a_before);
+		assert!(balance(ALICE, ASSET_B) > b_before);
+	});
+}
+
+#[test]
+fn withdraw_asset_amount_should_credit_exact_amount_and_burn_shares_within_max() {
+	plain_pool().execute(|| {
+		let withdraw = 100 * ONE;
+		let max_share = 500 * ONE;
+
+		let a_before = balance(ALICE, ASSET_A);
+		let shares_before = balance(ALICE, POOL_ID);
+
+		assert_ok!(Stableswap::withdraw_asset_amount(
+			RuntimeOrigin::signed(ALICE.into()),
+			POOL_ID,
+			ASSET_A,
+			withdraw,
+			max_share,
+		));
+
+		assert_eq!(balance(ALICE, ASSET_A) - a_before, withdraw);
+		let burned = shares_before - balance(ALICE, POOL_ID);
+		assert!(burned > 0, "withdraw must burn shares");
+		assert!(burned <= max_share, "burned {burned} exceeded max_share {max_share}");
+	});
+}
+
+#[test]
+fn withdraw_asset_amount_should_fail_when_share_cost_exceeds_max() {
+	plain_pool().execute(|| {
+		assert_noop!(
+			Stableswap::withdraw_asset_amount(
+				RuntimeOrigin::signed(ALICE.into()),
+				POOL_ID,
+				ASSET_A,
+				100 * ONE,
+				1, // far below the shares the withdraw would burn
+			),
+			pallet_stableswap::Error::<hydradx_runtime::Runtime>::SlippageLimit
+		);
+	});
+}
+
+#[test]
+fn update_amplification_should_set_final_amplification_when_scheduled_by_authority() {
+	plain_pool().execute(|| {
+		let current = System::block_number();
+		assert_ok!(Stableswap::update_amplification(
+			RuntimeOrigin::root(),
+			POOL_ID,
+			200,
+			current + 1,
+			current + 100,
+		));
+
+		let pool = Stableswap::pools(POOL_ID).expect("pool should exist");
+		assert_eq!(pool.final_amplification.get(), 200);
+	});
+}
+
+#[test]
+fn update_pool_max_peg_update_should_change_limit_when_called_by_authority() {
+	peg_pool().execute(|| {
+		assert_ok!(Stableswap::update_pool_max_peg_update(
+			RuntimeOrigin::root(),
+			PEG_POOL,
+			Perbill::from_percent(50),
+		));
+
+		let info = Stableswap::pool_peg_info(PEG_POOL).expect("peg info should exist");
+		assert_eq!(info.max_peg_update, Perbill::from_percent(50));
+	});
+}
+
+#[test]
+fn update_asset_peg_source_should_replace_peg_source_when_called_by_authority() {
+	peg_pool().execute(|| {
+		assert_ok!(Stableswap::update_asset_peg_source(
+			RuntimeOrigin::root(),
+			PEG_POOL,
+			PEG_B,
+			PegSource::Value((2, 1)),
+		));
+
+		let info = Stableswap::pool_peg_info(PEG_POOL).expect("peg info should exist");
+		// assets were registered in order [PEG_A, PEG_B] → PEG_B is index 1
+		assert_eq!(info.source[1], PegSource::Value((2, 1)));
+	});
+}

--- a/integration-tests/src/xyk_extra.rs
+++ b/integration-tests/src/xyk_extra.rs
@@ -1,0 +1,229 @@
+// Integration coverage for the slippage-guarded XYK LP paths that the suite
+// otherwise exercises only at the pallet level: `add_liquidity_with_limits` and
+// `remove_liquidity_with_limits`. Also includes a regression test asserting
+// `create_pool` (which is not `#[transactional]`) leaves no orphan pool state
+// when an inner asset transfer fails.
+
+use crate::driver::HydrationTestDriver;
+use crate::polkadot_test_net::*;
+use frame_support::{assert_noop, assert_ok};
+use hydradx_runtime::*;
+use hydradx_traits::AMM;
+use orml_traits::{MultiCurrency, MultiLockableCurrency};
+use pallet_xyk::types::AssetPair;
+use pretty_assertions::assert_eq;
+
+const ASSET_A: AssetId = 4400;
+const ASSET_B: AssetId = 4401;
+const ORPHAN_A: AssetId = 4402;
+const ORPHAN_B: AssetId = 4403;
+
+const DEC: u8 = 12;
+const ENDOWMENT: Balance = 1_000_000 * UNITS;
+const INITIAL_A: Balance = 100 * UNITS;
+const INITIAL_B: Balance = 200 * UNITS;
+
+fn balance(who: [u8; 32], asset: AssetId) -> Balance {
+	Tokens::free_balance(asset, &who.into())
+}
+
+fn pair() -> AssetPair {
+	AssetPair {
+		asset_in: ASSET_A,
+		asset_out: ASSET_B,
+	}
+}
+
+/// XYK pool `ASSET_A`/`ASSET_B` created by ALICE with a 100:200 reserve ratio.
+/// ALICE keeps a large balance of both assets for follow-up liquidity ops.
+fn xyk_pool() -> HydrationTestDriver {
+	let driver = HydrationTestDriver::default()
+		.register_asset(ASSET_A, b"exXKA", DEC, None)
+		.register_asset(ASSET_B, b"exXKB", DEC, None);
+	driver
+		.new_block()
+		.endow_account(ALICE.into(), ASSET_A, ENDOWMENT)
+		.endow_account(ALICE.into(), ASSET_B, ENDOWMENT)
+		.execute(|| {
+			assert_ok!(XYK::create_pool(
+				RuntimeOrigin::signed(ALICE.into()),
+				ASSET_A,
+				INITIAL_A,
+				ASSET_B,
+				INITIAL_B,
+			));
+		});
+	driver
+}
+
+#[test]
+fn add_liquidity_with_limits_should_mint_shares_when_within_limits() {
+	xyk_pool().execute(|| {
+		let share_token = XYK::get_share_token(pair());
+
+		let amount_a = 10 * UNITS;
+		let amount_b_max = 1_000 * UNITS;
+		let min_shares = 1;
+
+		let a_before = balance(ALICE, ASSET_A);
+		let b_before = balance(ALICE, ASSET_B);
+		let shares_before = balance(ALICE, share_token);
+
+		assert_ok!(XYK::add_liquidity_with_limits(
+			RuntimeOrigin::signed(ALICE.into()),
+			ASSET_A,
+			ASSET_B,
+			amount_a,
+			amount_b_max,
+			min_shares,
+		));
+
+		// asset_a is debited by exactly the requested amount
+		assert_eq!(a_before - balance(ALICE, ASSET_A), amount_a);
+
+		// asset_b is debited by a positive amount within the supplied max limit
+		let spent_b = b_before - balance(ALICE, ASSET_B);
+		assert!(spent_b > 0, "add_liquidity must consume the paired asset");
+		assert!(spent_b <= amount_b_max, "spent {spent_b} exceeded max {amount_b_max}");
+
+		// shares were minted to ALICE
+		let minted = balance(ALICE, share_token) - shares_before;
+		assert!(minted > 0, "shares must be minted");
+		assert!(minted >= min_shares, "minted {minted} below min_shares {min_shares}");
+	});
+}
+
+#[test]
+fn add_liquidity_with_limits_should_fail_when_min_shares_not_met() {
+	xyk_pool().execute(|| {
+		assert_noop!(
+			XYK::add_liquidity_with_limits(
+				RuntimeOrigin::signed(ALICE.into()),
+				ASSET_A,
+				ASSET_B,
+				10 * UNITS,
+				1_000 * UNITS,
+				1_000_000 * UNITS, // far above the shares this deposit can mint
+			),
+			pallet_xyk::Error::<hydradx_runtime::Runtime>::SlippageLimit
+		);
+	});
+}
+
+#[test]
+fn remove_liquidity_with_limits_should_return_assets_when_within_limits() {
+	xyk_pool().execute(|| {
+		let share_token = XYK::get_share_token(pair());
+
+		let shares_before = balance(ALICE, share_token);
+		assert!(shares_before > 0, "setup should have issued shares to ALICE");
+
+		let burn = shares_before / 2;
+		let a_before = balance(ALICE, ASSET_A);
+		let b_before = balance(ALICE, ASSET_B);
+
+		assert_ok!(XYK::remove_liquidity_with_limits(
+			RuntimeOrigin::signed(ALICE.into()),
+			ASSET_A,
+			ASSET_B,
+			burn,
+			1, // min_amount_a
+			1, // min_amount_b
+		));
+
+		// exactly the requested shares are burned
+		assert_eq!(shares_before - balance(ALICE, share_token), burn);
+
+		// both underlying assets are returned
+		assert!(balance(ALICE, ASSET_A) > a_before, "asset_a must be returned");
+		assert!(balance(ALICE, ASSET_B) > b_before, "asset_b must be returned");
+	});
+}
+
+#[test]
+fn remove_liquidity_with_limits_should_fail_when_min_amount_not_met() {
+	xyk_pool().execute(|| {
+		let share_token = XYK::get_share_token(pair());
+		let burn = balance(ALICE, share_token) / 2;
+
+		assert_noop!(
+			XYK::remove_liquidity_with_limits(
+				RuntimeOrigin::signed(ALICE.into()),
+				ASSET_A,
+				ASSET_B,
+				burn,
+				1_000_000 * UNITS, // min_amount_a far above what the burn returns
+				1,
+			),
+			pallet_xyk::Error::<hydradx_runtime::Runtime>::SlippageLimit
+		);
+	});
+}
+
+// Regression: `create_pool` is not `#[transactional]`. It writes `ShareToken`
+// and `PoolAssets`, transfers `asset_a` into the pool, and only then transfers
+// `asset_b`. Real extrinsic dispatch runs inside the executive's storage layer,
+// which rolls the whole call back on error; this test reproduces that layer with
+// `with_storage_layer` and asserts no orphan pool state survives a failed create.
+//
+// The failure is constructed cleanly with an ORML lock on `asset_b`: `free_balance`
+// ignores locks, so the pre-transfer balance check passes, but `transfer`'s
+// `ensure_can_withdraw` requires `free - amount >= frozen`, so the second transfer
+// (asset_b) fails after the first (asset_a) has already succeeded.
+#[test]
+fn create_pool_should_not_leave_orphan_state_when_asset_transfer_fails() {
+	let driver = HydrationTestDriver::default()
+		.register_asset(ORPHAN_A, b"exXKC", DEC, None)
+		.register_asset(ORPHAN_B, b"exXKD", DEC, None);
+	driver
+		.new_block()
+		.endow_account(ALICE.into(), ORPHAN_A, 1_000 * UNITS)
+		.endow_account(ALICE.into(), ORPHAN_B, 1_000 * UNITS)
+		.execute(|| {
+			// Lock most of asset_b: free stays at 1_000 units (passes the balance
+			// check) but only 100 units are transferable.
+			assert_ok!(<Tokens as MultiLockableCurrency<AccountId>>::set_lock(
+				*b"xykorph1",
+				ORPHAN_B,
+				&ALICE.into(),
+				900 * UNITS,
+			));
+
+			let orphan_pair = AssetPair {
+				asset_in: ORPHAN_A,
+				asset_out: ORPHAN_B,
+			};
+			let pool_account = XYK::get_pair_id(orphan_pair);
+			let a_before = balance(ALICE, ORPHAN_A);
+
+			let result = frame_support::storage::with_storage_layer(|| -> sp_runtime::DispatchResult {
+				XYK::create_pool(
+					RuntimeOrigin::signed(ALICE.into()),
+					ORPHAN_A,
+					100 * UNITS,
+					ORPHAN_B,
+					200 * UNITS,
+				)
+			});
+			assert!(
+				result.is_err(),
+				"create_pool should fail when the asset_b transfer is blocked"
+			);
+
+			// No orphan pool state may survive the failed call.
+			assert!(
+				!XYK::exists(orphan_pair),
+				"pool must not be registered after a failed create_pool"
+			);
+			assert_eq!(
+				balance(ALICE, ORPHAN_A),
+				a_before,
+				"asset_a must not be moved when create_pool fails"
+			);
+			assert_eq!(
+				Tokens::free_balance(ORPHAN_A, &pool_account),
+				0,
+				"pool account must hold no asset_a after a failed create_pool"
+			);
+		});
+}


### PR DESCRIPTION
Adds full-runtime integration coverage for extrinsics that were exercised only at the pallet level. Gaps were identified from the runtime interaction graph's `prioritized_test_gaps` pack (entrypoints with no static integration-test link) and each was confirmed to have zero references in `integration-tests/src/` before writing.

**84 new tests across 8 new modules:**

- `stableswap_extra` (8) — `buy`, `remove_liquidity`, `withdraw_asset_amount`, `update_amplification`, `update_asset_peg_source`, `update_pool_max_peg_update`
- `xyk_extra` (5) — `add_liquidity_with_limits`, `remove_liquidity_with_limits` (slippage guards) + a `create_pool` orphan-state regression (asserts the executive's storage layer rolls back a partial create)
- `omnipool_extra` (7) — `remove_liquidity_with_limit`, `refund_refused_asset` (all four error branches)
- `hsm_admin_extra` (4) — `update_collateral_asset`, `remove_collateral_asset` (snapshot-fork based)
- `liquidity_mining_extra` (15) — omnipool + xyk yield-farm lifecycle: `stop`/`resume`/`update`/`terminate_yield_farm`, `terminate_global_farm`, `update_global_farm`
- `signet` (19) — full pallet: `set_config`, `pause`/`unpause`, `sign`, `sign_bidirectional`, `withdraw_funds`, `respond`/`respond_error`/`respond_bidirectional`
- `amm_misc_extra` (8) — `bonds::redeem`, `lbp::add_liquidity`/`remove_liquidity`, `currencies::transfer_native_currency`
- `admin_misc_extra` (18) — `dispatcher::dispatch_as_treasury`, `multi-payment::reset_payment_currency`, `gigahdx::set_pool_contract`, `dispenser` (`set_config`/`pause`/`unpause`/`request_fund` guards)

**Notes / residual gaps (deliberately not faked):**
- `signet::respond*` only echo the caller's input as events — no on-chain signature validation, no authority gate, no pause check. Tests assert what exists; the missing gating is a finding worth a follow-up.
- `dispenser::request_fund` happy path needs a signet MPC signing flow (keccak-derived request id) — impractical in integration; covered by its `NotConfigured`/`Paused` guard rejections instead.
- Adds `pallet-signet` and `pallet-dispenser` as `integration-tests` dev-dependencies.

Verified locally: full crate compiles under `RUSTFLAGS=-D warnings`, `cargo fmt --check` clean, and all 84 new tests pass. `runtime-integration-tests` bumped to 1.104.2.