### PR TITLE
fix: retry dca on router trading limit reached

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "433.0.0"
+version = "434.0.0"
 dependencies = [
  "alloy-primitives 0.7.7",
  "alloy-sol-types 0.7.7",
@@ -9150,7 +9150,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-dca"
-version = "1.18.1"
+version = "1.18.2"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -13900,7 +13900,7 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "runtime-integration-tests"
-version = "1.104.0"
+version = "1.105.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "1.104.0"
+version = "1.105.0"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/src/dca.rs
+++ b/integration-tests/src/dca.rs
@@ -4952,6 +4952,87 @@ mod aave_atoken {
 		));
 	}
 
+	// Snapshot at block 13260776, produced with the same scraper command as above,
+	// --at 0x798bc20aeb759a30dd97aafdab03346ff463cbc17e776216d171a8b3ad6411d6
+	const PATH_TO_HSM_WINDDOWN_SNAPSHOT: &str = "dca-snapshot/SNAPSHOT_13260776";
+
+	// replays mainnet block 13260777: hsm wind-down schedule 33794 (sUSDe->HOLLAR->aUSDT) failed
+	// with router TradingLimitReached and was terminated instead of retried
+	#[test]
+	fn dca_should_retry_when_router_trading_limit_reached() {
+		TestNet::reset();
+
+		hydra_live_ext(PATH_TO_HSM_WINDDOWN_SNAPSHOT).execute_with(|| {
+			//Arrange
+			assert_eq!(hydradx_runtime::System::block_number(), 13260776);
+			let schedule_id = 33794;
+			assert!(DCA::schedules(schedule_id).is_some());
+			// on mainnet the timestamp inherent runs after on_initialize — keep the parent timestamp
+			hydradx_runtime::System::set_block_number(13260777);
+
+			// the slim snapshot strips schedule 33812's owner, so replay its trade by hand:
+			// the aave hop moves pool-111 shares out of the aHUSDT contract account, then the
+			// stableswap hop removes liquidity from pool 111 right before 33794 executes
+			let ahusdt: sp_runtime::AccountId32 =
+				hex_literal::hex!("455448001806860d27ee903c1ec7586d4f7d598d7591f1240000000000000000").into();
+			assert_ok!(Currencies::update_balance(
+				RuntimeOrigin::root(),
+				ahusdt,
+				111,
+				-22_133_969_015_170_432_881i128,
+			));
+			assert_ok!(Currencies::update_balance(
+				RuntimeOrigin::root(),
+				BOB.into(),
+				111,
+				22_133_969_015_170_432_881i128,
+			));
+			assert_ok!(Router::sell(
+				RuntimeOrigin::signed(BOB.into()),
+				111,
+				222,
+				22_133_969_015_170_432_881u128,
+				0,
+				vec![Trade {
+					pool: PoolType::Stableswap(111),
+					asset_in: 111,
+					asset_out: 222,
+				}]
+				.try_into()
+				.unwrap(),
+			));
+			// exact hollar amount of the mainnet swap — the replayed state matches
+			assert_eq!(Currencies::free_balance(222, &BOB.into()), 22_567_968_483_370_805_906);
+
+			//Act
+			DCA::on_initialize(13260777);
+
+			//Assert: trade failed exactly like mainnet, but got retried instead of terminated
+			assert_trade_failed_with_router_trading_limit_reached(schedule_id);
+			assert!(
+				DCA::schedules(schedule_id).is_some(),
+				"schedule must be retried, not terminated"
+			);
+			assert_eq!(DCA::retries_on_error(schedule_id), 1);
+		});
+	}
+
+	fn assert_trade_failed_with_router_trading_limit_reached(schedule_id: u32) {
+		let expected: sp_runtime::DispatchError = pallet_route_executor::Error::<Runtime>::TradingLimitReached.into();
+		let events = last_hydra_events(20);
+		let found = events.iter().any(|e| {
+			matches!(
+				e,
+				RuntimeEvent::DCA(pallet_dca::Event::TradeFailed { id, error, .. })
+				if *id == schedule_id && *error == expected
+			)
+		});
+		assert!(
+			found,
+			"expected TradeFailed event with router::TradingLimitReached for schedule {schedule_id}"
+		);
+	}
+
 	fn assert_trade_failed_with_omnipool_insufficient_balance(schedule_id: u32) {
 		let expected: sp_runtime::DispatchError = pallet_omnipool::Error::<Runtime>::InsufficientBalance.into();
 		let events = last_hydra_events(20);

--- a/integration-tests/src/dca.rs
+++ b/integration-tests/src/dca.rs
@@ -4944,6 +4944,14 @@ mod aave_atoken {
 		});
 	}
 
