### PR TITLE
Enable improved panic error reporting in runtime

### DIFF
--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -163,7 +163,7 @@ sp-staking = { workspace = true }
 sp-transaction-pool = { workspace = true }
 sp-version = { workspace = true }
 sp-trie = { workspace = true }
-sp-io = { workspace = true }
+sp-io = { workspace = true, features = ["improved_panic_error_reporting"] }
 primitive-types = { workspace = true }
 static_assertions = { workspace = true }
 


### PR DESCRIPTION
Enables the `sp-io/improved_panic_error_reporting` feature for the hydradx runtime, so runtime panics reach RPC callers as readable messages instead of opaque wasm traps.

## Motivation

While debugging #1491, a parameter-decode failure in `DryRunApi.dry_run_call` surfaced over public RPC as:

```
Execution failed: Execution aborted due to trap: wasm trap: wasm `unreachable` instruction executed
```

The actual panic message — `Bad input data provided to dry_run_call: Codec error. Nothing bad happened: someone sent an invalid transaction to the node.` — only exists in node logs, invisible to the RPC caller. It cost a chopsticks fork to see it, and the symptom was initially misdiagnosed as a runtime bug.

With this feature, `sp-io`'s wasm panic handler calls the `ext_panic_handler_abort_on_panic` host function instead of executing `unreachable`, and the client executor returns `Runtime panicked: <message>` (`sc-executor` `AbortedDueToPanic`) — making every future decode error, defensive panic, and `panic!` diagnosable directly from the RPC response.

## Safety

- **Client executors**: `sc-executor-wasmtime` has captured the message via `HostState::panic_message` since 2022; smoldot implements `ext_panic_handler_abort_on_panic_version_1`.
- **Relay-chain PVF validation**: the PVF executor's host function list omits `panic_handler`, but it instantiates with `allow_missing_func_imports: true`, so the import resolves to a stub. A panic during validation then traps exactly as it does today — outcome-identical (candidate invalid).
- The feature only affects the `#[panic_handler]`/`#[alloc_error_handler]` compiled into the wasm blob; no behavior change on the success path.

For reference, this is the same mechanism `substrate/client/executor/runtime-test` uses upstream.