+	#[test]
+	fn router_trading_limit_reached_should_be_retriable() {
+		use frame_support::traits::Contains;
+		assert!(hydradx_runtime::RetryOnErrorForDca::contains(
+			&pallet_route_executor::Error::<Runtime>::TradingLimitReached.into()
+		));
+	}
+
 	fn assert_trade_failed_with_omnipool_insufficient_balance(schedule_id: u32) {
 		let expected: sp_runtime::DispatchError = pallet_omnipool::Error::<Runtime>::InsufficientBalance.into();
 		let events = last_hydra_events(20);

--- a/pallets/dca/Cargo.toml
+++ b/pallets/dca/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'pallet-dca'
-version = "1.18.1"
+version = "1.18.2"
 description = 'A pallet to manage DCA scheduling'
 authors = ['GalacticCouncil']
 edition = '2021'

--- a/pallets/dca/src/tests/mock.rs
+++ b/pallets/dca/src/tests/mock.rs
@@ -60,6 +60,7 @@ pub const DAI: AssetId = 2;
 pub const BTC: AssetId = 3;
 pub const FORBIDDEN_ASSET: AssetId = 4;
 pub const DOT: AssetId = 5;
+pub const RETRY_ON_ERROR_ASSET: AssetId = 6;
 pub const REGISTERED_ASSET: AssetId = 1000;
 pub const ONE_HUNDRED_BLOCKS: BlockNumber = 100;
 
@@ -454,6 +455,12 @@ impl TradeExecution<OriginForRuntime, AccountId, AssetId, Balance> for OmniPool 
 			return Err(ExecutorError::Error(pallet_omnipool::Error::<Test>::NotAllowed.into()));
 		}
 
+		if asset_in == RETRY_ON_ERROR_ASSET {
+			return Err(ExecutorError::Error(
+				pallet_route_executor::Error::<Test>::TradingLimitReached.into(),
+			));
+		}
+
 		SELL_EXECUTIONS.with(|v| {
 			let mut m = v.borrow_mut();
 			m.push(SellExecution {
@@ -696,11 +703,19 @@ impl Config for Test {
 	type AmmTradeWeights = ();
 	type MinimumTradingLimit = MinTradeAmount;
 	type NativePriceOracle = NativePriceOracleMock;
-	type RetryOnError = ();
+	type RetryOnError = RetryOnErrorMock;
 	type PolkadotNativeAssetId = PolkadotNativeCurrencyId;
 	type SwappablePaymentAssetSupport = MockedInsufficientAssetSupport;
 	type ExtraGasSupport = ExtraGasSetterMock;
 	type GasWeightMapping = MockGasWeightMapping;
+}
+
+pub struct RetryOnErrorMock;
+
+impl frame_support::traits::Contains<DispatchError> for RetryOnErrorMock {
+	fn contains(t: &DispatchError) -> bool {
+		*t == pallet_route_executor::Error::<Test>::TradingLimitReached.into()
+	}
 }
 
 pub struct ExtraGasSetterMock;

--- a/pallets/dca/src/tests/on_initialize.rs
+++ b/pallets/dca/src/tests/on_initialize.rs
@@ -1335,6 +1335,53 @@ fn dca_schedule_should_terminate_when_error_is_not_configured_to_continue_on() {
 }
 
 #[test]
+fn dca_schedule_should_retry_when_error_is_configured_to_retry_on() {
+	ExtBuilder::default()
+		.with_endowed_accounts(vec![(ALICE, RETRY_ON_ERROR_ASSET, 5000 * ONE)])
+		.build()
+		.execute_with(|| {
+			//Arrange
+			proceed_to_blocknumber(1, 500);
+
+			let schedule = ScheduleBuilder::new()
+				.with_period(ONE_HUNDRED_BLOCKS)
+				.with_order(Order::Sell {
+					asset_in: RETRY_ON_ERROR_ASSET,
+					asset_out: BTC,
+					amount_in: ONE,
+					min_amount_out: Balance::MIN,
+					route: create_bounded_vec(vec![Trade {
+						pool: Omnipool,
+						asset_in: RETRY_ON_ERROR_ASSET,
+						asset_out: BTC,
+					}]),
+				})
+				.build();
+
+			assert_ok!(DCA::schedule(RuntimeOrigin::signed(ALICE), schedule, Option::None));
+
+			//Act and assert
+			let schedule_id = 0;
+			set_to_blocknumber(502);
+			assert!(DCA::schedules(schedule_id).is_some());
+			assert_eq!(DCA::retries_on_error(schedule_id), 1);
+			assert_scheduled_ids!(522, vec![schedule_id]);
+
+			set_to_blocknumber(522);
+			assert_eq!(DCA::retries_on_error(schedule_id), 2);
+			assert_scheduled_ids!(562, vec![schedule_id]);
+
+			set_to_blocknumber(562);
+			assert_eq!(DCA::retries_on_error(schedule_id), 3);
+			assert_scheduled_ids!(642, vec![schedule_id]);
+
+			set_to_blocknumber(642);
+			assert_number_of_executed_sell_trades!(0);
+			assert_that_dca_is_terminated(ALICE, schedule_id, Error::<Test>::MaxRetryReached.into());
+		});
+}
+
+#[test]
 fn dca_schedule_should_continue_on_multiple_failures_then_terminated() {
 	ExtBuilder::default()
 		.with_endowed_accounts(vec![(ALICE, HDX, 5000 * ONE)])

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "433.0.0"
+version = "434.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/assets.rs
+++ b/runtime/hydradx/src/assets.rs
@@ -942,6 +942,9 @@ impl Contains<DispatchError> for RetryOnErrorForDca {
 			// liquidity index is timestamp-dependent, so the rounding boundary
 			// shifts and a later attempt may pass.
 			pallet_omnipool::Error::<Runtime>::InsufficientBalance.into(),
+			// same class as dca's own retriable TradeLimitReached — erc20/aToken rounding
+			// can undershoot the dry-run output passed as router min limit
+			pallet_route_executor::Error::<Runtime>::TradingLimitReached.into(),
 			pallet_dispatcher::Error::<Runtime>::EvmOutOfGas.into(),
 			pallet_circuit_breaker::Error::<Runtime>::DepositLimitExceededForWhitelistedAccount.into(),
 		];

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -129,7 +129,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("hydradx"),
 	impl_name: Cow::Borrowed("hydradx"),
 	authoring_version: 1,
-	spec_version: 433,
+	spec_version: 434,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Fixes #1497

- adds `pallet_route_executor::Error::TradingLimitReached` to the `RetryOnErrorForDca` whitelist → retried with backoff instead of instant termination
- when the user min limit binds, dca passes the exact dry-run output as the router min limit → erc20/aToken rounding shortfall surfaces as the router error (semantically same as dca's own retriable `TradeLimitReached`)
- killed HSM wind-down schedules 33794/33795 on mainnet, 2026-07-21 (blocks 13260777 / 13260976)

Tests:
- mainnet replay: new snapshot at block 13260776 (`SNAPSHOT_13260776`, scraper `--slim`), replays block 13260777 — schedule 33812's pool-111 liquidity removal, then 33794 fails with router `TradingLimitReached` exactly like mainnet; asserts it is retried (verified red without the fix → terminates like mainnet)
- pallet unit test: whitelisted error → retry with backoff → `MaxRetryReached` termination after retries exhausted
- whitelist membership assertion for the runtime config

Versions: hydradx-runtime 434.0.0 + spec_version 434, pallet-dca 1.18.2, integration-tests 1.105.0