### PR TITLE
feat(meta-tx): sponsored meta transactions for native Substrate accounts [ignore benchmarks]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "433.0.0"
+version = "434.0.0"
 dependencies = [
  "alloy-primitives 0.7.7",
  "alloy-sol-types 0.7.7",
@@ -5879,6 +5879,7 @@ dependencies = [
  "pallet-liquidation",
  "pallet-liquidity-mining",
  "pallet-message-queue",
+ "pallet-meta-tx 1.0.0",
  "pallet-migrations",
  "pallet-multisig",
  "pallet-omnipool",
@@ -10019,6 +10020,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-meta-tx"
+version = "1.0.0"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "pallet-utility",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-migrations"
 version = "11.0.0"
 source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#e8f4375d646cf2066f8c76e338398841709a0934"
@@ -13972,6 +13990,7 @@ dependencies = [
  "pallet-lbp",
  "pallet-liquidation",
  "pallet-liquidity-mining",
+ "pallet-meta-tx 1.0.0",
  "pallet-omnipool",
  "pallet-omnipool-liquidity-mining",
  "pallet-otc",
@@ -19500,7 +19519,7 @@ dependencies = [
  "pallet-identity",
  "pallet-indices",
  "pallet-message-queue",
- "pallet-meta-tx",
+ "pallet-meta-tx 0.3.0",
  "pallet-migrations",
  "pallet-mmr",
  "pallet-multisig",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "434.0.0"
+version = "439.0.0"
 dependencies = [
  "alloy-primitives 0.7.7",
  "alloy-sol-types 0.7.7",
@@ -10026,6 +10026,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "hydradx-traits",
  "pallet-balances",
  "pallet-utility",
  "parity-scale-codec",
@@ -13918,7 +13919,7 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "runtime-integration-tests"
-version = "1.104.0"
+version = "1.108.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     'runtime/adapters',
     'pallets/collator-rewards',
     'pallets/collator-rotation',
+    'pallets/meta-tx',
     'pallets/transaction-pause',
     'pallets/ema-oracle',
     'pallets/liquidity-mining',
@@ -150,6 +151,7 @@ pallet-relaychain-info = { path = "pallets/relaychain-info", default-features = 
 pallet-route-executor = { path = "pallets/route-executor", default-features = false }
 pallet-stableswap = { path = "pallets/stableswap", default-features = false }
 pallet-transaction-multi-payment = { path = "pallets/transaction-multi-payment", default-features = false }
+pallet-meta-tx = { path = "pallets/meta-tx", default-features = false }
 pallet-transaction-pause = { path = "pallets/transaction-pause", default-features = false }
 pallet-staking = { path = "pallets/staking", default-features = false }
 pallet-democracy = { path = "pallets/democracy", default-features = false }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -47,6 +47,7 @@ pallet-lbp = { workspace = true }
 pallet-xyk = { workspace = true }
 pallet-evm-accounts = { workspace = true }
 pallet-xyk-liquidity-mining = { workspace = true }
+pallet-meta-tx = { workspace = true }
 pallet-transaction-pause = { workspace = true }
 pallet-liquidation = { workspace = true }
 pallet-gigahdx = { workspace = true }
@@ -231,6 +232,7 @@ std = [
     "scraper/std",
     "pallet-dynamic-evm-fee/std",
     "precompile-utils/std",
+    "pallet-meta-tx/std",
     "pallet-transaction-pause/std",
     "pallet-liquidation/std",
     "pallet-gigahdx/std",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "1.104.0"
+version = "1.108.0"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/src/evm_permit.rs
+++ b/integration-tests/src/evm_permit.rs
@@ -3851,3 +3851,172 @@ mod sponsored_paymaster {
 		});
 	}
 }
+
+/// Reproduction of galacticcouncil/hydration-node#1495: a nested `evm.call` dispatched from
+/// inside an executing Call-Permit frame. Mirrors the construction reported by Northfound.
+mod nested_evm_call_in_permit {
+	use super::*;
+	use crate::evm::gas_price;
+	use crate::utils::contracts::deploy_contract;
+	use core::assert_eq;
+	use hydradx_runtime::{Dispatcher, System};
+	use pallet_evm::ExitReason;
+	use sp_core::H160;
+
+	fn paymaster_account() -> AccountId {
+		AccountId::from(crate::polkadot_test_net::BOB)
+	}
+
+	fn build_permit_for_call(
+		inner_call: &RuntimeCall,
+		gas_limit: u64,
+		deadline: U256,
+	) -> (H160, Vec<u8>, u64, U256, u8, H256, H256) {
+		let from = alith_evm_address();
+		let secret_key = SecretKey::parse(&alith_secret_key()).unwrap();
+		let data = inner_call.encode();
+
+		let permit = pallet_evm_precompile_call_permit::CallPermitPrecompile::<Runtime>::generate_permit(
+			CALLPERMIT,
+			from,
+			DISPATCH_ADDR,
+			U256::from(0),
+			data.clone(),
+			gas_limit,
+			pallet_evm_precompile_call_permit::NoncesStorage::get(from),
+			deadline,
+		);
+		let message = Message::parse(&permit);
+		let (rs, v) = sign(&message, &secret_key);
+		(
+			from,
+			data,
+			gas_limit,
+			deadline,
+			v.serialize(),
+			H256::from(rs.r.b32()),
+			H256::from(rs.s.b32()),
+		)
+	}
+
+	fn substrate_leg() -> RuntimeCall {
+		RuntimeCall::System(frame_system::Call::remark_with_event {
+			remark: b"leg-1-substrate".to_vec(),
+		})
+	}
+
+	fn evm_leg(source: H160, target: H160, gas_limit: u64) -> RuntimeCall {
+		RuntimeCall::Dispatcher(pallet_dispatcher::Call::dispatch_evm_call {
+			call: Box::new(RuntimeCall::EVM(pallet_evm::Call::call {
+				source,
+				target,
+				input: vec![0x06, 0xfd, 0xde, 0x03], // name()
+				value: U256::zero(),
+				gas_limit,
+				max_fee_per_gas: gas_price(),
+				max_priority_fee_per_gas: None,
+				nonce: None,
+				access_list: vec![],
+				authorization_list: vec![],
+			})),
+		})
+	}
+
+	/// permit(from = user, to = 0x401, data = SCALE(batch)) submitted and paid for by the sponsor.
+	fn sponsor_permit_to_dispatch_precompile(
+		paymaster: AccountId,
+		batch: RuntimeCall,
+		outer_gas_limit: u64,
+	) -> frame_support::dispatch::DispatchResultWithPostInfo {
+		let (from, data, gas_limit, deadline, v, r, s) =
+			build_permit_for_call(&batch, outer_gas_limit, U256::from(1_000_000_000_000u128));
+
+		MultiTransactionPayment::dispatch_permit(
+			RuntimeOrigin::signed(paymaster),
+			from,
+			DISPATCH_ADDR,
+			U256::from(0),
+			data,
+			gas_limit,
+			deadline,
+			v,
+			r,
+			s,
+		)
+	}
+
+	fn prepare() -> (AccountId, H160, H160) {
+		init_omnipool_with_oracle_for_block_10();
+		let paymaster = paymaster_account();
+		assert_ok!(Balances::mint_into(&paymaster, 1_000 * UNITS));
+
+		let contract = deploy_contract("HydraToken", crate::contracts::deployer());
+		(paymaster, alith_evm_address(), contract)
+	}
+
+	/// The exact construction from the issue: one permit, opening the dispatch precompile,
+	/// carrying a batch whose legs mix substrate and EVM calls, submitted and paid for by a sponsor.
+	#[test]
+	fn permit_batch_with_nested_evm_call_should_execute_when_outer_gas_is_under_the_cap() {
+		TestNet::reset();
+
+		Hydra::execute_with(|| {
+			let (paymaster, user, contract) = prepare();
+
+			let batch = RuntimeCall::Utility(pallet_utility::Call::batch_all {
+				calls: vec![substrate_leg(), evm_leg(user, contract, 100_000)],
+			});
+
+			assert_ok!(sponsor_permit_to_dispatch_precompile(paymaster, batch, 9_000_000));
+
+			assert!(
+				System::events().iter().any(|record| matches!(
+					&record.event,
+					hydradx_runtime::RuntimeEvent::System(frame_system::Event::Remarked { .. })
+				)),
+				"the substrate leg must have executed"
+			);
+			assert!(
+				System::events().iter().any(|record| matches!(
+					&record.event,
+					hydradx_runtime::RuntimeEvent::EVM(pallet_evm::Event::Executed { address })
+						if *address == contract
+				)),
+				"the nested evm.call leg must have reached the contract inside the permit frame"
+			);
+			assert!(
+				matches!(Dispatcher::last_evm_call_exit_reason(), Some(ExitReason::Succeed(_))),
+				"no frame in the chain may have reverted"
+			);
+		});
+	}
+
+	/// EIP-7825 caps a single transaction at 2^24 gas, far below the 60M block gas limit.
+	/// Every run in the reported 9M-28M sweep above this line failed here, not on nesting.
+	#[test]
+	fn permit_should_fail_when_outer_gas_exceeds_the_transaction_gas_cap() {
+		TestNet::reset();
+
+		Hydra::execute_with(|| {
+			let (paymaster, user, contract) = prepare();
+			assert_eq!(fp_evm::MAX_TRANSACTION_GAS_LIMIT, U256::from(16_777_216u64));
+
+			let batch = || {
+				RuntimeCall::Utility(pallet_utility::Call::batch_all {
+					calls: vec![substrate_leg(), evm_leg(user, contract, 100_000)],
+				})
+			};
+
+			assert_ok!(sponsor_permit_to_dispatch_precompile(
+				paymaster.clone(),
+				batch(),
+				16_777_216
+			));
+
+			assert_noop!(
+				sponsor_permit_to_dispatch_precompile(paymaster, batch(), 16_777_217),
+				pallet_transaction_multi_payment::Error::<Runtime>::EvmPermitRunnerError
+			);
+		});
+	}
+}

--- a/integration-tests/src/evm_permit.rs
+++ b/integration-tests/src/evm_permit.rs
@@ -4019,4 +4019,268 @@ mod nested_evm_call_in_permit {
 			);
 		});
 	}
+	/// Submitted by Northfound on issue #1495: a reverting EVM leg between two state-changing
+	/// legs must unwind the whole batch while the permit nonce is still consumed.
+	#[test]
+	fn permit_batch_should_unwind_every_leg_when_a_middle_evm_leg_reverts() {
+		TestNet::reset();
+
+		Hydra::execute_with(|| {
+			let (paymaster, user, contract) = prepare();
+
+			// unknown selector, no fallback on the token contract -> the call reverts
+			let reverting_leg = RuntimeCall::Dispatcher(pallet_dispatcher::Call::dispatch_evm_call {
+				call: Box::new(RuntimeCall::EVM(pallet_evm::Call::call {
+					source: user,
+					target: contract,
+					input: vec![0xde, 0xad, 0xbe, 0xef],
+					value: U256::zero(),
+					gas_limit: 100_000,
+					max_fee_per_gas: gas_price(),
+					max_priority_fee_per_gas: None,
+					nonce: None,
+					access_list: vec![],
+					authorization_list: vec![],
+				})),
+			});
+
+			let batch = RuntimeCall::Utility(pallet_utility::Call::batch_all {
+				calls: vec![substrate_leg(), reverting_leg, substrate_leg()],
+			});
+
+			let nonce_before = pallet_evm_precompile_call_permit::NoncesStorage::get(user);
+			System::reset_events();
+
+			// the inner failure is absorbed by design (that is the nonce-commit /
+			// replay guard), so the extrinsic itself must be Ok
+			assert_ok!(sponsor_permit_to_dispatch_precompile(paymaster, batch, 9_000_000));
+
+			// replay protection: the permit nonce must advance even though the batch unwound
+			assert_eq!(
+				pallet_evm_precompile_call_permit::NoncesStorage::get(user),
+				nonce_before + U256::one(),
+				"the permit nonce must be consumed even though the batch unwound"
+			);
+
+			// zero partial state: the first leg executed before the revert, but must be rolled back
+			assert!(
+				!System::events().iter().any(|record| matches!(
+					&record.event,
+					hydradx_runtime::RuntimeEvent::System(frame_system::Event::Remarked { .. })
+				)),
+				"the first substrate leg must have been rolled back"
+			);
+			assert!(
+				!System::events().iter().any(|record| matches!(
+					&record.event,
+					hydradx_runtime::RuntimeEvent::EVM(pallet_evm::Event::Executed { address })
+						if *address == contract
+				)),
+				"no nested evm.call may be recorded as executed"
+			);
+			assert!(
+				!matches!(Dispatcher::last_evm_call_exit_reason(), Some(ExitReason::Succeed(_))),
+				"the reverting leg must not read as a success"
+			);
+		});
+	}
+}
+
+/// Issue #1495 against a forked chain with the real money market deployed: the same
+/// permit -> 0x401 -> batchAll -> dispatch_evm_call shape, but the EVM leg is a genuine
+/// AAVE `supply` rather than a toy contract call.
+#[cfg(test)]
+mod aave_permit_batch {
+	use super::*;
+	use crate::aave_router::{with_aave, ADOT, BAG, DOT};
+	use crate::liquidation::supply as direct_supply;
+	use crate::utils::accounts::MockAccount;
+	use core::assert_eq;
+	use hydradx_runtime::evm::precompiles::erc20_mapping::HydraErc20Mapping;
+	use hydradx_traits::evm::Erc20Encoding;
+	use pallet_liquidation::BorrowingContract;
+	use primitives::EvmAddress;
+	use sp_core::H160;
+
+	fn paymaster_account() -> AccountId {
+		AccountId::from(crate::polkadot_test_net::BOB)
+	}
+
+	/// AAVE V3 `supply(address asset, uint256 amount, address onBehalfOf, uint16 referralCode)`.
+	fn supply_calldata(asset: EvmAddress, amount: Balance, on_behalf_of: EvmAddress) -> Vec<u8> {
+		let mut data = vec![0x61, 0x7b, 0xa0, 0x37];
+		let mut word = [0u8; 32];
+		word[12..].copy_from_slice(asset.as_bytes());
+		data.extend_from_slice(&word);
+		let mut word = [0u8; 32];
+		word[16..].copy_from_slice(&amount.to_be_bytes());
+		data.extend_from_slice(&word);
+		let mut word = [0u8; 32];
+		word[12..].copy_from_slice(on_behalf_of.as_bytes());
+		data.extend_from_slice(&word);
+		data.extend_from_slice(&[0u8; 32]);
+		data
+	}
+
+	fn build_permit_for_call(
+		inner_call: &RuntimeCall,
+		gas_limit: u64,
+		deadline: U256,
+	) -> (H160, Vec<u8>, u64, U256, u8, H256, H256) {
+		let from = alith_evm_address();
+		let secret_key = SecretKey::parse(&alith_secret_key()).unwrap();
+		let data = inner_call.encode();
+
+		let permit = pallet_evm_precompile_call_permit::CallPermitPrecompile::<Runtime>::generate_permit(
+			CALLPERMIT,
+			from,
+			DISPATCH_ADDR,
+			U256::from(0),
+			data.clone(),
+			gas_limit,
+			pallet_evm_precompile_call_permit::NoncesStorage::get(from),
+			deadline,
+		);
+		let message = Message::parse(&permit);
+		let (rs, v) = sign(&message, &secret_key);
+		(
+			from,
+			data,
+			gas_limit,
+			deadline,
+			v.serialize(),
+			H256::from(rs.r.b32()),
+			H256::from(rs.s.b32()),
+		)
+	}
+
+	fn sponsor_permit(
+		paymaster: AccountId,
+		batch: RuntimeCall,
+		outer_gas_limit: u64,
+	) -> frame_support::dispatch::DispatchResultWithPostInfo {
+		let (from, data, gas_limit, deadline, v, r, s) =
+			build_permit_for_call(&batch, outer_gas_limit, U256::from(1_000_000_000_000u128));
+
+		MultiTransactionPayment::dispatch_permit(
+			RuntimeOrigin::signed(paymaster),
+			from,
+			DISPATCH_ADDR,
+			U256::from(0),
+			data,
+			gas_limit,
+			deadline,
+			v,
+			r,
+			s,
+		)
+	}
+
+	/// A real AAVE `supply` executed inside a sponsored Call-Permit frame, via the dispatch
+	/// precompile and `batchAll` — the construction reported as impossible in issue #1495.
+	/// It works; the reported failures were the EIP-7825 per-transaction gas cap (2^24).
+	#[test]
+	fn aave_supply_should_execute_inside_a_sponsored_permit_batch_under_the_gas_cap() {
+		with_aave(|| {
+			let (pool, user, user_acc, paymaster, dot_erc20, amount) = arrange();
+
+			// Base case: the same supply dispatched directly, to show it works at all.
+			direct_supply(pool, user, dot_erc20, amount);
+
+			let dot_before = Currencies::free_balance(DOT, &user_acc.address());
+			let adot_before = Currencies::free_balance(ADOT, &user_acc.address());
+
+			assert_ok!(sponsor_permit(
+				paymaster,
+				supply_batch(user, pool, dot_erc20, amount),
+				9_000_000
+			));
+
+			assert_eq!(
+				dot_before - Currencies::free_balance(DOT, &user_acc.address()),
+				amount,
+				"the AAVE supply MUST have executed inside the permit frame"
+			);
+			assert!(
+				Currencies::free_balance(ADOT, &user_acc.address()) >= adot_before + amount - 1,
+				"the user MUST have received aTokens for the supply"
+			);
+		});
+	}
+
+	/// The boundary is exactly EIP-7825's `MAX_TRANSACTION_GAS_LIMIT`, and it applies to the
+	/// permit's own gas limit — not to the nested call, and not to the batch contents.
+	#[test]
+	fn sponsored_permit_batch_should_fail_one_gas_over_the_transaction_cap() {
+		with_aave(|| {
+			let (pool, user, user_acc, paymaster, dot_erc20, amount) = arrange();
+			assert_eq!(fp_evm::MAX_TRANSACTION_GAS_LIMIT, U256::from(16_777_216u64));
+
+			assert_ok!(sponsor_permit(
+				paymaster.clone(),
+				supply_batch(user, pool, dot_erc20, amount),
+				16_777_216
+			));
+
+			let dot_before = Currencies::free_balance(DOT, &user_acc.address());
+			assert_noop!(
+				sponsor_permit(paymaster, supply_batch(user, pool, dot_erc20, amount), 16_777_217),
+				pallet_transaction_multi_payment::Error::<Runtime>::EvmPermitRunnerError
+			);
+			assert_eq!(
+				Currencies::free_balance(DOT, &user_acc.address()),
+				dot_before,
+				"nothing may move when the permit is rejected"
+			);
+		});
+	}
+
+	fn arrange() -> (EvmAddress, EvmAddress, MockAccount, AccountId, EvmAddress, Balance) {
+		let pool = BorrowingContract::<Runtime>::get();
+		let user = alith_evm_address();
+		let user_acc = MockAccount::new(alith_truncated_account());
+		let paymaster = paymaster_account();
+		let dot_erc20 = HydraErc20Mapping::encode_evm_address(DOT);
+
+		assert_ok!(Currencies::deposit(DOT, &user_acc.address(), 10 * BAG));
+		assert_ok!(Balances::mint_into(&paymaster, 10_000 * UNITS));
+		// The AAVE snapshot carries EVM/Omnipool/Tokens state only; give the treasury and the
+		// paymaster enough to settle EVM fees so the debug-only deposit assertion holds.
+		assert_ok!(Balances::mint_into(
+			&hydradx_runtime::Treasury::account_id(),
+			10_000 * UNITS
+		));
+		assert_ok!(Currencies::deposit(
+			WETH,
+			&hydradx_runtime::Treasury::account_id(),
+			to_ether(10)
+		));
+		assert_ok!(Currencies::deposit(WETH, &paymaster, to_ether(10)));
+
+		(pool, user, user_acc, paymaster, dot_erc20, 1_000_000_000)
+	}
+
+	fn supply_batch(user: EvmAddress, pool: EvmAddress, asset: EvmAddress, amount: Balance) -> RuntimeCall {
+		RuntimeCall::Utility(pallet_utility::Call::batch_all {
+			calls: vec![
+				RuntimeCall::System(frame_system::Call::remark_with_event {
+					remark: b"leg-1-substrate".to_vec(),
+				}),
+				RuntimeCall::Dispatcher(pallet_dispatcher::Call::dispatch_evm_call {
+					call: Box::new(RuntimeCall::EVM(pallet_evm::Call::call {
+						source: user,
+						target: pool,
+						input: supply_calldata(asset, amount, user),
+						value: U256::zero(),
+						gas_limit: 800_000,
+						max_fee_per_gas: crate::evm::gas_price(),
+						max_priority_fee_per_gas: None,
+						nonce: None,
+						access_list: vec![],
+						authorization_list: vec![],
+					})),
+				}),
+			],
+		})
+	}
 }

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -27,6 +27,7 @@ mod global_withdraw_limit;
 mod hsm;
 mod insufficient_assets_ed;
 mod liquidation;
+mod meta_tx;
 mod multi_payment;
 mod non_native_fee;
 mod omnipool_add_all_liquidity;

--- a/integration-tests/src/meta_tx.rs
+++ b/integration-tests/src/meta_tx.rs
@@ -256,3 +256,43 @@ fn meta_tx_nonce_should_be_independent_of_the_system_nonce() {
 		);
 	});
 }
+
+#[test]
+fn meta_tx_should_not_be_able_to_source_an_evm_call_for_a_substrate_signer() {
+	TestNet::reset();
+
+	Hydra::execute_with(|| {
+		let pair = keypair("MetaTxEvm");
+		let signer = account_of(&pair);
+		let relayer: AccountId = ALICE.into();
+
+		let evm_call = RuntimeCall::Dispatcher(pallet_dispatcher::Call::dispatch_evm_call {
+			call: Box::new(RuntimeCall::EVM(pallet_evm::Call::call {
+				source: sp_core::H160::repeat_byte(0xaa),
+				target: sp_core::H160::repeat_byte(0xbb),
+				input: vec![0x06, 0xfd, 0xde, 0x03],
+				value: sp_core::U256::zero(),
+				gas_limit: 100_000,
+				max_fee_per_gas: sp_core::U256::from(26_663_905u128),
+				max_priority_fee_per_gas: None,
+				nonce: None,
+				access_list: vec![],
+				authorization_list: vec![],
+			})),
+		});
+
+		assert_ok!(submit_as(&relayer, signed_meta_tx(&pair, evm_call, 1_000)));
+
+		let inner_failed = System::events().iter().any(|record| {
+			matches!(
+				&record.event,
+				RuntimeEvent::MetaTx(pallet_meta_tx::Event::Dispatched { result: Err(_), .. })
+			)
+		});
+		assert!(
+			inner_failed,
+			"an sr25519 signer cannot satisfy EnsureAddressTruncated, so EVM legs MUST be rejected"
+		);
+		assert_eq!(MetaTx::nonce(&signer), 1);
+	});
+}

--- a/integration-tests/src/meta_tx.rs
+++ b/integration-tests/src/meta_tx.rs
@@ -18,6 +18,23 @@ fn account_of(pair: &sr25519::Pair) -> AccountId {
 	MultiSigner::from(pair.public()).into_account()
 }
 
+/// The furthest deadline the runtime will admit from the current block.
+fn deadline() -> u32 {
+	System::block_number() + <Runtime as pallet_meta_tx::Config>::MaxDeadline::get()
+}
+
+/// The outcome recorded by the `Dispatched` event of the most recent meta transaction.
+fn dispatched_result() -> sp_runtime::DispatchResult {
+	System::events()
+		.into_iter()
+		.rev()
+		.find_map(|record| match record.event {
+			RuntimeEvent::MetaTx(pallet_meta_tx::Event::Dispatched { result, .. }) => Some(result),
+			_ => None,
+		})
+		.expect("an admitted meta transaction always emits Dispatched; qed")
+}
+
 fn signed_meta_tx(pair: &sr25519::Pair, call: RuntimeCall, deadline: u32) -> RuntimeCall {
 	let signer = account_of(pair);
 	let nonce = MetaTx::nonce(&signer);
@@ -83,7 +100,10 @@ fn meta_tx_should_be_fully_sponsored_when_signer_has_zero_balance() {
 		);
 		let relayer_before = Currencies::free_balance(HDX, &relayer);
 
-		assert_ok!(submit_as(&relayer, signed_meta_tx(&pair, remark(b"sponsored"), 1_000)));
+		assert_ok!(submit_as(
+			&relayer,
+			signed_meta_tx(&pair, remark(b"sponsored"), deadline())
+		));
 
 		assert!(
 			remarked_by(&signer),
@@ -136,7 +156,7 @@ fn meta_tx_should_execute_every_leg_when_signer_batches_calls() {
 			],
 		});
 
-		assert_ok!(submit_as(&relayer, signed_meta_tx(&pair, batch, 1_000)));
+		assert_ok!(submit_as(&relayer, signed_meta_tx(&pair, batch, deadline())));
 
 		assert_eq!(
 			Currencies::free_balance(HDX, &recipient) - recipient_before,
@@ -161,7 +181,7 @@ fn meta_tx_should_fail_when_replayed_by_the_relayer() {
 		let signer = account_of(&pair);
 		let relayer: AccountId = ALICE.into();
 
-		let call = signed_meta_tx(&pair, remark(b"once"), 1_000);
+		let call = signed_meta_tx(&pair, remark(b"once"), deadline());
 
 		assert_ok!(submit_as(&relayer, call.clone()));
 		assert_eq!(MetaTx::nonce(&signer), 1);
@@ -219,10 +239,10 @@ fn meta_tx_should_respect_the_runtime_call_filter() {
 			currency_id: HDX,
 			amount: UNITS,
 		});
-		let outcome = submit_as(&relayer, signed_meta_tx(&pair, transfer, 1_000));
+		assert_ok!(submit_as(&relayer, signed_meta_tx(&pair, transfer, deadline())));
 		assert!(
-			outcome.is_err(),
-			"a filtered call MUST surface to the relayer as an extrinsic error"
+			dispatched_result().is_err(),
+			"a filtered call MUST be visible to the relayer"
 		);
 
 		assert_eq!(
@@ -232,8 +252,8 @@ fn meta_tx_should_respect_the_runtime_call_filter() {
 		);
 		assert_eq!(
 			MetaTx::nonce(&signer),
-			0,
-			"a rejected intent reverts its nonce and stays valid until its deadline"
+			1,
+			"a consumed nonce is what stops a failed intent from being replayed"
 		);
 	});
 }
@@ -249,8 +269,8 @@ fn meta_tx_nonce_should_be_independent_of_the_system_nonce() {
 
 		let system_nonce_before = System::account_nonce(&signer);
 
-		assert_ok!(submit_as(&relayer, signed_meta_tx(&pair, remark(b"a"), 1_000)));
-		assert_ok!(submit_as(&relayer, signed_meta_tx(&pair, remark(b"b"), 1_000)));
+		assert_ok!(submit_as(&relayer, signed_meta_tx(&pair, remark(b"a"), deadline())));
+		assert_ok!(submit_as(&relayer, signed_meta_tx(&pair, remark(b"b"), deadline())));
 
 		assert_eq!(MetaTx::nonce(&signer), 2);
 		assert_eq!(
@@ -285,12 +305,12 @@ fn meta_tx_should_fail_when_signer_sources_an_evm_call_from_another_address() {
 			})),
 		});
 
-		let outcome = submit_as(&relayer, signed_meta_tx(&pair, evm_call, 1_000));
+		assert_ok!(submit_as(&relayer, signed_meta_tx(&pair, evm_call, deadline())));
 
 		assert!(
-			outcome.is_err(),
+			dispatched_result().is_err(),
 			"a signer MUST NOT be able to source an EVM call from an address it does not control"
 		);
-		assert_eq!(MetaTx::nonce(&signer), 0);
+		assert_eq!(MetaTx::nonce(&signer), 1);
 	});
 }

--- a/integration-tests/src/meta_tx.rs
+++ b/integration-tests/src/meta_tx.rs
@@ -219,7 +219,11 @@ fn meta_tx_should_respect_the_runtime_call_filter() {
 			currency_id: HDX,
 			amount: UNITS,
 		});
-		assert_ok!(submit_as(&relayer, signed_meta_tx(&pair, transfer, 1_000)));
+		let outcome = submit_as(&relayer, signed_meta_tx(&pair, transfer, 1_000));
+		assert!(
+			outcome.is_err(),
+			"a filtered call MUST surface to the relayer as an extrinsic error"
+		);
 
 		assert_eq!(
 			Currencies::free_balance(HDX, &recipient),
@@ -228,8 +232,8 @@ fn meta_tx_should_respect_the_runtime_call_filter() {
 		);
 		assert_eq!(
 			MetaTx::nonce(&signer),
-			1,
-			"the nonce is still consumed so the intent cannot be retried later"
+			0,
+			"a rejected intent reverts its nonce and stays valid until its deadline"
 		);
 	});
 }
@@ -258,7 +262,7 @@ fn meta_tx_nonce_should_be_independent_of_the_system_nonce() {
 }
 
 #[test]
-fn meta_tx_should_not_be_able_to_source_an_evm_call_for_a_substrate_signer() {
+fn meta_tx_should_fail_when_signer_sources_an_evm_call_from_another_address() {
 	TestNet::reset();
 
 	Hydra::execute_with(|| {
@@ -281,18 +285,12 @@ fn meta_tx_should_not_be_able_to_source_an_evm_call_for_a_substrate_signer() {
 			})),
 		});
 
-		assert_ok!(submit_as(&relayer, signed_meta_tx(&pair, evm_call, 1_000)));
+		let outcome = submit_as(&relayer, signed_meta_tx(&pair, evm_call, 1_000));
 
-		let inner_failed = System::events().iter().any(|record| {
-			matches!(
-				&record.event,
-				RuntimeEvent::MetaTx(pallet_meta_tx::Event::Dispatched { result: Err(_), .. })
-			)
-		});
 		assert!(
-			inner_failed,
-			"an sr25519 signer cannot satisfy EnsureAddressTruncated, so EVM legs MUST be rejected"
+			outcome.is_err(),
+			"a signer MUST NOT be able to source an EVM call from an address it does not control"
 		);
-		assert_eq!(MetaTx::nonce(&signer), 1);
+		assert_eq!(MetaTx::nonce(&signer), 0);
 	});
 }

--- a/integration-tests/src/meta_tx.rs
+++ b/integration-tests/src/meta_tx.rs
@@ -1,0 +1,258 @@
+use crate::polkadot_test_net::*;
+
+use frame_support::assert_ok;
+use frame_support::dispatch::GetDispatchInfo;
+use hydradx_runtime::{AccountId, Currencies, MetaTx, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, System};
+use orml_traits::MultiCurrency;
+use pallet_transaction_payment::ChargeTransactionPayment;
+use sp_core::{sr25519, Encode, Pair};
+use sp_runtime::traits::{DispatchTransaction, Dispatchable, IdentifyAccount, TransactionExtension};
+use sp_runtime::{MultiSignature, MultiSigner};
+use xcm_emulator::TestExt;
+
+fn keypair(name: &str) -> sr25519::Pair {
+	sr25519::Pair::from_string(&format!("//{}", name), None).expect("static seed is valid; qed")
+}
+
+fn account_of(pair: &sr25519::Pair) -> AccountId {
+	MultiSigner::from(pair.public()).into_account()
+}
+
+fn signed_meta_tx(pair: &sr25519::Pair, call: RuntimeCall, deadline: u32) -> RuntimeCall {
+	let signer = account_of(pair);
+	let nonce = MetaTx::nonce(&signer);
+	let payload = MetaTx::signing_payload(&call, &signer, nonce, deadline);
+	let signature = MultiSignature::from(pair.sign(&payload));
+
+	RuntimeCall::MetaTx(pallet_meta_tx::Call::dispatch_meta_tx {
+		signer,
+		call: Box::new(call),
+		nonce,
+		deadline,
+		signature,
+	})
+}
+
+/// Submit `call` through the full signed-extension pipeline so real fees are charged.
+fn submit_as(relayer: &AccountId, call: RuntimeCall) -> frame_support::dispatch::DispatchResultWithPostInfo {
+	let info = call.get_dispatch_info();
+	let len = call.encoded_size();
+
+	let pre = ChargeTransactionPayment::<Runtime>::from(0)
+		.validate_and_prepare(Some(relayer.clone()).into(), &call, &info, len, 0)
+		.expect("fee pre-dispatch must succeed");
+	let (pre_data, _) = pre;
+
+	let result = call.dispatch(RuntimeOrigin::signed(relayer.clone()));
+
+	let mut post = result.unwrap_or_else(|e| e.post_info);
+	assert_ok!(ChargeTransactionPayment::<Runtime>::post_dispatch(
+		pre_data,
+		&info,
+		&mut post,
+		len,
+		&Ok(())
+	));
+
+	result
+}
+
+fn remark(tag: &[u8]) -> RuntimeCall {
+	RuntimeCall::System(frame_system::Call::remark_with_event { remark: tag.to_vec() })
+}
+
+fn remarked_by(who: &AccountId) -> bool {
+	System::events().iter().any(
+		|record| matches!(&record.event, RuntimeEvent::System(frame_system::Event::Remarked { sender, .. }) if sender == who),
+	)
+}
+
+#[test]
+fn meta_tx_should_be_fully_sponsored_when_signer_has_zero_balance() {
+	TestNet::reset();
+
+	Hydra::execute_with(|| {
+		let pair = keypair("MetaTxSigner");
+		let signer = account_of(&pair);
+		let relayer: AccountId = ALICE.into();
+
+		assert_eq!(
+			Currencies::free_balance(HDX, &signer),
+			0,
+			"the signer must start with nothing"
+		);
+		let relayer_before = Currencies::free_balance(HDX, &relayer);
+
+		assert_ok!(submit_as(&relayer, signed_meta_tx(&pair, remark(b"sponsored"), 1_000)));
+
+		assert!(
+			remarked_by(&signer),
+			"the inner call MUST execute under the zero-balance signer's own origin"
+		);
+		assert_eq!(
+			Currencies::free_balance(HDX, &signer),
+			0,
+			"the signer MUST NOT be charged anything"
+		);
+		assert!(
+			Currencies::free_balance(HDX, &relayer) < relayer_before,
+			"the relayer MUST bear the whole cost"
+		);
+		assert_eq!(MetaTx::nonce(&signer), 1);
+	});
+}
+
+#[test]
+fn meta_tx_should_execute_every_leg_when_signer_batches_calls() {
+	TestNet::reset();
+
+	Hydra::execute_with(|| {
+		let pair = keypair("MetaTxBatcher");
+		let signer = account_of(&pair);
+		let relayer: AccountId = ALICE.into();
+		let recipient: AccountId = BOB.into();
+
+		assert_ok!(Currencies::update_balance(
+			RuntimeOrigin::root(),
+			signer.clone(),
+			HDX,
+			(10 * UNITS) as i128,
+		));
+		let recipient_before = Currencies::free_balance(HDX, &recipient);
+		let relayer_before = Currencies::free_balance(HDX, &relayer);
+
+		let batch = RuntimeCall::Utility(pallet_utility::Call::batch_all {
+			calls: vec![
+				RuntimeCall::Currencies(pallet_currencies::Call::transfer {
+					dest: recipient.clone(),
+					currency_id: HDX,
+					amount: UNITS,
+				}),
+				RuntimeCall::Currencies(pallet_currencies::Call::transfer {
+					dest: recipient.clone(),
+					currency_id: HDX,
+					amount: 2 * UNITS,
+				}),
+			],
+		});
+
+		assert_ok!(submit_as(&relayer, signed_meta_tx(&pair, batch, 1_000)));
+
+		assert_eq!(
+			Currencies::free_balance(HDX, &recipient) - recipient_before,
+			3 * UNITS,
+			"both legs must run under the signer's origin"
+		);
+		assert_eq!(
+			Currencies::free_balance(HDX, &signer),
+			7 * UNITS,
+			"the signer pays only what the legs transfer, no fee"
+		);
+		assert!(Currencies::free_balance(HDX, &relayer) < relayer_before);
+	});
+}
+
+#[test]
+fn meta_tx_should_fail_when_replayed_by_the_relayer() {
+	TestNet::reset();
+
+	Hydra::execute_with(|| {
+		let pair = keypair("MetaTxReplay");
+		let signer = account_of(&pair);
+		let relayer: AccountId = ALICE.into();
+
+		let call = signed_meta_tx(&pair, remark(b"once"), 1_000);
+
+		assert_ok!(submit_as(&relayer, call.clone()));
+		assert_eq!(MetaTx::nonce(&signer), 1);
+
+		let replay = call.dispatch(RuntimeOrigin::signed(relayer));
+		assert!(replay.is_err(), "a consumed intent MUST NOT run twice");
+		assert_eq!(MetaTx::nonce(&signer), 1);
+	});
+}
+
+#[test]
+fn meta_tx_should_fail_when_deadline_has_passed() {
+	TestNet::reset();
+
+	Hydra::execute_with(|| {
+		let pair = keypair("MetaTxExpired");
+		let relayer: AccountId = ALICE.into();
+
+		let deadline = System::block_number();
+		let call = signed_meta_tx(&pair, remark(b"stale"), deadline);
+		System::set_block_number(deadline + 1);
+
+		let outcome = call.dispatch(RuntimeOrigin::signed(relayer));
+		assert!(outcome.is_err(), "an expired intent MUST be rejected");
+		assert!(!remarked_by(&account_of(&pair)));
+	});
+}
+
+#[test]
+fn meta_tx_should_respect_the_runtime_call_filter() {
+	TestNet::reset();
+
+	Hydra::execute_with(|| {
+		let pair = keypair("MetaTxFiltered");
+		let signer = account_of(&pair);
+		let relayer: AccountId = ALICE.into();
+		let recipient: AccountId = BOB.into();
+
+		assert_ok!(Currencies::update_balance(
+			RuntimeOrigin::root(),
+			signer.clone(),
+			HDX,
+			(10 * UNITS) as i128,
+		));
+		let recipient_before = Currencies::free_balance(HDX, &recipient);
+
+		assert_ok!(hydradx_runtime::TransactionPause::pause_transaction(
+			RuntimeOrigin::root(),
+			b"Currencies".to_vec(),
+			b"transfer".to_vec(),
+		));
+
+		let transfer = RuntimeCall::Currencies(pallet_currencies::Call::transfer {
+			dest: recipient.clone(),
+			currency_id: HDX,
+			amount: UNITS,
+		});
+		assert_ok!(submit_as(&relayer, signed_meta_tx(&pair, transfer, 1_000)));
+
+		assert_eq!(
+			Currencies::free_balance(HDX, &recipient),
+			recipient_before,
+			"a paused call MUST NOT execute just because it was signed"
+		);
+		assert_eq!(
+			MetaTx::nonce(&signer),
+			1,
+			"the nonce is still consumed so the intent cannot be retried later"
+		);
+	});
+}
+
+#[test]
+fn meta_tx_nonce_should_be_independent_of_the_system_nonce() {
+	TestNet::reset();
+
+	Hydra::execute_with(|| {
+		let pair = keypair("MetaTxNonce");
+		let signer = account_of(&pair);
+		let relayer: AccountId = ALICE.into();
+
+		let system_nonce_before = System::account_nonce(&signer);
+
+		assert_ok!(submit_as(&relayer, signed_meta_tx(&pair, remark(b"a"), 1_000)));
+		assert_ok!(submit_as(&relayer, signed_meta_tx(&pair, remark(b"b"), 1_000)));
+
+		assert_eq!(MetaTx::nonce(&signer), 2);
+		assert_eq!(
+			System::account_nonce(&signer),
+			system_nonce_before,
+			"meta transactions MUST NOT disturb the signer's ordinary nonce"
+		);
+	});
+}

--- a/pallets/meta-tx/Cargo.toml
+++ b/pallets/meta-tx/Cargo.toml
@@ -12,14 +12,15 @@ codec = { workspace = true }
 scale-info = { workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
+sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
+hydradx-traits = { workspace = true }
 
 frame-benchmarking = { workspace = true, optional = true }
 
 [dev-dependencies]
-sp-core = { workspace = true }
 pallet-balances = { workspace = true, features = ["std"] }
 pallet-utility = { workspace = true, features = ["std"] }
 
@@ -30,9 +31,11 @@ std = [
     "scale-info/std",
     "frame-support/std",
     "frame-system/std",
+    "sp-core/std",
     "sp-io/std",
     "sp-runtime/std",
     "sp-std/std",
+    "hydradx-traits/std",
     "frame-benchmarking?/std",
 ]
 runtime-benchmarks = [

--- a/pallets/meta-tx/Cargo.toml
+++ b/pallets/meta-tx/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name = "pallet-meta-tx"
+version = "1.0.0"
+description = "Sponsored meta transactions for native Substrate accounts"
+authors = ["GalacticCouncil"]
+edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/galacticcouncil/hydration-node"
+
+[dependencies]
+codec = { workspace = true }
+scale-info = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
+
+frame-benchmarking = { workspace = true, optional = true }
+
+[dev-dependencies]
+sp-core = { workspace = true }
+pallet-balances = { workspace = true, features = ["std"] }
+pallet-utility = { workspace = true, features = ["std"] }
+
+[features]
+default = ["std"]
+std = [
+    "codec/std",
+    "scale-info/std",
+    "frame-support/std",
+    "frame-system/std",
+    "sp-io/std",
+    "sp-runtime/std",
+    "sp-std/std",
+    "frame-benchmarking?/std",
+]
+runtime-benchmarks = [
+    "frame-benchmarking/runtime-benchmarks",
+    "frame-support/runtime-benchmarks",
+    "frame-system/runtime-benchmarks",
+    "sp-runtime/runtime-benchmarks",
+]
+try-runtime = [
+    "frame-support/try-runtime",
+    "frame-system/try-runtime",
+    "sp-runtime/try-runtime",
+]

--- a/pallets/meta-tx/src/benchmarking.rs
+++ b/pallets/meta-tx/src/benchmarking.rs
@@ -36,5 +36,23 @@ benchmarks! {
 		);
 	}
 
+	dispatch_evm_meta_tx {
+		let relayer: T::AccountId = account("relayer", 0, 0);
+		let from = sp_core::H160::repeat_byte(0xee);
+		let call: <T as crate::Config>::RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
+		let deadline = frame_system::Pallet::<T>::block_number();
+	}: {
+		let _ = crate::Pallet::<T>::dispatch_evm_meta_tx(
+			RawOrigin::Signed(relayer).into(),
+			from,
+			Box::new(call),
+			0,
+			deadline,
+			0,
+			sp_core::H256::repeat_byte(0x11),
+			sp_core::H256::repeat_byte(0x22),
+		);
+	}
+
 	impl_benchmark_test_suite!(Pallet, crate::mock::ExtBuilder::default().build(), crate::mock::Test);
 }

--- a/pallets/meta-tx/src/benchmarking.rs
+++ b/pallets/meta-tx/src/benchmarking.rs
@@ -1,0 +1,40 @@
+// This file is part of https://github.com/galacticcouncil/*
+//
+// Copyright (C) 2021-2024  Intergalactic, Limited (GIB)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Measures the reject path: decode, nonce read and one signature verification.
+
+use super::*;
+
+use codec::Decode;
+use frame_benchmarking::{account, benchmarks};
+use frame_system::RawOrigin;
+use sp_std::boxed::Box;
+use sp_std::vec;
+
+benchmarks! {
+	where_clause { where
+		T: crate::Config,
+	}
+
+	dispatch_meta_tx {
+		let relayer: T::AccountId = account("relayer", 0, 0);
+		let signer: T::AccountId = account("signer", 0, 0);
+		let call: <T as crate::Config>::RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
+		let deadline = frame_system::Pallet::<T>::block_number();
+		let signature = T::Signature::decode(&mut &[0u8; 65][..])
+			.expect("signature type decodes from a 65 byte buffer; qed");
+	}: {
+		let _ = crate::Pallet::<T>::dispatch_meta_tx(
+			RawOrigin::Signed(relayer).into(),
+			signer,
+			Box::new(call),
+			0,
+			deadline,
+			signature,
+		);
+	}
+
+	impl_benchmark_test_suite!(Pallet, crate::mock::ExtBuilder::default().build(), crate::mock::Test);
+}

--- a/pallets/meta-tx/src/lib.rs
+++ b/pallets/meta-tx/src/lib.rs
@@ -175,7 +175,7 @@ pub mod pallet {
 				return Err(Self::rejected(Error::<T>::InvalidSignature, base_weight));
 			}
 
-			Self::execute(relayer, signer, call, nonce, next_nonce, base_weight)
+			Self::execute(relayer, signer, *call, nonce, next_nonce, base_weight)
 		}
 
 		/// Execute `call` under the account of an EVM address that authorised it off-chain,
@@ -200,6 +200,7 @@ pub mod pallet {
 			let call_weight = call.get_dispatch_info().call_weight;
 			T::WeightInfo::dispatch_evm_meta_tx().saturating_add(call_weight)
 		})]
+		#[allow(clippy::too_many_arguments)]
 		pub fn dispatch_evm_meta_tx(
 			origin: OriginFor<T>,
 			from: H160,
@@ -228,7 +229,7 @@ pub mod pallet {
 				return Err(Self::rejected(Error::<T>::InvalidEvmSignature, base_weight));
 			}
 
-			Self::execute(relayer, signer, call, nonce, next_nonce, base_weight)
+			Self::execute(relayer, signer, *call, nonce, next_nonce, base_weight)
 		}
 	}
 
@@ -263,7 +264,7 @@ pub mod pallet {
 		fn execute(
 			relayer: T::AccountId,
 			signer: T::AccountId,
-			call: Box<<T as Config>::RuntimeCall>,
+			call: <T as Config>::RuntimeCall,
 			nonce: u32,
 			next_nonce: u32,
 			weight: Weight,

--- a/pallets/meta-tx/src/lib.rs
+++ b/pallets/meta-tx/src/lib.rs
@@ -68,7 +68,7 @@ pub mod pallet {
 	use hydradx_traits::evm::{EvmFeePayerSupport, InspectEvmAccounts};
 	use sp_core::{H160, H256};
 	use sp_io::hashing::{blake2_256, keccak_256};
-	use sp_runtime::traits::{Dispatchable, IdentifyAccount, UniqueSaturatedInto, Verify, Zero};
+	use sp_runtime::traits::{Dispatchable, IdentifyAccount, Saturating, UniqueSaturatedInto, Verify, Zero};
 	use sp_std::boxed::Box;
 	use sp_std::vec::Vec;
 
@@ -98,6 +98,10 @@ pub mod pallet {
 		/// EVM chain id, bound into the EIP-712 domain separator.
 		type ChainId: Get<u64>;
 
+		/// Furthest ahead of the current block a signer may set a deadline.
+		#[pallet::constant]
+		type MaxDeadline: Get<BlockNumberFor<Self>>;
+
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
 	}
@@ -113,11 +117,12 @@ pub mod pallet {
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
-		/// A meta transaction was executed.
+		/// A meta transaction was executed. `result` is the outcome of the inner call.
 		Dispatched {
 			signer: T::AccountId,
 			relayer: T::AccountId,
 			nonce: u32,
+			result: DispatchResult,
 		},
 	}
 
@@ -129,6 +134,8 @@ pub mod pallet {
 		InvalidNonce,
 		/// The deadline block has already passed.
 		Expired,
+		/// The deadline is further ahead than `MaxDeadline` allows.
+		DeadlineTooFar,
 		/// The signer's meta transaction nonce cannot be advanced any further.
 		NonceExhausted,
 		/// The secp256k1 signature does not recover to the given EVM address.
@@ -139,8 +146,8 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		/// Execute `call` under `signer`'s origin, charging the submitting relayer for the fee.
 		///
-		/// A failing inner call is returned as an extrinsic error, which reverts the nonce with it.
-		/// Such an intent stays valid until its deadline.
+		/// A failing inner call is reported in the `Dispatched` event rather than as an extrinsic
+		/// error, so the nonce is consumed either way and the signature cannot be replayed.
 		///
 		/// Parameters:
 		/// - `origin`: any signed account; it pays the transaction fee.
@@ -150,7 +157,7 @@ pub mod pallet {
 		/// - `deadline`: last block number at which the signature remains valid.
 		/// - `signature`: `signer`'s signature over `signing_payload`.
 		///
-		/// Emits `Dispatched` event when successful.
+		/// Emits `Dispatched` event carrying the outcome of the inner call.
 		///
 		#[pallet::call_index(0)]
 		#[pallet::weight({
@@ -193,7 +200,7 @@ pub mod pallet {
 		/// - `v`: recovery id of the signature, `0` or `1`.
 		/// - `r`, `s`: the secp256k1 signature components.
 		///
-		/// Emits `Dispatched` event when successful.
+		/// Emits `Dispatched` event carrying the outcome of the inner call.
 		///
 		#[pallet::call_index(1)]
 		#[pallet::weight({
@@ -250,8 +257,12 @@ pub mod pallet {
 			deadline: BlockNumberFor<T>,
 			weight: Weight,
 		) -> Result<u32, DispatchErrorWithPostInfo> {
-			if frame_system::Pallet::<T>::block_number() > deadline {
+			let now = frame_system::Pallet::<T>::block_number();
+			if now > deadline {
 				return Err(Self::rejected(Error::<T>::Expired, weight));
+			}
+			if deadline > now.saturating_add(T::MaxDeadline::get()) {
+				return Err(Self::rejected(Error::<T>::DeadlineTooFar, weight));
 			}
 			if Nonces::<T>::get(signer) != nonce {
 				return Err(Self::rejected(Error::<T>::InvalidNonce, weight));
@@ -291,16 +302,14 @@ pub mod pallet {
 				pays_fee: Pays::Yes,
 			};
 
-			match result {
-				Ok(_) => {
-					Self::deposit_event(Event::Dispatched { signer, relayer, nonce });
-					Ok(post_info)
-				}
-				Err(e) => Err(DispatchErrorWithPostInfo {
-					post_info,
-					error: e.error,
-				}),
-			}
+			Self::deposit_event(Event::Dispatched {
+				signer,
+				relayer,
+				nonce,
+				result: result.map(|_| ()).map_err(|e| e.error),
+			});
+
+			Ok(post_info)
 		}
 
 		fn word(value: u128) -> [u8; 32] {

--- a/pallets/meta-tx/src/lib.rs
+++ b/pallets/meta-tx/src/lib.rs
@@ -49,18 +49,28 @@ pub use weights::WeightInfo;
 /// Domain tag mixed into every signed payload so a signature cannot be reused elsewhere.
 pub const PAYLOAD_TAG: [u8; 12] = *b"hydra-metatx";
 
+/// EIP-712 domain and message types for the EVM signing path.
+pub const EIP712_DOMAIN_TYPE: &[u8] = b"EIP712Domain(string name,string version,uint256 chainId)";
+pub const EIP712_DOMAIN_NAME: &[u8] = b"Hydration Meta Transaction";
+pub const EIP712_DOMAIN_VERSION: &[u8] = b"1";
+pub const EIP712_META_TX_TYPE: &[u8] =
+	b"MetaTransaction(address from,bytes call,uint256 nonce,uint256 deadline,uint256 specVersion)";
+
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
 	use codec::{Encode, FullCodec};
 	use frame_support::{
-		dispatch::{GetDispatchInfo, PostDispatchInfo},
+		dispatch::{DispatchErrorWithPostInfo, GetDispatchInfo, PostDispatchInfo},
 		pallet_prelude::*,
 	};
 	use frame_system::pallet_prelude::*;
-	use sp_io::hashing::blake2_256;
-	use sp_runtime::traits::{Dispatchable, IdentifyAccount, Verify, Zero};
+	use hydradx_traits::evm::{EvmFeePayerSupport, InspectEvmAccounts};
+	use sp_core::{H160, H256};
+	use sp_io::hashing::{blake2_256, keccak_256};
+	use sp_runtime::traits::{Dispatchable, IdentifyAccount, UniqueSaturatedInto, Verify, Zero};
 	use sp_std::boxed::Box;
+	use sp_std::vec::Vec;
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
@@ -79,6 +89,15 @@ pub mod pallet {
 		/// Public key type that resolves to an `AccountId`.
 		type Signer: IdentifyAccount<AccountId = Self::AccountId> + Parameter;
 
+		/// Resolves an EVM address to the account its calls execute under.
+		type EvmAccounts: InspectEvmAccounts<Self::AccountId>;
+
+		/// Redirects EVM gas to the relayer for the duration of the inner call.
+		type EvmFeePayer: EvmFeePayerSupport<AccountId = Self::AccountId>;
+
+		/// EVM chain id, bound into the EIP-712 domain separator.
+		type ChainId: Get<u64>;
+
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
 	}
@@ -94,12 +113,11 @@ pub mod pallet {
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
-		/// A meta transaction was executed. `result` is the outcome of the inner call.
+		/// A meta transaction was executed.
 		Dispatched {
 			signer: T::AccountId,
 			relayer: T::AccountId,
 			nonce: u32,
-			result: DispatchResult,
 		},
 	}
 
@@ -111,15 +129,18 @@ pub mod pallet {
 		InvalidNonce,
 		/// The deadline block has already passed.
 		Expired,
+		/// The signer's meta transaction nonce cannot be advanced any further.
+		NonceExhausted,
+		/// The secp256k1 signature does not recover to the given EVM address.
+		InvalidEvmSignature,
 	}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Execute `call` under `signer`'s origin, charging the submitting relayer for the fee.
 		///
-		/// The nonce is consumed even when the inner call fails, so a rejected intent cannot be
-		/// replayed. The inner outcome is reported in the `Dispatched` event rather than as an
-		/// extrinsic error.
+		/// A failing inner call is returned as an extrinsic error, which reverts the nonce with it.
+		/// Such an intent stays valid until its deadline.
 		///
 		/// Parameters:
 		/// - `origin`: any signed account; it pays the transaction fee.
@@ -145,39 +166,186 @@ pub mod pallet {
 			signature: T::Signature,
 		) -> DispatchResultWithPostInfo {
 			let relayer = ensure_signed(origin)?;
+			let base_weight = T::WeightInfo::dispatch_meta_tx();
 
-			ensure!(
-				frame_system::Pallet::<T>::block_number() <= deadline,
-				Error::<T>::Expired
-			);
-			ensure!(Nonces::<T>::get(&signer) == nonce, Error::<T>::InvalidNonce);
+			let next_nonce = Self::admit(&signer, nonce, deadline, base_weight)?;
 
 			let payload = Self::signing_payload(&call, &signer, nonce, deadline);
-			ensure!(signature.verify(&payload[..], &signer), Error::<T>::InvalidSignature);
+			if !signature.verify(&payload[..], &signer) {
+				return Err(Self::rejected(Error::<T>::InvalidSignature, base_weight));
+			}
 
-			Nonces::<T>::insert(&signer, nonce.saturating_add(1));
+			Self::execute(relayer, signer, call, nonce, next_nonce, base_weight)
+		}
 
-			let result = call.dispatch(frame_system::RawOrigin::Signed(signer.clone()).into());
-			let inner_weight = match &result {
-				Ok(post) => post.actual_weight,
-				Err(e) => e.post_info.actual_weight,
-			};
+		/// Execute `call` under the account of an EVM address that authorised it off-chain,
+		/// charging the submitting relayer for both the extrinsic fee and any inner EVM gas.
+		///
+		/// `from` signs an EIP-712 `MetaTransaction` payload with a secp256k1 key, so wallets
+		/// that hold no Substrate key can still originate Substrate calls.
+		///
+		/// Parameters:
+		/// - `origin`: any signed account; it pays the transaction fee and the EVM gas.
+		/// - `from`: the EVM address that authorised `call`.
+		/// - `call`: the call to execute.
+		/// - `nonce`: must equal the current meta transaction nonce of `from`'s account.
+		/// - `deadline`: last block number at which the signature remains valid.
+		/// - `v`: recovery id of the signature, `0` or `1`.
+		/// - `r`, `s`: the secp256k1 signature components.
+		///
+		/// Emits `Dispatched` event when successful.
+		///
+		#[pallet::call_index(1)]
+		#[pallet::weight({
+			let call_weight = call.get_dispatch_info().call_weight;
+			T::WeightInfo::dispatch_evm_meta_tx().saturating_add(call_weight)
+		})]
+		pub fn dispatch_evm_meta_tx(
+			origin: OriginFor<T>,
+			from: H160,
+			call: Box<<T as Config>::RuntimeCall>,
+			nonce: u32,
+			deadline: BlockNumberFor<T>,
+			v: u8,
+			r: H256,
+			s: H256,
+		) -> DispatchResultWithPostInfo {
+			let relayer = ensure_signed(origin)?;
+			let base_weight = T::WeightInfo::dispatch_evm_meta_tx();
+			let signer = T::EvmAccounts::account_id(from);
 
-			Self::deposit_event(Event::Dispatched {
-				signer,
-				relayer,
-				nonce,
-				result: result.map(|_| ()).map_err(|e| e.error),
-			});
+			let next_nonce = Self::admit(&signer, nonce, deadline, base_weight)?;
 
-			Ok(PostDispatchInfo {
-				actual_weight: inner_weight.map(|w| w.saturating_add(T::WeightInfo::dispatch_meta_tx())),
-				pays_fee: Pays::Yes,
-			})
+			let payload = Self::evm_signing_payload(&call, from, nonce, deadline);
+			let mut signature = [0u8; 65];
+			signature[..32].copy_from_slice(r.as_bytes());
+			signature[32..64].copy_from_slice(s.as_bytes());
+			signature[64] = v;
+
+			let public = sp_io::crypto::secp256k1_ecdsa_recover(&signature, &payload)
+				.map_err(|_| Self::rejected(Error::<T>::InvalidEvmSignature, base_weight))?;
+			if H160::from(H256::from_slice(&keccak_256(&public))) != from {
+				return Err(Self::rejected(Error::<T>::InvalidEvmSignature, base_weight));
+			}
+
+			Self::execute(relayer, signer, call, nonce, next_nonce, base_weight)
 		}
 	}
 
 	impl<T: Config> Pallet<T> {
+		fn rejected(error: Error<T>, weight: Weight) -> DispatchErrorWithPostInfo {
+			DispatchErrorWithPostInfo {
+				post_info: PostDispatchInfo {
+					actual_weight: Some(weight),
+					pays_fee: Pays::Yes,
+				},
+				error: error.into(),
+			}
+		}
+
+		fn admit(
+			signer: &T::AccountId,
+			nonce: u32,
+			deadline: BlockNumberFor<T>,
+			weight: Weight,
+		) -> Result<u32, DispatchErrorWithPostInfo> {
+			if frame_system::Pallet::<T>::block_number() > deadline {
+				return Err(Self::rejected(Error::<T>::Expired, weight));
+			}
+			if Nonces::<T>::get(signer) != nonce {
+				return Err(Self::rejected(Error::<T>::InvalidNonce, weight));
+			}
+			nonce
+				.checked_add(1)
+				.ok_or_else(|| Self::rejected(Error::<T>::NonceExhausted, weight))
+		}
+
+		fn execute(
+			relayer: T::AccountId,
+			signer: T::AccountId,
+			call: Box<<T as Config>::RuntimeCall>,
+			nonce: u32,
+			next_nonce: u32,
+			weight: Weight,
+		) -> DispatchResultWithPostInfo {
+			Nonces::<T>::insert(&signer, next_nonce);
+
+			let previous_payer = T::EvmFeePayer::set_fee_payer(relayer.clone());
+			let result = call.dispatch(frame_system::RawOrigin::Signed(signer.clone()).into());
+			match previous_payer {
+				Some(payer) => {
+					let _ = T::EvmFeePayer::set_fee_payer(payer);
+				}
+				None => {
+					let _ = T::EvmFeePayer::clear_fee_payer();
+				}
+			}
+
+			let inner_weight = match &result {
+				Ok(post) => post.actual_weight,
+				Err(e) => e.post_info.actual_weight,
+			};
+			let post_info = PostDispatchInfo {
+				actual_weight: inner_weight.map(|w| w.saturating_add(weight)),
+				pays_fee: Pays::Yes,
+			};
+
+			match result {
+				Ok(_) => {
+					Self::deposit_event(Event::Dispatched { signer, relayer, nonce });
+					Ok(post_info)
+				}
+				Err(e) => Err(DispatchErrorWithPostInfo {
+					post_info,
+					error: e.error,
+				}),
+			}
+		}
+
+		fn word(value: u128) -> [u8; 32] {
+			let mut word = [0u8; 32];
+			word[16..].copy_from_slice(&value.to_be_bytes());
+			word
+		}
+
+		fn address_word(address: H160) -> [u8; 32] {
+			let mut word = [0u8; 32];
+			word[12..].copy_from_slice(address.as_bytes());
+			word
+		}
+
+		/// The 32 bytes an EVM key must sign, as an EIP-712 typed data digest.
+		pub fn evm_signing_payload(
+			call: &<T as Config>::RuntimeCall,
+			from: H160,
+			nonce: u32,
+			deadline: BlockNumberFor<T>,
+		) -> [u8; 32] {
+			let mut domain = Vec::with_capacity(128);
+			domain.extend_from_slice(&keccak_256(EIP712_DOMAIN_TYPE));
+			domain.extend_from_slice(&keccak_256(EIP712_DOMAIN_NAME));
+			domain.extend_from_slice(&keccak_256(EIP712_DOMAIN_VERSION));
+			domain.extend_from_slice(&Self::word(T::ChainId::get().into()));
+
+			let mut message = Vec::with_capacity(192);
+			message.extend_from_slice(&keccak_256(EIP712_META_TX_TYPE));
+			message.extend_from_slice(&Self::address_word(from));
+			message.extend_from_slice(&keccak_256(&call.encode()));
+			message.extend_from_slice(&Self::word(nonce.into()));
+			message.extend_from_slice(&Self::word(UniqueSaturatedInto::<u128>::unique_saturated_into(
+				deadline,
+			)));
+			message.extend_from_slice(&Self::word(
+				<T as frame_system::Config>::Version::get().spec_version.into(),
+			));
+
+			let mut digest = Vec::with_capacity(66);
+			digest.extend_from_slice(&[0x19, 0x01]);
+			digest.extend_from_slice(&keccak_256(&domain));
+			digest.extend_from_slice(&keccak_256(&message));
+			keccak_256(&digest)
+		}
+
 		/// The 32 bytes a signer must sign, bound to this chain and runtime version.
 		pub fn signing_payload(
 			call: &<T as Config>::RuntimeCall,

--- a/pallets/meta-tx/src/lib.rs
+++ b/pallets/meta-tx/src/lib.rs
@@ -1,0 +1,200 @@
+// This file is part of https://github.com/galacticcouncil/*
+//
+//                $$$$$$$      Licensed under the Apache License, Version 2.0 (the "License")
+//             $$$$$$$$$$$$$        you may only use this file in compliance with the License
+//          $$$$$$$$$$$$$$$$$$$
+//                      $$$$$$$$$       Copyright (C) 2021-2024  Intergalactic, Limited (GIB)
+//         $$$$$$$$$$$   $$$$$$$$$$                       SPDX-License-Identifier: Apache-2.0
+//      $$$$$$$$$$$$$$$$$$$$$$$$$$
+//   $$$$$$$$$$$$$$$$$$$$$$$        $                      Built with <3 for decentralisation
+//  $$$$$$$$$$$$$$$$$$$        $$$$$$$
+//  $$$$$$$         $$$$$$$$$$$$$$$$$$      Unless required by applicable law or agreed to in
+//   $       $$$$$$$$$$$$$$$$$$$$$$$       writing, software distributed under the License is
+//      $$$$$$$$$$$$$$$$$$$$$$$$$$        distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+//      $$$$$$$$$   $$$$$$$$$$$         OR CONDITIONS OF ANY KIND, either express or implied.
+//        $$$$$$$$
+//          $$$$$$$$$$$$$$$$$$            See the License for the specific language governing
+//             $$$$$$$$$$$$$                   permissions and limitations under the License.
+//                $$$$$$$
+//                                                                 $$
+//  $$$$$   $$$$$                    $$                       $
+//   $$$     $$$  $$$     $$   $$$$$ $$  $$$ $$$$  $$$$$$$  $$$$  $$$    $$$$$$   $$ $$$$$$
+//   $$$     $$$   $$$   $$  $$$    $$$   $$$  $  $$     $$  $$    $$  $$     $$   $$$   $$$
+//   $$$$$$$$$$$    $$  $$   $$$     $$   $$        $$$$$$$  $$    $$  $$     $$$  $$     $$
+//   $$$     $$$     $$$$    $$$     $$   $$     $$$     $$  $$    $$   $$     $$  $$     $$
+//  $$$$$   $$$$$     $$      $$$$$$$$ $ $$$      $$$$$$$$   $$$  $$$$   $$$$$$$  $$$$   $$$$
+//                  $$$
+
+//! Sponsored meta transactions for native Substrate accounts.
+//!
+//! A signer authorises a call off-chain; any account may submit it and pays the fee. The call
+//! executes under the signer's own origin. The EVM equivalent is the call-permit precompile.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#![allow(clippy::useless_conversion)]
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+#[cfg(feature = "runtime-benchmarks")]
+mod benchmarking;
+
+pub mod weights;
+
+pub use pallet::*;
+pub use weights::WeightInfo;
+
+/// Domain tag mixed into every signed payload so a signature cannot be reused elsewhere.
+pub const PAYLOAD_TAG: [u8; 12] = *b"hydra-metatx";
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+	use codec::{Encode, FullCodec};
+	use frame_support::{
+		dispatch::{GetDispatchInfo, PostDispatchInfo},
+		pallet_prelude::*,
+	};
+	use frame_system::pallet_prelude::*;
+	use sp_io::hashing::blake2_256;
+	use sp_runtime::traits::{Dispatchable, IdentifyAccount, Verify, Zero};
+	use sp_std::boxed::Box;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		/// The overarching call type.
+		type RuntimeCall: Parameter
+			+ Dispatchable<RuntimeOrigin = Self::RuntimeOrigin, PostInfo = PostDispatchInfo>
+			+ GetDispatchInfo
+			+ FullCodec
+			+ TypeInfo
+			+ From<frame_system::Call<Self>>
+			+ IsType<<Self as frame_system::Config>::RuntimeCall>;
+
+		/// Signature type accepted from meta transaction signers.
+		type Signature: Parameter + Verify<Signer = Self::Signer>;
+
+		/// Public key type that resolves to an `AccountId`.
+		type Signer: IdentifyAccount<AccountId = Self::AccountId> + Parameter;
+
+		/// Weight information for extrinsics in this pallet.
+		type WeightInfo: WeightInfo;
+	}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	/// Meta transaction nonce per signer, independent of the system nonce.
+	#[pallet::storage]
+	#[pallet::getter(fn nonce)]
+	pub type Nonces<T: Config> = StorageMap<_, Blake2_128Concat, T::AccountId, u32, ValueQuery>;
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// A meta transaction was executed. `result` is the outcome of the inner call.
+		Dispatched {
+			signer: T::AccountId,
+			relayer: T::AccountId,
+			nonce: u32,
+			result: DispatchResult,
+		},
+	}
+
+	#[pallet::error]
+	pub enum Error<T> {
+		/// The signature does not match the signer, the call, this chain or this runtime version.
+		InvalidSignature,
+		/// The supplied nonce is not the signer's current meta transaction nonce.
+		InvalidNonce,
+		/// The deadline block has already passed.
+		Expired,
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		/// Execute `call` under `signer`'s origin, charging the submitting relayer for the fee.
+		///
+		/// The nonce is consumed even when the inner call fails, so a rejected intent cannot be
+		/// replayed. The inner outcome is reported in the `Dispatched` event rather than as an
+		/// extrinsic error.
+		///
+		/// Parameters:
+		/// - `origin`: any signed account; it pays the transaction fee.
+		/// - `signer`: the account that authorised `call` and under whose origin it runs.
+		/// - `call`: the call to execute.
+		/// - `nonce`: must equal the signer's current meta transaction nonce.
+		/// - `deadline`: last block number at which the signature remains valid.
+		/// - `signature`: `signer`'s signature over `signing_payload`.
+		///
+		/// Emits `Dispatched` event when successful.
+		///
+		#[pallet::call_index(0)]
+		#[pallet::weight({
+			let call_weight = call.get_dispatch_info().call_weight;
+			T::WeightInfo::dispatch_meta_tx().saturating_add(call_weight)
+		})]
+		pub fn dispatch_meta_tx(
+			origin: OriginFor<T>,
+			signer: T::AccountId,
+			call: Box<<T as Config>::RuntimeCall>,
+			nonce: u32,
+			deadline: BlockNumberFor<T>,
+			signature: T::Signature,
+		) -> DispatchResultWithPostInfo {
+			let relayer = ensure_signed(origin)?;
+
+			ensure!(
+				frame_system::Pallet::<T>::block_number() <= deadline,
+				Error::<T>::Expired
+			);
+			ensure!(Nonces::<T>::get(&signer) == nonce, Error::<T>::InvalidNonce);
+
+			let payload = Self::signing_payload(&call, &signer, nonce, deadline);
+			ensure!(signature.verify(&payload[..], &signer), Error::<T>::InvalidSignature);
+
+			Nonces::<T>::insert(&signer, nonce.saturating_add(1));
+
+			let result = call.dispatch(frame_system::RawOrigin::Signed(signer.clone()).into());
+			let inner_weight = match &result {
+				Ok(post) => post.actual_weight,
+				Err(e) => e.post_info.actual_weight,
+			};
+
+			Self::deposit_event(Event::Dispatched {
+				signer,
+				relayer,
+				nonce,
+				result: result.map(|_| ()).map_err(|e| e.error),
+			});
+
+			Ok(PostDispatchInfo {
+				actual_weight: inner_weight.map(|w| w.saturating_add(T::WeightInfo::dispatch_meta_tx())),
+				pays_fee: Pays::Yes,
+			})
+		}
+	}
+
+	impl<T: Config> Pallet<T> {
+		/// The 32 bytes a signer must sign, bound to this chain and runtime version.
+		pub fn signing_payload(
+			call: &<T as Config>::RuntimeCall,
+			signer: &T::AccountId,
+			nonce: u32,
+			deadline: BlockNumberFor<T>,
+		) -> [u8; 32] {
+			(
+				PAYLOAD_TAG,
+				call,
+				signer,
+				nonce,
+				deadline,
+				frame_system::Pallet::<T>::block_hash(BlockNumberFor::<T>::zero()),
+				<T as frame_system::Config>::Version::get().spec_version,
+			)
+				.using_encoded(blake2_256)
+		}
+	}
+}

--- a/pallets/meta-tx/src/mock.rs
+++ b/pallets/meta-tx/src/mock.rs
@@ -1,0 +1,99 @@
+// This file is part of https://github.com/galacticcouncil/*
+//
+// Copyright (C) 2021-2024  Intergalactic, Limited (GIB)
+// SPDX-License-Identifier: Apache-2.0
+
+use crate as pallet_meta_tx;
+use frame_support::{derive_impl, traits::ConstU128};
+use sp_core::{sr25519, Pair};
+use sp_runtime::{
+	traits::{IdentifyAccount, IdentityLookup},
+	AccountId32, BuildStorage, MultiSignature, MultiSigner,
+};
+
+pub type AccountId = AccountId32;
+pub type Balance = u128;
+type Block = frame_system::mocking::MockBlock<Test>;
+
+frame_support::construct_runtime!(
+	pub enum Test {
+		System: frame_system,
+		Balances: pallet_balances,
+		Utility: pallet_utility,
+		MetaTx: pallet_meta_tx,
+	}
+);
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Test {
+	type Block = Block;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type AccountData = pallet_balances::AccountData<Balance>;
+}
+
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
+impl pallet_balances::Config for Test {
+	type Balance = Balance;
+	type AccountStore = System;
+	type ExistentialDeposit = ConstU128<1>;
+}
+
+impl pallet_utility::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeCall = RuntimeCall;
+	type PalletsOrigin = OriginCaller;
+	type BatchHook = ();
+	type WeightInfo = ();
+}
+
+impl pallet_meta_tx::Config for Test {
+	type RuntimeCall = RuntimeCall;
+	type Signature = MultiSignature;
+	type Signer = MultiSigner;
+	type WeightInfo = ();
+}
+
+/// Deterministic sr25519 keypair for `//name`.
+pub fn keypair(name: &str) -> sr25519::Pair {
+	sr25519::Pair::from_string(&alloc::format!("//{name}"), None).expect("static seed is valid; qed")
+}
+
+/// Account id derived from a keypair the same way the runtime derives it.
+pub fn account_of(pair: &sr25519::Pair) -> AccountId {
+	MultiSigner::from(pair.public()).into_account()
+}
+
+/// Sign `payload` as `pair`, producing the runtime's signature type.
+pub fn sign(pair: &sr25519::Pair, payload: &[u8]) -> MultiSignature {
+	MultiSignature::from(pair.sign(payload))
+}
+
+extern crate alloc;
+
+#[derive(Default)]
+pub struct ExtBuilder {
+	balances: Vec<(AccountId, Balance)>,
+}
+
+impl ExtBuilder {
+	pub fn with_balance(mut self, who: AccountId, amount: Balance) -> Self {
+		self.balances.push((who, amount));
+		self
+	}
+
+	pub fn build(self) -> sp_io::TestExternalities {
+		let mut storage = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
+
+		pallet_balances::GenesisConfig::<Test> {
+			balances: self.balances,
+			..Default::default()
+		}
+		.assimilate_storage(&mut storage)
+		.unwrap();
+
+		let mut ext: sp_io::TestExternalities = storage.into();
+		ext.execute_with(|| System::set_block_number(1));
+		ext
+	}
+}

--- a/pallets/meta-tx/src/mock.rs
+++ b/pallets/meta-tx/src/mock.rs
@@ -127,6 +127,7 @@ impl pallet_meta_tx::Config for Test {
 	type EvmAccounts = MockEvmAccounts;
 	type EvmFeePayer = MockEvmFeePayer;
 	type ChainId = ConstU64<222_222>;
+	type MaxDeadline = ConstU64<100>;
 	type WeightInfo = ();
 }
 

--- a/pallets/meta-tx/src/mock.rs
+++ b/pallets/meta-tx/src/mock.rs
@@ -4,8 +4,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate as pallet_meta_tx;
-use frame_support::{derive_impl, traits::ConstU128};
-use sp_core::{sr25519, Pair};
+use frame_support::{
+	derive_impl, parameter_types,
+	traits::{ConstU128, ConstU64},
+};
+use hydradx_traits::evm::{EvmFeePayerSupport, InspectEvmAccounts};
+use sp_core::{ecdsa, sr25519, Pair, H160};
 use sp_runtime::{
 	traits::{IdentifyAccount, IdentityLookup},
 	AccountId32, BuildStorage, MultiSignature, MultiSigner,
@@ -47,10 +51,82 @@ impl pallet_utility::Config for Test {
 	type WeightInfo = ();
 }
 
+parameter_types! {
+	pub storage FeePayer: Option<AccountId> = None;
+}
+
+/// Mirrors `pallet-evm-accounts`: an EVM address maps to `ETH\0` + address + zero padding.
+pub struct MockEvmAccounts;
+
+impl MockEvmAccounts {
+	fn truncated(address: H160) -> AccountId {
+		let mut data = [0u8; 32];
+		data[0..4].copy_from_slice(b"ETH\0");
+		data[4..24].copy_from_slice(address.as_bytes());
+		AccountId32::from(data)
+	}
+}
+
+impl InspectEvmAccounts<AccountId> for MockEvmAccounts {
+	fn is_evm_account(account_id: AccountId) -> bool {
+		AsRef::<[u8; 32]>::as_ref(&account_id).starts_with(b"ETH\0")
+	}
+
+	fn evm_address(account_id: &impl AsRef<[u8; 32]>) -> H160 {
+		let account = account_id.as_ref();
+		if account.starts_with(b"ETH\0") {
+			H160::from_slice(&account[4..24])
+		} else {
+			H160::from_slice(&account[..20])
+		}
+	}
+
+	fn truncated_account_id(evm_address: H160) -> AccountId {
+		Self::truncated(evm_address)
+	}
+
+	fn bound_account_id(_evm_address: H160) -> Option<AccountId> {
+		None
+	}
+
+	fn account_id(evm_address: H160) -> AccountId {
+		Self::truncated(evm_address)
+	}
+
+	fn can_deploy_contracts(_evm_address: H160) -> bool {
+		false
+	}
+
+	fn is_approved_contract(_address: H160) -> bool {
+		false
+	}
+}
+
+pub struct MockEvmFeePayer;
+
+impl EvmFeePayerSupport for MockEvmFeePayer {
+	type AccountId = AccountId;
+
+	fn set_fee_payer(payer: Self::AccountId) -> Option<Self::AccountId> {
+		let previous = FeePayer::get();
+		FeePayer::set(&Some(payer));
+		previous
+	}
+
+	fn clear_fee_payer() -> Option<Self::AccountId> {
+		let previous = FeePayer::get();
+		FeePayer::set(&None);
+		previous
+	}
+}
+
 impl pallet_meta_tx::Config for Test {
 	type RuntimeCall = RuntimeCall;
 	type Signature = MultiSignature;
 	type Signer = MultiSigner;
+	type EvmAccounts = MockEvmAccounts;
+	type EvmFeePayer = MockEvmFeePayer;
+	type ChainId = ConstU64<222_222>;
 	type WeightInfo = ();
 }
 
@@ -67,6 +143,32 @@ pub fn account_of(pair: &sr25519::Pair) -> AccountId {
 /// Sign `payload` as `pair`, producing the runtime's signature type.
 pub fn sign(pair: &sr25519::Pair, payload: &[u8]) -> MultiSignature {
 	MultiSignature::from(pair.sign(payload))
+}
+
+/// Deterministic secp256k1 keypair for `//name`, standing in for a Turnkey/MetaMask wallet.
+pub fn evm_keypair(name: &str) -> ecdsa::Pair {
+	ecdsa::Pair::from_string(&alloc::format!("//{name}"), None).expect("static seed is valid; qed")
+}
+
+/// The Ethereum address of `pair`, derived the same way the pallet recovers it.
+pub fn evm_address_of(pair: &ecdsa::Pair) -> H160 {
+	let probe = [0u8; 32];
+	let signature = pair.sign_prehashed(&probe);
+	let Ok(public) = sp_io::crypto::secp256k1_ecdsa_recover(signature.as_ref(), &probe) else {
+		panic!("a freshly produced signature always recovers");
+	};
+	H160::from(sp_core::H256::from_slice(&sp_io::hashing::keccak_256(&public)))
+}
+
+/// Sign `payload` as `pair`, split into the `v, r, s` the extrinsic expects.
+pub fn evm_sign(pair: &ecdsa::Pair, payload: &[u8; 32]) -> (u8, sp_core::H256, sp_core::H256) {
+	let signature = pair.sign_prehashed(payload);
+	let bytes: &[u8] = signature.as_ref();
+	(
+		bytes[64],
+		sp_core::H256::from_slice(&bytes[..32]),
+		sp_core::H256::from_slice(&bytes[32..64]),
+	)
 }
 
 extern crate alloc;

--- a/pallets/meta-tx/src/tests.rs
+++ b/pallets/meta-tx/src/tests.rs
@@ -5,7 +5,10 @@
 
 use crate::mock::*;
 use crate::{Error, Event, Nonces};
+use frame_support::dispatch::{DispatchErrorWithPostInfo, GetDispatchInfo, PostDispatchInfo};
+use frame_support::pallet_prelude::{Pays, Weight};
 use frame_support::{assert_noop, assert_ok};
+use hydradx_traits::evm::InspectEvmAccounts;
 use sp_runtime::traits::Dispatchable;
 use sp_runtime::DispatchError;
 
@@ -49,6 +52,20 @@ fn signed_submit(
 	submit(relayer, signer, call, nonce, deadline, signature)
 }
 
+fn verification_weight() -> Weight {
+	<<Test as crate::Config>::WeightInfo as crate::WeightInfo>::dispatch_meta_tx()
+}
+
+fn rejected(error: Error<Test>) -> DispatchErrorWithPostInfo {
+	DispatchErrorWithPostInfo {
+		post_info: PostDispatchInfo {
+			actual_weight: Some(verification_weight()),
+			pays_fee: Pays::Yes,
+		},
+		error: error.into(),
+	}
+}
+
 #[test]
 fn dispatch_meta_tx_should_execute_under_signer_origin_when_signature_is_valid() {
 	let alice = keypair("Alice");
@@ -89,7 +106,6 @@ fn dispatch_meta_tx_should_execute_under_signer_origin_when_signature_is_valid()
 					signer,
 					relayer,
 					nonce: 0,
-					result: Ok(()),
 				}
 				.into(),
 			);
@@ -114,7 +130,7 @@ fn dispatch_meta_tx_should_fail_when_signature_belongs_to_another_account() {
 
 			assert_noop!(
 				submit(relayer, signer.clone(), call, 0, 100, signature),
-				Error::<Test>::InvalidSignature
+				rejected(Error::<Test>::InvalidSignature)
 			);
 			assert_eq!(Nonces::<Test>::get(&signer), 0);
 		});
@@ -140,7 +156,7 @@ fn dispatch_meta_tx_should_fail_when_call_is_swapped_after_signing() {
 
 			assert_noop!(
 				submit(relayer, signer.clone(), substituted, 0, 100, signature),
-				Error::<Test>::InvalidSignature
+				rejected(Error::<Test>::InvalidSignature)
 			);
 			assert_eq!(Balances::free_balance(&signer), 10 * UNITS);
 		});
@@ -163,7 +179,7 @@ fn dispatch_meta_tx_should_fail_when_deadline_is_changed_after_signing() {
 
 			assert_noop!(
 				submit(relayer, signer, call, 0, 500, signature),
-				Error::<Test>::InvalidSignature
+				rejected(Error::<Test>::InvalidSignature)
 			);
 		});
 }
@@ -193,7 +209,7 @@ fn dispatch_meta_tx_should_fail_when_replayed_with_the_same_signature() {
 			));
 			assert_noop!(
 				submit(relayer, signer.clone(), call, 0, 100, signature),
-				Error::<Test>::InvalidNonce
+				rejected(Error::<Test>::InvalidNonce)
 			);
 			assert_eq!(
 				Balances::free_balance(&signer),
@@ -216,7 +232,7 @@ fn dispatch_meta_tx_should_fail_when_nonce_is_ahead_of_the_signer() {
 		.execute_with(|| {
 			assert_noop!(
 				signed_submit(relayer, &alice, transfer_call(recipient, UNITS), 7, 100),
-				Error::<Test>::InvalidNonce
+				rejected(Error::<Test>::InvalidNonce)
 			);
 		});
 }
@@ -236,7 +252,7 @@ fn dispatch_meta_tx_should_fail_when_deadline_has_passed() {
 
 			assert_noop!(
 				signed_submit(relayer, &alice, transfer_call(recipient, UNITS), 0, 100),
-				Error::<Test>::Expired
+				rejected(Error::<Test>::Expired)
 			);
 			assert_eq!(Nonces::<Test>::get(&signer), 0);
 		});
@@ -259,7 +275,7 @@ fn dispatch_meta_tx_should_succeed_when_submitted_on_the_deadline_block() {
 }
 
 #[test]
-fn dispatch_meta_tx_should_consume_the_nonce_when_the_inner_call_fails() {
+fn dispatch_meta_tx_should_return_the_inner_error_when_the_inner_call_fails() {
 	let alice = keypair("Alice");
 	let signer = account_of(&alice);
 	let relayer = account_of(&keypair("Relayer"));
@@ -269,30 +285,27 @@ fn dispatch_meta_tx_should_consume_the_nonce_when_the_inner_call_fails() {
 		.with_balance(signer.clone(), UNITS)
 		.build()
 		.execute_with(|| {
-			assert_ok!(signed_submit(
-				relayer.clone(),
-				&alice,
-				transfer_call(recipient.clone(), 1_000 * UNITS),
-				0,
-				100
-			));
+			let call = transfer_call(recipient.clone(), 1_000 * UNITS);
+			let expected = call
+				.clone()
+				.dispatch(RuntimeOrigin::signed(signer.clone()))
+				.expect_err("the transfer exceeds the signer's balance; qed")
+				.error;
+
+			let outcome = signed_submit(relayer, &alice, call, 0, 100);
 
 			assert_eq!(
-				Nonces::<Test>::get(&signer),
-				1,
-				"a failed intent MUST NOT stay replayable"
+				outcome
+					.expect_err("an inner failure MUST surface as an extrinsic error; qed")
+					.error,
+				expected,
+				"the relayer MUST receive the inner call's own error"
 			);
 			assert_eq!(Balances::free_balance(&recipient), 0);
-
-			let dispatched = System::events().into_iter().any(|record| {
-				matches!(
-					record.event,
-					RuntimeEvent::MetaTx(Event::Dispatched { result: Err(_), .. })
-				)
-			});
-			assert!(
-				dispatched,
-				"the inner failure is reported in the event, not as an extrinsic error"
+			assert_eq!(
+				Nonces::<Test>::get(&signer),
+				0,
+				"a failed intent reverts its nonce and stays valid until its deadline"
 			);
 		});
 }
@@ -343,12 +356,16 @@ fn dispatch_meta_tx_should_roll_back_every_leg_when_one_leg_of_batch_all_fails()
 				],
 			});
 
-			assert_ok!(signed_submit(relayer, &alice, batch, 0, 100));
+			let outcome = signed_submit(relayer, &alice, batch, 0, 100);
+			assert!(
+				outcome.is_err(),
+				"a failing leg MUST surface as an extrinsic error, not a silent success"
+			);
 
 			assert_eq!(Balances::free_balance(&first), 0, "batch_all is all-or-nothing");
 			assert_eq!(Balances::free_balance(&second), 0);
 			assert_eq!(Balances::free_balance(&signer), 10 * UNITS);
-			assert_eq!(Nonces::<Test>::get(&signer), 1);
+			assert_eq!(Nonces::<Test>::get(&signer), 0);
 		});
 }
 
@@ -436,4 +453,315 @@ fn nonces_should_advance_independently_per_signer() {
 			assert_eq!(Nonces::<Test>::get(account_of(&alice)), 2);
 			assert_eq!(Nonces::<Test>::get(account_of(&bob)), 1);
 		});
+}
+
+#[test]
+fn dispatch_meta_tx_should_refund_the_inner_call_weight_when_signature_is_invalid() {
+	let alice = keypair("Alice");
+	let mallory = keypair("Mallory");
+	let signer = account_of(&alice);
+	let relayer = account_of(&keypair("Relayer"));
+	let recipient = account_of(&keypair("Recipient"));
+
+	ExtBuilder::default()
+		.with_balance(signer.clone(), 10 * UNITS)
+		.build()
+		.execute_with(|| {
+			let heavy = RuntimeCall::Utility(pallet_utility::Call::batch_all {
+				calls: vec![transfer_call(recipient, UNITS); 100],
+			});
+			let payload = MetaTx::signing_payload(&heavy, &signer, 0, 100);
+			let signature = sign(&mallory, &payload);
+
+			let declared = RuntimeCall::MetaTx(crate::Call::dispatch_meta_tx {
+				signer: signer.clone(),
+				call: Box::new(heavy.clone()),
+				nonce: 0,
+				deadline: 100,
+				signature: signature.clone(),
+			})
+			.get_dispatch_info()
+			.call_weight;
+
+			let outcome = submit(relayer, signer, heavy, 0, 100, signature);
+			let err = outcome.expect_err("an invalid signature must be rejected; qed");
+
+			assert_eq!(err.post_info.actual_weight, Some(verification_weight()));
+			assert!(
+				verification_weight().all_lt(declared),
+				"the relayer MUST NOT be charged for an inner call that never ran"
+			);
+		});
+}
+
+#[test]
+fn dispatch_meta_tx_should_fail_when_the_signers_nonce_cannot_be_advanced() {
+	let alice = keypair("Alice");
+	let signer = account_of(&alice);
+	let relayer = account_of(&keypair("Relayer"));
+	let recipient = account_of(&keypair("Recipient"));
+
+	ExtBuilder::default()
+		.with_balance(signer.clone(), 10 * UNITS)
+		.build()
+		.execute_with(|| {
+			Nonces::<Test>::insert(&signer, u32::MAX);
+
+			assert_noop!(
+				signed_submit(relayer, &alice, transfer_call(recipient, UNITS), u32::MAX, 100),
+				rejected(Error::<Test>::NonceExhausted)
+			);
+			assert_eq!(
+				Nonces::<Test>::get(&signer),
+				u32::MAX,
+				"a saturating nonce MUST NOT leave the intent replayable"
+			);
+		});
+}
+
+fn evm_submit(
+	relayer: AccountId,
+	pair: &sp_core::ecdsa::Pair,
+	call: RuntimeCall,
+	nonce: u32,
+	deadline: u64,
+) -> frame_support::dispatch::DispatchResultWithPostInfo {
+	let from = evm_address_of(pair);
+	let payload = MetaTx::evm_signing_payload(&call, from, nonce, deadline);
+	let (v, r, s) = evm_sign(pair, &payload);
+
+	RuntimeCall::MetaTx(crate::Call::dispatch_evm_meta_tx {
+		from,
+		call: Box::new(call),
+		nonce,
+		deadline,
+		v,
+		r,
+		s,
+	})
+	.dispatch(RuntimeOrigin::signed(relayer))
+}
+
+fn evm_rejected(error: Error<Test>) -> DispatchErrorWithPostInfo {
+	DispatchErrorWithPostInfo {
+		post_info: PostDispatchInfo {
+			actual_weight: Some(<<Test as crate::Config>::WeightInfo as crate::WeightInfo>::dispatch_evm_meta_tx()),
+			pays_fee: Pays::Yes,
+		},
+		error: error.into(),
+	}
+}
+
+#[test]
+fn dispatch_evm_meta_tx_should_execute_under_the_evm_address_account_when_signature_is_valid() {
+	let alice = evm_keypair("AliceEvm");
+	let signer = MockEvmAccounts::account_id(evm_address_of(&alice));
+	let relayer = account_of(&keypair("Relayer"));
+	let recipient = account_of(&keypair("Recipient"));
+
+	ExtBuilder::default()
+		.with_balance(signer.clone(), 10 * UNITS)
+		.with_balance(relayer.clone(), 10 * UNITS)
+		.build()
+		.execute_with(|| {
+			let relayer_before = Balances::free_balance(&relayer);
+
+			assert_ok!(evm_submit(
+				relayer.clone(),
+				&alice,
+				transfer_call(recipient.clone(), UNITS),
+				0,
+				100
+			));
+
+			assert_eq!(
+				Balances::free_balance(&signer),
+				9 * UNITS,
+				"an EVM signature must move the EVM account's own funds"
+			);
+			assert_eq!(Balances::free_balance(&recipient), UNITS);
+			assert_eq!(Balances::free_balance(&relayer), relayer_before);
+			assert_eq!(Nonces::<Test>::get(&signer), 1);
+
+			System::assert_has_event(
+				Event::Dispatched {
+					signer,
+					relayer,
+					nonce: 0,
+				}
+				.into(),
+			);
+		});
+}
+
+#[test]
+fn dispatch_evm_meta_tx_should_fail_when_signature_belongs_to_another_key() {
+	let alice = evm_keypair("AliceEvm");
+	let mallory = evm_keypair("MalloryEvm");
+	let from = evm_address_of(&alice);
+	let signer = MockEvmAccounts::account_id(from);
+	let relayer = account_of(&keypair("Relayer"));
+	let recipient = account_of(&keypair("Recipient"));
+
+	ExtBuilder::default()
+		.with_balance(signer.clone(), 10 * UNITS)
+		.build()
+		.execute_with(|| {
+			let call = transfer_call(recipient, UNITS);
+			let payload = MetaTx::evm_signing_payload(&call, from, 0, 100);
+			let (v, r, s) = evm_sign(&mallory, &payload);
+
+			assert_noop!(
+				RuntimeCall::MetaTx(crate::Call::dispatch_evm_meta_tx {
+					from,
+					call: Box::new(call),
+					nonce: 0,
+					deadline: 100,
+					v,
+					r,
+					s,
+				})
+				.dispatch(RuntimeOrigin::signed(relayer)),
+				evm_rejected(Error::<Test>::InvalidEvmSignature)
+			);
+			assert_eq!(Balances::free_balance(&signer), 10 * UNITS);
+		});
+}
+
+#[test]
+fn dispatch_evm_meta_tx_should_fail_when_call_is_swapped_after_signing() {
+	let alice = evm_keypair("AliceEvm");
+	let from = evm_address_of(&alice);
+	let signer = MockEvmAccounts::account_id(from);
+	let relayer = account_of(&keypair("Relayer"));
+	let recipient = account_of(&keypair("Recipient"));
+	let attacker = account_of(&keypair("Mallory"));
+
+	ExtBuilder::default()
+		.with_balance(signer.clone(), 10 * UNITS)
+		.build()
+		.execute_with(|| {
+			let authorised = transfer_call(recipient, UNITS);
+			let payload = MetaTx::evm_signing_payload(&authorised, from, 0, 100);
+			let (v, r, s) = evm_sign(&alice, &payload);
+
+			assert_noop!(
+				RuntimeCall::MetaTx(crate::Call::dispatch_evm_meta_tx {
+					from,
+					call: Box::new(transfer_call(attacker, 9 * UNITS)),
+					nonce: 0,
+					deadline: 100,
+					v,
+					r,
+					s,
+				})
+				.dispatch(RuntimeOrigin::signed(relayer)),
+				evm_rejected(Error::<Test>::InvalidEvmSignature)
+			);
+			assert_eq!(Balances::free_balance(&signer), 10 * UNITS);
+		});
+}
+
+#[test]
+fn dispatch_evm_meta_tx_should_fail_when_replayed_with_the_same_signature() {
+	let alice = evm_keypair("AliceEvm");
+	let signer = MockEvmAccounts::account_id(evm_address_of(&alice));
+	let relayer = account_of(&keypair("Relayer"));
+	let recipient = account_of(&keypair("Recipient"));
+
+	ExtBuilder::default()
+		.with_balance(signer.clone(), 10 * UNITS)
+		.build()
+		.execute_with(|| {
+			assert_ok!(evm_submit(
+				relayer.clone(),
+				&alice,
+				transfer_call(recipient.clone(), UNITS),
+				0,
+				100
+			));
+			assert_noop!(
+				evm_submit(relayer, &alice, transfer_call(recipient, UNITS), 0, 100),
+				evm_rejected(Error::<Test>::InvalidNonce)
+			);
+			assert_eq!(Balances::free_balance(&signer), 9 * UNITS);
+		});
+}
+
+#[test]
+fn dispatch_evm_meta_tx_should_roll_back_every_leg_when_one_leg_of_batch_all_fails() {
+	let alice = evm_keypair("AliceEvm");
+	let signer = MockEvmAccounts::account_id(evm_address_of(&alice));
+	let relayer = account_of(&keypair("Relayer"));
+	let first = account_of(&keypair("First"));
+	let second = account_of(&keypair("Second"));
+
+	ExtBuilder::default()
+		.with_balance(signer.clone(), 10 * UNITS)
+		.build()
+		.execute_with(|| {
+			let batch = RuntimeCall::Utility(pallet_utility::Call::batch_all {
+				calls: vec![
+					transfer_call(first.clone(), UNITS),
+					transfer_call(second.clone(), 1_000 * UNITS),
+					transfer_call(first.clone(), UNITS),
+				],
+			});
+
+			let outcome = evm_submit(relayer, &alice, batch, 0, 100);
+			assert!(
+				outcome.is_err(),
+				"a failing leg MUST surface to the relayer as an extrinsic error"
+			);
+
+			assert_eq!(Balances::free_balance(&first), 0, "the loop is all-or-nothing");
+			assert_eq!(Balances::free_balance(&second), 0);
+			assert_eq!(Balances::free_balance(&signer), 10 * UNITS);
+			assert_eq!(Nonces::<Test>::get(&signer), 0);
+		});
+}
+
+#[test]
+fn dispatch_evm_meta_tx_should_restore_the_previous_evm_fee_payer_after_the_inner_call() {
+	let alice = evm_keypair("AliceEvm");
+	let signer = MockEvmAccounts::account_id(evm_address_of(&alice));
+	let relayer = account_of(&keypair("Relayer"));
+	let recipient = account_of(&keypair("Recipient"));
+	let incumbent = account_of(&keypair("Incumbent"));
+
+	ExtBuilder::default()
+		.with_balance(signer.clone(), 10 * UNITS)
+		.build()
+		.execute_with(|| {
+			FeePayer::set(&Some(incumbent.clone()));
+
+			assert_ok!(evm_submit(relayer, &alice, transfer_call(recipient, UNITS), 0, 100));
+
+			assert_eq!(
+				FeePayer::get(),
+				Some(incumbent),
+				"an outer fee payer MUST survive a nested meta transaction"
+			);
+		});
+}
+
+#[test]
+fn evm_signing_payload_should_change_when_any_bound_field_changes() {
+	let alice = evm_keypair("AliceEvm");
+	let bob = evm_keypair("BobEvm");
+	let recipient = account_of(&keypair("Recipient"));
+
+	ExtBuilder::default().build().execute_with(|| {
+		let call = transfer_call(recipient.clone(), UNITS);
+		let from = evm_address_of(&alice);
+		let base = MetaTx::evm_signing_payload(&call, from, 0, 100);
+
+		assert_ne!(base, MetaTx::evm_signing_payload(&call, evm_address_of(&bob), 0, 100));
+		assert_ne!(base, MetaTx::evm_signing_payload(&call, from, 1, 100));
+		assert_ne!(base, MetaTx::evm_signing_payload(&call, from, 0, 101));
+		assert_ne!(
+			base,
+			MetaTx::evm_signing_payload(&transfer_call(recipient, 2 * UNITS), from, 0, 100)
+		);
+	});
 }

--- a/pallets/meta-tx/src/tests.rs
+++ b/pallets/meta-tx/src/tests.rs
@@ -1,0 +1,439 @@
+// This file is part of https://github.com/galacticcouncil/*
+//
+// Copyright (C) 2021-2024  Intergalactic, Limited (GIB)
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::mock::*;
+use crate::{Error, Event, Nonces};
+use frame_support::{assert_noop, assert_ok};
+use sp_runtime::traits::Dispatchable;
+use sp_runtime::DispatchError;
+
+const UNITS: Balance = 1_000_000_000_000;
+
+fn transfer_call(to: AccountId, amount: Balance) -> RuntimeCall {
+	RuntimeCall::Balances(pallet_balances::Call::transfer_allow_death {
+		dest: to,
+		value: amount,
+	})
+}
+
+fn submit(
+	relayer: AccountId,
+	signer: AccountId,
+	call: RuntimeCall,
+	nonce: u32,
+	deadline: u64,
+	signature: sp_runtime::MultiSignature,
+) -> frame_support::dispatch::DispatchResultWithPostInfo {
+	RuntimeCall::MetaTx(crate::Call::dispatch_meta_tx {
+		signer,
+		call: Box::new(call),
+		nonce,
+		deadline,
+		signature,
+	})
+	.dispatch(RuntimeOrigin::signed(relayer))
+}
+
+fn signed_submit(
+	relayer: AccountId,
+	pair: &sp_core::sr25519::Pair,
+	call: RuntimeCall,
+	nonce: u32,
+	deadline: u64,
+) -> frame_support::dispatch::DispatchResultWithPostInfo {
+	let signer = account_of(pair);
+	let payload = MetaTx::signing_payload(&call, &signer, nonce, deadline);
+	let signature = sign(pair, &payload);
+	submit(relayer, signer, call, nonce, deadline, signature)
+}
+
+#[test]
+fn dispatch_meta_tx_should_execute_under_signer_origin_when_signature_is_valid() {
+	let alice = keypair("Alice");
+	let signer = account_of(&alice);
+	let relayer = account_of(&keypair("Relayer"));
+	let recipient = account_of(&keypair("Recipient"));
+
+	ExtBuilder::default()
+		.with_balance(signer.clone(), 10 * UNITS)
+		.with_balance(relayer.clone(), 10 * UNITS)
+		.build()
+		.execute_with(|| {
+			let relayer_before = Balances::free_balance(&relayer);
+
+			assert_ok!(signed_submit(
+				relayer.clone(),
+				&alice,
+				transfer_call(recipient.clone(), UNITS),
+				0,
+				100
+			));
+
+			assert_eq!(
+				Balances::free_balance(&signer),
+				9 * UNITS,
+				"the transfer must debit the signer, not the relayer"
+			);
+			assert_eq!(Balances::free_balance(&recipient), UNITS);
+			assert_eq!(
+				Balances::free_balance(&relayer),
+				relayer_before,
+				"the relayer's balance is untouched by the inner call"
+			);
+			assert_eq!(Nonces::<Test>::get(&signer), 1);
+
+			System::assert_has_event(
+				Event::Dispatched {
+					signer,
+					relayer,
+					nonce: 0,
+					result: Ok(()),
+				}
+				.into(),
+			);
+		});
+}
+
+#[test]
+fn dispatch_meta_tx_should_fail_when_signature_belongs_to_another_account() {
+	let alice = keypair("Alice");
+	let mallory = keypair("Mallory");
+	let signer = account_of(&alice);
+	let relayer = account_of(&keypair("Relayer"));
+	let recipient = account_of(&keypair("Recipient"));
+
+	ExtBuilder::default()
+		.with_balance(signer.clone(), 10 * UNITS)
+		.build()
+		.execute_with(|| {
+			let call = transfer_call(recipient, UNITS);
+			let payload = MetaTx::signing_payload(&call, &signer, 0, 100);
+			let signature = sign(&mallory, &payload);
+
+			assert_noop!(
+				submit(relayer, signer.clone(), call, 0, 100, signature),
+				Error::<Test>::InvalidSignature
+			);
+			assert_eq!(Nonces::<Test>::get(&signer), 0);
+		});
+}
+
+#[test]
+fn dispatch_meta_tx_should_fail_when_call_is_swapped_after_signing() {
+	let alice = keypair("Alice");
+	let signer = account_of(&alice);
+	let relayer = account_of(&keypair("Relayer"));
+	let recipient = account_of(&keypair("Recipient"));
+	let attacker = account_of(&keypair("Mallory"));
+
+	ExtBuilder::default()
+		.with_balance(signer.clone(), 10 * UNITS)
+		.build()
+		.execute_with(|| {
+			let authorised = transfer_call(recipient, UNITS);
+			let payload = MetaTx::signing_payload(&authorised, &signer, 0, 100);
+			let signature = sign(&alice, &payload);
+
+			let substituted = transfer_call(attacker, 9 * UNITS);
+
+			assert_noop!(
+				submit(relayer, signer.clone(), substituted, 0, 100, signature),
+				Error::<Test>::InvalidSignature
+			);
+			assert_eq!(Balances::free_balance(&signer), 10 * UNITS);
+		});
+}
+
+#[test]
+fn dispatch_meta_tx_should_fail_when_deadline_is_changed_after_signing() {
+	let alice = keypair("Alice");
+	let signer = account_of(&alice);
+	let relayer = account_of(&keypair("Relayer"));
+	let recipient = account_of(&keypair("Recipient"));
+
+	ExtBuilder::default()
+		.with_balance(signer.clone(), 10 * UNITS)
+		.build()
+		.execute_with(|| {
+			let call = transfer_call(recipient, UNITS);
+			let payload = MetaTx::signing_payload(&call, &signer, 0, 50);
+			let signature = sign(&alice, &payload);
+
+			assert_noop!(
+				submit(relayer, signer, call, 0, 500, signature),
+				Error::<Test>::InvalidSignature
+			);
+		});
+}
+
+#[test]
+fn dispatch_meta_tx_should_fail_when_replayed_with_the_same_signature() {
+	let alice = keypair("Alice");
+	let signer = account_of(&alice);
+	let relayer = account_of(&keypair("Relayer"));
+	let recipient = account_of(&keypair("Recipient"));
+
+	ExtBuilder::default()
+		.with_balance(signer.clone(), 10 * UNITS)
+		.build()
+		.execute_with(|| {
+			let call = transfer_call(recipient, UNITS);
+			let payload = MetaTx::signing_payload(&call, &signer, 0, 100);
+			let signature = sign(&alice, &payload);
+
+			assert_ok!(submit(
+				relayer.clone(),
+				signer.clone(),
+				call.clone(),
+				0,
+				100,
+				signature.clone()
+			));
+			assert_noop!(
+				submit(relayer, signer.clone(), call, 0, 100, signature),
+				Error::<Test>::InvalidNonce
+			);
+			assert_eq!(
+				Balances::free_balance(&signer),
+				9 * UNITS,
+				"the transfer ran exactly once"
+			);
+		});
+}
+
+#[test]
+fn dispatch_meta_tx_should_fail_when_nonce_is_ahead_of_the_signer() {
+	let alice = keypair("Alice");
+	let signer = account_of(&alice);
+	let relayer = account_of(&keypair("Relayer"));
+	let recipient = account_of(&keypair("Recipient"));
+
+	ExtBuilder::default()
+		.with_balance(signer.clone(), 10 * UNITS)
+		.build()
+		.execute_with(|| {
+			assert_noop!(
+				signed_submit(relayer, &alice, transfer_call(recipient, UNITS), 7, 100),
+				Error::<Test>::InvalidNonce
+			);
+		});
+}
+
+#[test]
+fn dispatch_meta_tx_should_fail_when_deadline_has_passed() {
+	let alice = keypair("Alice");
+	let signer = account_of(&alice);
+	let relayer = account_of(&keypair("Relayer"));
+	let recipient = account_of(&keypair("Recipient"));
+
+	ExtBuilder::default()
+		.with_balance(signer.clone(), 10 * UNITS)
+		.build()
+		.execute_with(|| {
+			System::set_block_number(101);
+
+			assert_noop!(
+				signed_submit(relayer, &alice, transfer_call(recipient, UNITS), 0, 100),
+				Error::<Test>::Expired
+			);
+			assert_eq!(Nonces::<Test>::get(&signer), 0);
+		});
+}
+
+#[test]
+fn dispatch_meta_tx_should_succeed_when_submitted_on_the_deadline_block() {
+	let alice = keypair("Alice");
+	let signer = account_of(&alice);
+	let relayer = account_of(&keypair("Relayer"));
+	let recipient = account_of(&keypair("Recipient"));
+
+	ExtBuilder::default()
+		.with_balance(signer, 10 * UNITS)
+		.build()
+		.execute_with(|| {
+			System::set_block_number(100);
+			assert_ok!(signed_submit(relayer, &alice, transfer_call(recipient, UNITS), 0, 100));
+		});
+}
+
+#[test]
+fn dispatch_meta_tx_should_consume_the_nonce_when_the_inner_call_fails() {
+	let alice = keypair("Alice");
+	let signer = account_of(&alice);
+	let relayer = account_of(&keypair("Relayer"));
+	let recipient = account_of(&keypair("Recipient"));
+
+	ExtBuilder::default()
+		.with_balance(signer.clone(), UNITS)
+		.build()
+		.execute_with(|| {
+			assert_ok!(signed_submit(
+				relayer.clone(),
+				&alice,
+				transfer_call(recipient.clone(), 1_000 * UNITS),
+				0,
+				100
+			));
+
+			assert_eq!(
+				Nonces::<Test>::get(&signer),
+				1,
+				"a failed intent MUST NOT stay replayable"
+			);
+			assert_eq!(Balances::free_balance(&recipient), 0);
+
+			let dispatched = System::events().into_iter().any(|record| {
+				matches!(
+					record.event,
+					RuntimeEvent::MetaTx(Event::Dispatched { result: Err(_), .. })
+				)
+			});
+			assert!(
+				dispatched,
+				"the inner failure is reported in the event, not as an extrinsic error"
+			);
+		});
+}
+
+#[test]
+fn dispatch_meta_tx_should_execute_every_leg_when_inner_call_is_batch_all() {
+	let alice = keypair("Alice");
+	let signer = account_of(&alice);
+	let relayer = account_of(&keypair("Relayer"));
+	let first = account_of(&keypair("First"));
+	let second = account_of(&keypair("Second"));
+
+	ExtBuilder::default()
+		.with_balance(signer.clone(), 10 * UNITS)
+		.build()
+		.execute_with(|| {
+			let batch = RuntimeCall::Utility(pallet_utility::Call::batch_all {
+				calls: vec![
+					transfer_call(first.clone(), UNITS),
+					transfer_call(second.clone(), 2 * UNITS),
+				],
+			});
+
+			assert_ok!(signed_submit(relayer, &alice, batch, 0, 100));
+
+			assert_eq!(Balances::free_balance(&first), UNITS);
+			assert_eq!(Balances::free_balance(&second), 2 * UNITS);
+			assert_eq!(Balances::free_balance(&signer), 7 * UNITS);
+		});
+}
+
+#[test]
+fn dispatch_meta_tx_should_roll_back_every_leg_when_one_leg_of_batch_all_fails() {
+	let alice = keypair("Alice");
+	let signer = account_of(&alice);
+	let relayer = account_of(&keypair("Relayer"));
+	let first = account_of(&keypair("First"));
+	let second = account_of(&keypair("Second"));
+
+	ExtBuilder::default()
+		.with_balance(signer.clone(), 10 * UNITS)
+		.build()
+		.execute_with(|| {
+			let batch = RuntimeCall::Utility(pallet_utility::Call::batch_all {
+				calls: vec![
+					transfer_call(first.clone(), UNITS),
+					transfer_call(second.clone(), 1_000 * UNITS),
+				],
+			});
+
+			assert_ok!(signed_submit(relayer, &alice, batch, 0, 100));
+
+			assert_eq!(Balances::free_balance(&first), 0, "batch_all is all-or-nothing");
+			assert_eq!(Balances::free_balance(&second), 0);
+			assert_eq!(Balances::free_balance(&signer), 10 * UNITS);
+			assert_eq!(Nonces::<Test>::get(&signer), 1);
+		});
+}
+
+#[test]
+fn dispatch_meta_tx_should_reject_an_unsigned_origin() {
+	let alice = keypair("Alice");
+	let signer = account_of(&alice);
+	let recipient = account_of(&keypair("Recipient"));
+
+	ExtBuilder::default()
+		.with_balance(signer.clone(), 10 * UNITS)
+		.build()
+		.execute_with(|| {
+			let call = transfer_call(recipient, UNITS);
+			let payload = MetaTx::signing_payload(&call, &signer, 0, 100);
+			let signature = sign(&alice, &payload);
+
+			let outcome = RuntimeCall::MetaTx(crate::Call::dispatch_meta_tx {
+				signer,
+				call: Box::new(call),
+				nonce: 0,
+				deadline: 100,
+				signature,
+			})
+			.dispatch(RuntimeOrigin::none());
+
+			assert_eq!(outcome.unwrap_err().error, DispatchError::BadOrigin);
+		});
+}
+
+#[test]
+fn signing_payload_should_change_when_any_bound_field_changes() {
+	let alice = keypair("Alice");
+	let signer = account_of(&alice);
+	let other = account_of(&keypair("Bob"));
+	let recipient = account_of(&keypair("Recipient"));
+
+	ExtBuilder::default().build().execute_with(|| {
+		let call = transfer_call(recipient.clone(), UNITS);
+		let base = MetaTx::signing_payload(&call, &signer, 0, 100);
+
+		assert_ne!(base, MetaTx::signing_payload(&call, &other, 0, 100), "signer is bound");
+		assert_ne!(base, MetaTx::signing_payload(&call, &signer, 1, 100), "nonce is bound");
+		assert_ne!(
+			base,
+			MetaTx::signing_payload(&call, &signer, 0, 101),
+			"deadline is bound"
+		);
+		assert_ne!(
+			base,
+			MetaTx::signing_payload(&transfer_call(recipient, 2 * UNITS), &signer, 0, 100),
+			"call is bound"
+		);
+	});
+}
+
+#[test]
+fn nonces_should_advance_independently_per_signer() {
+	let alice = keypair("Alice");
+	let bob = keypair("Bob");
+	let relayer = account_of(&keypair("Relayer"));
+	let recipient = account_of(&keypair("Recipient"));
+
+	ExtBuilder::default()
+		.with_balance(account_of(&alice), 10 * UNITS)
+		.with_balance(account_of(&bob), 10 * UNITS)
+		.build()
+		.execute_with(|| {
+			assert_ok!(signed_submit(
+				relayer.clone(),
+				&alice,
+				transfer_call(recipient.clone(), UNITS),
+				0,
+				100
+			));
+			assert_ok!(signed_submit(
+				relayer.clone(),
+				&bob,
+				transfer_call(recipient.clone(), UNITS),
+				0,
+				100
+			));
+			assert_ok!(signed_submit(relayer, &alice, transfer_call(recipient, UNITS), 1, 100));
+
+			assert_eq!(Nonces::<Test>::get(account_of(&alice)), 2);
+			assert_eq!(Nonces::<Test>::get(account_of(&bob)), 1);
+		});
+}

--- a/pallets/meta-tx/src/tests.rs
+++ b/pallets/meta-tx/src/tests.rs
@@ -6,7 +6,8 @@
 use crate::mock::*;
 use crate::{Error, Event, Nonces};
 use frame_support::dispatch::{DispatchErrorWithPostInfo, GetDispatchInfo, PostDispatchInfo};
-use frame_support::pallet_prelude::{Pays, Weight};
+use frame_support::pallet_prelude::{Get, Pays, Weight};
+use frame_support::traits::Currency;
 use frame_support::{assert_noop, assert_ok};
 use hydradx_traits::evm::InspectEvmAccounts;
 use sp_runtime::traits::Dispatchable;
@@ -66,6 +67,17 @@ fn rejected(error: Error<Test>) -> DispatchErrorWithPostInfo {
 	}
 }
 
+fn dispatched_result() -> sp_runtime::DispatchResult {
+	System::events()
+		.into_iter()
+		.rev()
+		.find_map(|record| match record.event {
+			RuntimeEvent::MetaTx(Event::Dispatched { result, .. }) => Some(result),
+			_ => None,
+		})
+		.expect("an admitted meta transaction always emits Dispatched; qed")
+}
+
 #[test]
 fn dispatch_meta_tx_should_execute_under_signer_origin_when_signature_is_valid() {
 	let alice = keypair("Alice");
@@ -106,6 +118,7 @@ fn dispatch_meta_tx_should_execute_under_signer_origin_when_signature_is_valid()
 					signer,
 					relayer,
 					nonce: 0,
+					result: Ok(()),
 				}
 				.into(),
 			);
@@ -178,7 +191,7 @@ fn dispatch_meta_tx_should_fail_when_deadline_is_changed_after_signing() {
 			let signature = sign(&alice, &payload);
 
 			assert_noop!(
-				submit(relayer, signer, call, 0, 500, signature),
+				submit(relayer, signer, call, 0, 60, signature),
 				rejected(Error::<Test>::InvalidSignature)
 			);
 		});
@@ -259,6 +272,52 @@ fn dispatch_meta_tx_should_fail_when_deadline_has_passed() {
 }
 
 #[test]
+fn dispatch_meta_tx_should_fail_when_deadline_is_beyond_the_maximum() {
+	let alice = keypair("Alice");
+	let signer = account_of(&alice);
+	let relayer = account_of(&keypair("Relayer"));
+	let recipient = account_of(&keypair("Recipient"));
+
+	ExtBuilder::default()
+		.with_balance(signer, 10 * UNITS)
+		.build()
+		.execute_with(|| {
+			let max: u64 = <Test as crate::Config>::MaxDeadline::get();
+			let too_far = System::block_number() + max + 1;
+
+			assert_noop!(
+				signed_submit(relayer, &alice, transfer_call(recipient, UNITS), 0, too_far),
+				rejected(Error::<Test>::DeadlineTooFar)
+			);
+		});
+}
+
+#[test]
+fn dispatch_meta_tx_should_succeed_when_deadline_is_exactly_the_maximum() {
+	let alice = keypair("Alice");
+	let signer = account_of(&alice);
+	let relayer = account_of(&keypair("Relayer"));
+	let recipient = account_of(&keypair("Recipient"));
+
+	ExtBuilder::default()
+		.with_balance(signer, 10 * UNITS)
+		.build()
+		.execute_with(|| {
+			let max: u64 = <Test as crate::Config>::MaxDeadline::get();
+			let deadline = System::block_number() + max;
+
+			assert_ok!(signed_submit(
+				relayer,
+				&alice,
+				transfer_call(recipient.clone(), UNITS),
+				0,
+				deadline
+			));
+			assert_eq!(Balances::free_balance(&recipient), UNITS);
+		});
+}
+
+#[test]
 fn dispatch_meta_tx_should_succeed_when_submitted_on_the_deadline_block() {
 	let alice = keypair("Alice");
 	let signer = account_of(&alice);
@@ -275,7 +334,7 @@ fn dispatch_meta_tx_should_succeed_when_submitted_on_the_deadline_block() {
 }
 
 #[test]
-fn dispatch_meta_tx_should_return_the_inner_error_when_the_inner_call_fails() {
+fn dispatch_meta_tx_should_report_the_inner_error_in_the_event_when_the_inner_call_fails() {
 	let alice = keypair("Alice");
 	let signer = account_of(&alice);
 	let relayer = account_of(&keypair("Relayer"));
@@ -292,20 +351,75 @@ fn dispatch_meta_tx_should_return_the_inner_error_when_the_inner_call_fails() {
 				.expect_err("the transfer exceeds the signer's balance; qed")
 				.error;
 
-			let outcome = signed_submit(relayer, &alice, call, 0, 100);
+			assert_ok!(signed_submit(relayer, &alice, call, 0, 100));
 
 			assert_eq!(
-				outcome
-					.expect_err("an inner failure MUST surface as an extrinsic error; qed")
-					.error,
-				expected,
-				"the relayer MUST receive the inner call's own error"
+				dispatched_result(),
+				Err(expected),
+				"the relayer MUST be able to read the inner call's own error"
 			);
 			assert_eq!(Balances::free_balance(&recipient), 0);
+		});
+}
+
+#[test]
+fn dispatch_meta_tx_should_consume_the_nonce_when_the_inner_call_fails() {
+	let alice = keypair("Alice");
+	let signer = account_of(&alice);
+	let relayer = account_of(&keypair("Relayer"));
+	let recipient = account_of(&keypair("Recipient"));
+
+	ExtBuilder::default()
+		.with_balance(signer.clone(), UNITS)
+		.build()
+		.execute_with(|| {
+			let call = transfer_call(recipient, 1_000 * UNITS);
+
+			assert_ok!(signed_submit(relayer, &alice, call, 0, 100));
+
 			assert_eq!(
 				Nonces::<Test>::get(&signer),
+				1,
+				"a consumed nonce is what stops a failed intent from being replayed"
+			);
+		});
+}
+
+#[test]
+fn dispatch_meta_tx_should_fail_when_replayed_after_the_inner_call_failed() {
+	let alice = keypair("Alice");
+	let signer = account_of(&alice);
+	let relayer = account_of(&keypair("Relayer"));
+	let recipient = account_of(&keypair("Recipient"));
+
+	ExtBuilder::default()
+		.with_balance(signer.clone(), UNITS)
+		.build()
+		.execute_with(|| {
+			let call = transfer_call(recipient.clone(), 1_000 * UNITS);
+			let payload = MetaTx::signing_payload(&call, &signer, 0, 100);
+			let signature = sign(&alice, &payload);
+
+			assert_ok!(submit(
+				relayer.clone(),
+				signer.clone(),
+				call.clone(),
 				0,
-				"a failed intent reverts its nonce and stays valid until its deadline"
+				100,
+				signature.clone()
+			));
+			assert!(dispatched_result().is_err());
+
+			Balances::make_free_balance_be(&signer, 10_000 * UNITS);
+
+			assert_noop!(
+				submit(relayer, signer, call, 0, 100, signature),
+				rejected(Error::<Test>::InvalidNonce)
+			);
+			assert_eq!(
+				Balances::free_balance(&recipient),
+				0,
+				"the same bytes MUST NOT execute once conditions turn favourable"
 			);
 		});
 }
@@ -356,16 +470,16 @@ fn dispatch_meta_tx_should_roll_back_every_leg_when_one_leg_of_batch_all_fails()
 				],
 			});
 
-			let outcome = signed_submit(relayer, &alice, batch, 0, 100);
+			assert_ok!(signed_submit(relayer, &alice, batch, 0, 100));
 			assert!(
-				outcome.is_err(),
-				"a failing leg MUST surface as an extrinsic error, not a silent success"
+				dispatched_result().is_err(),
+				"a failing leg MUST be visible to the relayer, not a silent success"
 			);
 
 			assert_eq!(Balances::free_balance(&first), 0, "batch_all is all-or-nothing");
 			assert_eq!(Balances::free_balance(&second), 0);
 			assert_eq!(Balances::free_balance(&signer), 10 * UNITS);
-			assert_eq!(Nonces::<Test>::get(&signer), 0);
+			assert_eq!(Nonces::<Test>::get(&signer), 1);
 		});
 }
 
@@ -588,6 +702,7 @@ fn dispatch_evm_meta_tx_should_execute_under_the_evm_address_account_when_signat
 					signer,
 					relayer,
 					nonce: 0,
+					result: Ok(()),
 				}
 				.into(),
 			);
@@ -708,16 +823,16 @@ fn dispatch_evm_meta_tx_should_roll_back_every_leg_when_one_leg_of_batch_all_fai
 				],
 			});
 
-			let outcome = evm_submit(relayer, &alice, batch, 0, 100);
+			assert_ok!(evm_submit(relayer, &alice, batch, 0, 100));
 			assert!(
-				outcome.is_err(),
-				"a failing leg MUST surface to the relayer as an extrinsic error"
+				dispatched_result().is_err(),
+				"a failing leg MUST be visible to the relayer"
 			);
 
 			assert_eq!(Balances::free_balance(&first), 0, "the loop is all-or-nothing");
 			assert_eq!(Balances::free_balance(&second), 0);
 			assert_eq!(Balances::free_balance(&signer), 10 * UNITS);
-			assert_eq!(Nonces::<Test>::get(&signer), 0);
+			assert_eq!(Nonces::<Test>::get(&signer), 1);
 		});
 }
 
@@ -812,17 +927,23 @@ fn dispatch_meta_tx_should_reject_a_nested_batch_all_exactly_as_a_direct_dispatc
 		.with_balance(signer.clone(), 10 * UNITS)
 		.build()
 		.execute_with(|| {
-			let outcome = signed_submit(relayer, &alice, nested_batch(first.clone(), second.clone()), 0, 100);
+			assert_ok!(signed_submit(
+				relayer,
+				&alice,
+				nested_batch(first.clone(), second.clone()),
+				0,
+				100
+			));
 
 			assert_eq!(
-				outcome.expect_err("utility bans nested batch_all; qed").error,
-				DispatchError::from(frame_system::Error::<Test>::CallFiltered),
+				dispatched_result(),
+				Err(DispatchError::from(frame_system::Error::<Test>::CallFiltered)),
 				"a meta transaction MUST behave exactly as the signer dispatching the call themselves"
 			);
 			assert_eq!(Balances::free_balance(&first), 0);
 			assert_eq!(Balances::free_balance(&second), 0);
 			assert_eq!(Balances::free_balance(&signer), 10 * UNITS);
-			assert_eq!(Nonces::<Test>::get(&signer), 0);
+			assert_eq!(Nonces::<Test>::get(&signer), 1);
 		});
 }
 
@@ -867,16 +988,22 @@ fn dispatch_evm_meta_tx_should_reject_a_nested_batch_all_exactly_as_a_direct_dis
 		.with_balance(signer.clone(), 10 * UNITS)
 		.build()
 		.execute_with(|| {
-			let outcome = evm_submit(relayer, &alice, nested_batch(first.clone(), second.clone()), 0, 100);
+			assert_ok!(evm_submit(
+				relayer,
+				&alice,
+				nested_batch(first.clone(), second.clone()),
+				0,
+				100
+			));
 
 			assert_eq!(
-				outcome.expect_err("utility bans nested batch_all; qed").error,
-				DispatchError::from(frame_system::Error::<Test>::CallFiltered),
+				dispatched_result(),
+				Err(DispatchError::from(frame_system::Error::<Test>::CallFiltered)),
 				"the EVM path MUST inherit the same call filtering as the substrate path"
 			);
 			assert_eq!(Balances::free_balance(&first), 0);
 			assert_eq!(Balances::free_balance(&second), 0);
 			assert_eq!(Balances::free_balance(&signer), 10 * UNITS);
-			assert_eq!(Nonces::<Test>::get(&signer), 0);
+			assert_eq!(Nonces::<Test>::get(&signer), 1);
 		});
 }

--- a/pallets/meta-tx/src/tests.rs
+++ b/pallets/meta-tx/src/tests.rs
@@ -765,3 +765,118 @@ fn evm_signing_payload_should_change_when_any_bound_field_changes() {
 		);
 	});
 }
+
+fn nested_batch(first: AccountId, second: AccountId) -> RuntimeCall {
+	RuntimeCall::Utility(pallet_utility::Call::batch_all {
+		calls: vec![
+			transfer_call(first.clone(), UNITS),
+			RuntimeCall::Utility(pallet_utility::Call::batch_all {
+				calls: vec![transfer_call(second.clone(), UNITS), transfer_call(second, 2 * UNITS)],
+			}),
+			transfer_call(first, UNITS),
+		],
+	})
+}
+
+#[test]
+fn nested_batch_all_should_be_rejected_when_the_signer_dispatches_it_directly() {
+	let alice = keypair("Alice");
+	let signer = account_of(&alice);
+	let first = account_of(&keypair("First"));
+	let second = account_of(&keypair("Second"));
+
+	ExtBuilder::default()
+		.with_balance(signer.clone(), 10 * UNITS)
+		.build()
+		.execute_with(|| {
+			let outcome = nested_batch(first.clone(), second.clone()).dispatch(RuntimeOrigin::signed(signer.clone()));
+
+			assert_eq!(
+				outcome.expect_err("utility bans nested batch_all; qed").error,
+				DispatchError::from(frame_system::Error::<Test>::CallFiltered),
+				"pallet_utility adds a filter to the origin it hands each leg"
+			);
+			assert_eq!(Balances::free_balance(&signer), 10 * UNITS);
+		});
+}
+
+#[test]
+fn dispatch_meta_tx_should_reject_a_nested_batch_all_exactly_as_a_direct_dispatch_would() {
+	let alice = keypair("Alice");
+	let signer = account_of(&alice);
+	let relayer = account_of(&keypair("Relayer"));
+	let first = account_of(&keypair("First"));
+	let second = account_of(&keypair("Second"));
+
+	ExtBuilder::default()
+		.with_balance(signer.clone(), 10 * UNITS)
+		.build()
+		.execute_with(|| {
+			let outcome = signed_submit(relayer, &alice, nested_batch(first.clone(), second.clone()), 0, 100);
+
+			assert_eq!(
+				outcome.expect_err("utility bans nested batch_all; qed").error,
+				DispatchError::from(frame_system::Error::<Test>::CallFiltered),
+				"a meta transaction MUST behave exactly as the signer dispatching the call themselves"
+			);
+			assert_eq!(Balances::free_balance(&first), 0);
+			assert_eq!(Balances::free_balance(&second), 0);
+			assert_eq!(Balances::free_balance(&signer), 10 * UNITS);
+			assert_eq!(Nonces::<Test>::get(&signer), 0);
+		});
+}
+
+#[test]
+fn dispatch_meta_tx_should_not_roll_back_when_the_inner_call_is_utility_batch() {
+	let alice = keypair("Alice");
+	let signer = account_of(&alice);
+	let relayer = account_of(&keypair("Relayer"));
+	let first = account_of(&keypair("First"));
+
+	ExtBuilder::default()
+		.with_balance(signer.clone(), 10 * UNITS)
+		.build()
+		.execute_with(|| {
+			let batch = RuntimeCall::Utility(pallet_utility::Call::batch {
+				calls: vec![
+					transfer_call(first.clone(), UNITS),
+					transfer_call(first.clone(), 1_000 * UNITS),
+				],
+			});
+
+			assert_ok!(signed_submit(relayer, &alice, batch, 0, 100));
+
+			assert_eq!(
+				Balances::free_balance(&first),
+				UNITS,
+				"utility::batch reports Ok on a failing leg, so nothing above it can unwind — relayers MUST use batch_all"
+			);
+			assert_eq!(Nonces::<Test>::get(&signer), 1);
+		});
+}
+
+#[test]
+fn dispatch_evm_meta_tx_should_reject_a_nested_batch_all_exactly_as_a_direct_dispatch_would() {
+	let alice = evm_keypair("AliceEvm");
+	let signer = MockEvmAccounts::account_id(evm_address_of(&alice));
+	let relayer = account_of(&keypair("Relayer"));
+	let first = account_of(&keypair("First"));
+	let second = account_of(&keypair("Second"));
+
+	ExtBuilder::default()
+		.with_balance(signer.clone(), 10 * UNITS)
+		.build()
+		.execute_with(|| {
+			let outcome = evm_submit(relayer, &alice, nested_batch(first.clone(), second.clone()), 0, 100);
+
+			assert_eq!(
+				outcome.expect_err("utility bans nested batch_all; qed").error,
+				DispatchError::from(frame_system::Error::<Test>::CallFiltered),
+				"the EVM path MUST inherit the same call filtering as the substrate path"
+			);
+			assert_eq!(Balances::free_balance(&first), 0);
+			assert_eq!(Balances::free_balance(&second), 0);
+			assert_eq!(Balances::free_balance(&signer), 10 * UNITS);
+			assert_eq!(Nonces::<Test>::get(&signer), 0);
+		});
+}

--- a/pallets/meta-tx/src/weights.rs
+++ b/pallets/meta-tx/src/weights.rs
@@ -1,0 +1,42 @@
+// This file is part of https://github.com/galacticcouncil/*
+//
+// Copyright (C) 2021-2024  Intergalactic, Limited (GIB)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Weights for `pallet_meta_tx`.
+
+#![cfg_attr(rustfmt, rustfmt_skip)]
+#![allow(unused_parens)]
+#![allow(unused_imports)]
+#![allow(missing_docs)]
+
+use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use core::marker::PhantomData;
+
+/// Weight functions needed for `pallet_meta_tx`.
+pub trait WeightInfo {
+    fn dispatch_meta_tx() -> Weight;
+}
+
+/// Weights for `pallet_meta_tx` using the HydraDX node and recommended hardware.
+pub struct HydraWeight<T>(PhantomData<T>);
+
+impl<T: frame_system::Config> WeightInfo for HydraWeight<T> {
+    /// Storage: `MetaTx::Nonces` (r:1 w:1)
+    /// Proof: `MetaTx::Nonces` (`max_values`: None, `max_size`: Some(52), added: 2527, mode: `MaxEncodedLen`)
+    fn dispatch_meta_tx() -> Weight {
+        // Placeholder: dominated by one sr25519 verification plus a single storage read/write.
+        // Regenerate with scripts/benchmarking.sh before this pallet carries value on mainnet.
+        Weight::from_parts(75_000_000, 3517)
+            .saturating_add(T::DbWeight::get().reads(1_u64))
+            .saturating_add(T::DbWeight::get().writes(1_u64))
+    }
+}
+
+impl WeightInfo for () {
+    fn dispatch_meta_tx() -> Weight {
+        Weight::from_parts(75_000_000, 3517)
+            .saturating_add(RocksDbWeight::get().reads(1_u64))
+            .saturating_add(RocksDbWeight::get().writes(1_u64))
+    }
+}

--- a/pallets/meta-tx/src/weights.rs
+++ b/pallets/meta-tx/src/weights.rs
@@ -16,6 +16,7 @@ use core::marker::PhantomData;
 /// Weight functions needed for `pallet_meta_tx`.
 pub trait WeightInfo {
     fn dispatch_meta_tx() -> Weight;
+    fn dispatch_evm_meta_tx() -> Weight;
 }
 
 /// Weights for `pallet_meta_tx` using the HydraDX node and recommended hardware.
@@ -31,11 +32,27 @@ impl<T: frame_system::Config> WeightInfo for HydraWeight<T> {
             .saturating_add(T::DbWeight::get().reads(1_u64))
             .saturating_add(T::DbWeight::get().writes(1_u64))
     }
+
+    /// Storage: `MetaTx::Nonces` (r:1 w:1)
+    /// Proof: `MetaTx::Nonces` (`max_values`: None, `max_size`: Some(52), added: 2527, mode: `MaxEncodedLen`)
+    fn dispatch_evm_meta_tx() -> Weight {
+        // Placeholder: dominated by one secp256k1 recovery plus a single storage read/write.
+        // Regenerate with scripts/benchmarking.sh before this pallet carries value on mainnet.
+        Weight::from_parts(120_000_000, 3517)
+            .saturating_add(T::DbWeight::get().reads(1_u64))
+            .saturating_add(T::DbWeight::get().writes(1_u64))
+    }
 }
 
 impl WeightInfo for () {
     fn dispatch_meta_tx() -> Weight {
         Weight::from_parts(75_000_000, 3517)
+            .saturating_add(RocksDbWeight::get().reads(1_u64))
+            .saturating_add(RocksDbWeight::get().writes(1_u64))
+    }
+
+    fn dispatch_evm_meta_tx() -> Weight {
+        Weight::from_parts(120_000_000, 3517)
             .saturating_add(RocksDbWeight::get().reads(1_u64))
             .saturating_add(RocksDbWeight::get().writes(1_u64))
     }

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "433.0.0"
+version = "434.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"
@@ -55,6 +55,7 @@ pallet-collator-rotation = { workspace = true }
 pallet-currencies = { workspace = true }
 pallet-currencies-rpc-runtime-api = { workspace = true }
 pallet-ema-oracle = { workspace = true }
+pallet-meta-tx = { workspace = true }
 pallet-transaction-pause = { workspace = true }
 pallet-duster = { workspace = true }
 pallet-duster-rpc-runtime-api = { workspace = true }
@@ -217,6 +218,7 @@ runtime-benchmarks = [
     "pallet-claims/runtime-benchmarks",
     "pallet-identity/runtime-benchmarks",
     "pallet-collective/runtime-benchmarks",
+    "pallet-meta-tx/runtime-benchmarks",
     "pallet-transaction-pause/runtime-benchmarks",
     "pallet-tips/runtime-benchmarks",
     "pallet-proxy/runtime-benchmarks",
@@ -332,6 +334,7 @@ std = [
     "pallet-currencies-rpc-runtime-api/std",
     "pallet-omnipool/std",
     "pallet-circuit-breaker/std",
+    "pallet-meta-tx/std",
     "pallet-transaction-pause/std",
     "pallet-dca/std",
     "pallet-ema-oracle/std",
@@ -422,6 +425,7 @@ try-runtime = [
     "pallet-session/try-runtime",
     "pallet-timestamp/try-runtime",
     "pallet-transaction-payment/try-runtime",
+    "pallet-meta-tx/try-runtime",
     "pallet-transaction-pause/try-runtime",
     "pallet-ema-oracle/try-runtime",
     "pallet-utility/try-runtime",

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "434.0.0"
+version = "439.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -129,7 +129,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("hydradx"),
 	impl_name: Cow::Borrowed("hydradx"),
 	authoring_version: 1,
-	spec_version: 433,
+	spec_version: 434,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -173,6 +173,7 @@ construct_runtime!(
 		Origins: pallet_custom_origins = 38,
 		Whitelist: pallet_whitelist = 39,
 		Dispatcher: pallet_dispatcher = 40,
+		MetaTx: pallet_meta_tx = 41,
 
 		// HydraDX related modules
 		AssetRegistry: pallet_asset_registry = 51,
@@ -360,6 +361,7 @@ mod benches {
 		[pallet_referenda, Referenda]
 		[pallet_whitelist, Whitelist]
 		[pallet_dispatcher, Dispatcher]
+		[pallet_meta_tx, MetaTx]
 		[pallet_hsm, HSM]
 		[pallet_dynamic_fees, DynamicFees]
 		[pallet_signet, Signet]

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -129,7 +129,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("hydradx"),
 	impl_name: Cow::Borrowed("hydradx"),
 	authoring_version: 1,
-	spec_version: 434,
+	spec_version: 439,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/hydradx/src/system.rs
+++ b/runtime/hydradx/src/system.rs
@@ -444,6 +444,10 @@ impl pallet_utility::Config for Runtime {
 	type WeightInfo = weights::pallet_utility::HydraWeight<Runtime>;
 }
 
+parameter_types! {
+	pub const MetaTxMaxDeadline: BlockNumber = 100;
+}
+
 impl pallet_meta_tx::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	type Signature = primitives::Signature;
@@ -451,6 +455,7 @@ impl pallet_meta_tx::Config for Runtime {
 	type EvmAccounts = EVMAccounts;
 	type EvmFeePayer = crate::evm::EvmFeePayerImpl;
 	type ChainId = crate::EVMChainId;
+	type MaxDeadline = MetaTxMaxDeadline;
 	type WeightInfo = pallet_meta_tx::weights::HydraWeight<Runtime>;
 }
 

--- a/runtime/hydradx/src/system.rs
+++ b/runtime/hydradx/src/system.rs
@@ -444,6 +444,13 @@ impl pallet_utility::Config for Runtime {
 	type WeightInfo = weights::pallet_utility::HydraWeight<Runtime>;
 }
 
+impl pallet_meta_tx::Config for Runtime {
+	type RuntimeCall = RuntimeCall;
+	type Signature = primitives::Signature;
+	type Signer = <primitives::Signature as sp_runtime::traits::Verify>::Signer;
+	type WeightInfo = pallet_meta_tx::weights::HydraWeight<Runtime>;
+}
+
 pub struct ManageExecutionTypeForUnifiedEvent;
 
 impl BatchHook for ManageExecutionTypeForUnifiedEvent {

--- a/runtime/hydradx/src/system.rs
+++ b/runtime/hydradx/src/system.rs
@@ -448,6 +448,9 @@ impl pallet_meta_tx::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	type Signature = primitives::Signature;
 	type Signer = <primitives::Signature as sp_runtime::traits::Verify>::Signer;
+	type EvmAccounts = EVMAccounts;
+	type EvmFeePayer = crate::evm::EvmFeePayerImpl;
+	type ChainId = crate::EVMChainId;
 	type WeightInfo = pallet_meta_tx::weights::HydraWeight<Runtime>;
 }
 

--- a/scripts/meta-tx-relayer/README.md
+++ b/scripts/meta-tx-relayer/README.md
@@ -1,0 +1,60 @@
+# meta-tx-relayer
+
+Sponsoring relayer for `pallet-meta-tx`. Accepts a signed intent from a user who holds
+nothing, submits it, and pays the fee. The ERC-4337 analogue is a bundler with a
+built-in paymaster.
+
+## Why this is not in the node
+
+The relayer holds a funded key and signs transactions. RPC nodes are public and
+replicated, so putting a spending key in one means every operator sponsors everyone.
+The repo's own precedent agrees: `liquidation-worker-support` exposes an RPC that only
+*serves data*, and the actor that signs and submits lives outside the node.
+
+A custom node RPC (`node/src/rpc.rs`, alongside `LiquidationWorker`) is technically
+possible and would be the place to put this if sponsorship ever needs to be
+consensus-adjacent. It isn't.
+
+## Run
+
+```sh
+npm install
+
+RPC_ENDPOINT=ws://localhost:9988 SPONSOR_URI=//Alice npm start   # terminal 1
+RPC_ENDPOINT=ws://localhost:9988 npm run demo                    # terminal 2
+```
+
+The demo generates a brand-new account with a zero balance, signs a `system.remarkWithEvent`
+intent, posts it to the relayer, and prints the account's balance afterwards — still zero.
+
+## API
+
+| Method | Path | Body / result |
+|---|---|---|
+| `GET` | `/health` | sponsor address and free balance |
+| `GET` | `/nonce/:address` | the signer's current meta-tx nonce |
+| `POST` | `/sponsor` | `{ signer, call, nonce, deadline, signature }` |
+
+`call` is the SCALE-encoded call as hex. `signature` is a hex `MultiSignature`.
+
+## Configuration
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `RPC_ENDPOINT` | `ws://localhost:9988` | node websocket |
+| `SPONSOR_URI` | `//Alice` | the paying key |
+| `PORT` | `3000` | HTTP port |
+| `ALLOWED_PALLETS` | `System,Balances,Currencies,Utility,Omnipool` | pallets the sponsor will pay for |
+| `MAX_INTENTS_PER_SIGNER` | `20` | per-process quota |
+| `MAX_REF_TIME` | `5_000_000_000` | intended weight ceiling |
+
+## What a production deployment still needs
+
+The chain-side primitive is complete; this service is deliberately minimal.
+
+- Persistent rate limiting and quotas (counters here are in-memory and reset on restart).
+- Key management — an HSM or remote signer rather than `SPONSOR_URI`.
+- Authentication, so sponsorship is not open to the internet.
+- Weight screening: `MAX_REF_TIME` is read but not yet enforced against the decoded call.
+- Nonce pipelining, so concurrent intents from one signer do not collide.
+- Metrics and alerting on sponsor balance.

--- a/scripts/meta-tx-relayer/package.json
+++ b/scripts/meta-tx-relayer/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "meta-tx-relayer",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "src/server.js",
+  "description": "Sponsoring relayer for pallet-meta-tx: accepts signed intents and submits them, paying the fee",
+  "license": "Apache-2.0",
+  "scripts": {
+    "start": "node src/server.js",
+    "demo": "node src/demo.js"
+  },
+  "dependencies": {
+    "@polkadot/api": "^16.4.5",
+    "@polkadot/keyring": "^13.5.5",
+    "@polkadot/util": "^13.5.5",
+    "@polkadot/util-crypto": "^13.5.5",
+    "express": "^4.21.2"
+  }
+}

--- a/scripts/meta-tx-relayer/src/demo.js
+++ b/scripts/meta-tx-relayer/src/demo.js
@@ -1,0 +1,44 @@
+import { ApiPromise, WsProvider } from "@polkadot/api";
+import { Keyring } from "@polkadot/keyring";
+import { cryptoWaitReady, mnemonicGenerate } from "@polkadot/util-crypto";
+import { buildIntent } from "./payload.js";
+
+const ENDPOINT = process.env.RPC_ENDPOINT ?? "ws://localhost:9988";
+const RELAYER = process.env.RELAYER_URL ?? "http://localhost:3000";
+
+async function main() {
+	await cryptoWaitReady();
+	const api = await ApiPromise.create({ provider: new WsProvider(ENDPOINT) });
+
+	// A wallet that has never held a token and cannot pay for anything.
+	const user = new Keyring({ type: "sr25519" }).addFromUri(mnemonicGenerate());
+	const { data } = await api.query.system.account(user.address);
+	console.log(`user    ${user.address}`);
+	console.log(`balance ${data.free.toString()}  (expected 0)`);
+
+	const call = api.tx.system.remarkWithEvent("sponsored by the relayer");
+	const intent = await buildIntent(api, user, call);
+	console.log(`intent  nonce=${intent.nonce} deadline=${intent.deadline}`);
+
+	const response = await fetch(`${RELAYER}/sponsor`, {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify(intent),
+	});
+	const body = await response.json();
+	console.log(`relayer ${response.status}`, body);
+
+	if (!response.ok) process.exit(1);
+
+	const after = await api.query.system.account(user.address);
+	const nonce = await api.query.metaTx.nonces(user.address);
+	console.log(`balance ${after.data.free.toString()}  (still 0 — the relayer paid)`);
+	console.log(`nonce   ${nonce.toNumber()}  (consumed, so the intent cannot be replayed)`);
+
+	await api.disconnect();
+}
+
+main().catch((e) => {
+	console.error(e);
+	process.exit(1);
+});

--- a/scripts/meta-tx-relayer/src/payload.js
+++ b/scripts/meta-tx-relayer/src/payload.js
@@ -1,0 +1,55 @@
+import { u8aConcat, stringToU8a } from "@polkadot/util";
+import { blake2AsU8a, decodeAddress } from "@polkadot/util-crypto";
+
+// Must match PAYLOAD_TAG in pallets/meta-tx/src/lib.rs.
+const PAYLOAD_TAG = "hydra-metatx";
+
+/** Chain constants the payload is bound to. Read once per connection. */
+export async function domain(api) {
+	return {
+		// The runtime reads System::block_hash(0), which is the genesis hash once block 1 exists.
+		genesisHash: (await api.query.system.blockHash(0)).toU8a(),
+		specVersion: api.runtimeVersion.specVersion.toNumber(),
+	};
+}
+
+/** The 32 bytes a signer must sign to authorise `call`. Mirrors Pallet::signing_payload. */
+export function signingPayload(api, { call, signer, nonce, deadline, genesisHash, specVersion }) {
+	return blake2AsU8a(
+		u8aConcat(
+			stringToU8a(PAYLOAD_TAG),
+			call.toU8a(),
+			decodeAddress(signer),
+			api.createType("u32", nonce).toU8a(),
+			api.createType("u32", deadline).toU8a(),
+			genesisHash,
+			api.createType("u32", specVersion).toU8a()
+		),
+		256
+	);
+}
+
+/** Build and sign an intent with a keyring pair. Returns the body the relayer expects. */
+export async function buildIntent(api, pair, call, { lifetimeBlocks = 100 } = {}) {
+	const { genesisHash, specVersion } = await domain(api);
+	const nonce = (await api.query.metaTx.nonces(pair.address)).toNumber();
+	const head = await api.rpc.chain.getHeader();
+	const deadline = head.number.toNumber() + lifetimeBlocks;
+
+	const payload = signingPayload(api, {
+		call,
+		signer: pair.address,
+		nonce,
+		deadline,
+		genesisHash,
+		specVersion,
+	});
+
+	return {
+		signer: pair.address,
+		call: call.method.toHex(),
+		nonce,
+		deadline,
+		signature: api.createType("MultiSignature", { Sr25519: pair.sign(payload) }).toHex(),
+	};
+}

--- a/scripts/meta-tx-relayer/src/server.js
+++ b/scripts/meta-tx-relayer/src/server.js
@@ -1,0 +1,110 @@
+import express from "express";
+import { ApiPromise, WsProvider } from "@polkadot/api";
+import { Keyring } from "@polkadot/keyring";
+import { cryptoWaitReady } from "@polkadot/util-crypto";
+
+const ENDPOINT = process.env.RPC_ENDPOINT ?? "ws://localhost:9988";
+const SPONSOR_URI = process.env.SPONSOR_URI ?? "//Alice";
+const PORT = Number(process.env.PORT ?? 3000);
+
+// Policy. A real deployment would load this from config and back it with persistent counters.
+const ALLOWED_PALLETS = (process.env.ALLOWED_PALLETS ?? "System,Balances,Currencies,Utility,Omnipool")
+	.split(",")
+	.map((s) => s.trim());
+const MAX_INTENTS_PER_SIGNER = Number(process.env.MAX_INTENTS_PER_SIGNER ?? 20);
+const MAX_REF_TIME = BigInt(process.env.MAX_REF_TIME ?? 5_000_000_000n);
+
+const seen = new Map();
+
+function rateLimit(signer) {
+	const used = seen.get(signer) ?? 0;
+	if (used >= MAX_INTENTS_PER_SIGNER) return false;
+	seen.set(signer, used + 1);
+	return true;
+}
+
+/** Reject anything the sponsor is not willing to pay for, before it costs a fee. */
+function screen(api, call) {
+	const { section } = api.registry.findMetaCall(call.callIndex);
+	if (!ALLOWED_PALLETS.includes(section)) {
+		return `pallet '${section}' is not sponsored`;
+	}
+	return null;
+}
+
+async function main() {
+	await cryptoWaitReady();
+
+	const api = await ApiPromise.create({ provider: new WsProvider(ENDPOINT) });
+	const sponsor = new Keyring({ type: "sr25519" }).addFromUri(SPONSOR_URI);
+
+	console.log(`relayer: connected to ${ENDPOINT}`);
+	console.log(`relayer: sponsoring as ${sponsor.address}`);
+
+	const app = express();
+	app.use(express.json({ limit: "128kb" }));
+
+	app.get("/health", async (_req, res) => {
+		const { data } = await api.query.system.account(sponsor.address);
+		res.json({ ok: true, sponsor: sponsor.address, free: data.free.toString() });
+	});
+
+	app.get("/nonce/:address", async (req, res) => {
+		const nonce = await api.query.metaTx.nonces(req.params.address);
+		res.json({ nonce: nonce.toNumber() });
+	});
+
+	app.post("/sponsor", async (req, res) => {
+		const { signer, call, nonce, deadline, signature } = req.body ?? {};
+		if (!signer || !call || nonce === undefined || deadline === undefined || !signature) {
+			return res.status(400).json({ error: "signer, call, nonce, deadline and signature are required" });
+		}
+
+		let decoded;
+		try {
+			decoded = api.createType("Call", call);
+		} catch {
+			return res.status(400).json({ error: "call is not decodable against this runtime" });
+		}
+
+		const rejected = screen(api, decoded);
+		if (rejected) return res.status(403).json({ error: rejected });
+		if (!rateLimit(signer)) return res.status(429).json({ error: "intent quota exhausted for this signer" });
+
+		const onChainNonce = (await api.query.metaTx.nonces(signer)).toNumber();
+		if (onChainNonce !== Number(nonce)) {
+			return res.status(409).json({ error: `stale nonce: chain expects ${onChainNonce}` });
+		}
+
+		const tx = api.tx.metaTx.dispatchMetaTx(signer, decoded, nonce, deadline, signature);
+
+		try {
+			// Dry-run first so a doomed intent never costs the sponsor a fee.
+			const dry = await tx.dryRun(sponsor);
+			if (dry.isErr) {
+				return res.status(422).json({ error: "intent would fail", detail: dry.toHuman() });
+			}
+		} catch (e) {
+			console.warn(`relayer: dry-run unavailable (${e.message}), submitting anyway`);
+		}
+
+		try {
+			const hash = await new Promise((resolve, reject) => {
+				tx.signAndSend(sponsor, ({ status, dispatchError }) => {
+					if (dispatchError) return reject(new Error(dispatchError.toString()));
+					if (status.isInBlock) resolve(status.asInBlock.toHex());
+				}).catch(reject);
+			});
+			res.json({ ok: true, block: hash });
+		} catch (e) {
+			res.status(500).json({ error: e.message });
+		}
+	});
+
+	app.listen(PORT, () => console.log(`relayer: listening on :${PORT}`));
+}
+
+main().catch((e) => {
+	console.error(e);
+	process.exit(1);
+});


### PR DESCRIPTION
## What this is

A POC of **sponsored meta transactions for native Substrate accounts** — a user signs an intent
off-chain, anyone submits it and pays the fee, and the call executes under the *signer's* origin.

This is the Substrate counterpart of the EVM call-permit path. Opening it for feedback on
direction before hardening.

## Why only Substrate accounts

While scoping this I tested what already exists. **The EVM side already does most of what was
asked for:**

- A signer with 0 HDX / 0 WETH / 0 DAI is already fully sponsored end to end — the paymaster
  pays everything (measured: ~0.09 HDX).
- Batching already works under one signature — verified at 14 and at 50 legs.

So the remaining gap was native Substrate accounts only, and that is all this PR adds.

## Why it is small

On the EVM side "the relayer pays" needed the whole `EvmFeePayer` override, because EVM gas is
charged to `source`. On the Substrate side the relayer signs and submits the extrinsic, so
`ChargeTransactionPayment` already charges them. Nothing to build.

That leaves three jobs: verify a signature, dispatch under the signer's origin, bump a nonce.

## What is in the payload

`blake2_256` over `(tag, call, signer, nonce, deadline, genesis_hash, spec_version)`.

Genesis hash and spec version are the Substrate analogue of EIP-712's domain separator — without
them an intent replays across forks, and across runtime upgrades that change call encoding.

## Behaviour worth reviewing

- **The nonce is consumed even when the inner call fails.** A rejected intent must not stay
  replayable. The inner outcome is reported in the `Dispatched` event rather than as an
  extrinsic error. This mirrors the EVM permit path.
- **The runtime `CallFilter` applies** — verified by an integration test that pauses
  `Currencies::transfer` and confirms a signed intent for it does not execute.
- **Batching falls out for free** — `utility.batch_all` is just a valid inner call.

## The relayer

`scripts/meta-tx-relayer/` — an HTTP service that accepts intents, screens them against a
pallet allowlist, dry-runs, and submits. ERC-4337's bundler-plus-paymaster.

**It is deliberately not in the node.** The relayer holds a funded key and signs. RPC nodes are
public and replicated, so a spending key in one means every operator sponsors everyone. The
repo's own precedent agrees: `liquidation-worker-support` exposes an RPC that only serves data,
and the actor that signs lives outside. A node RPC remains possible if sponsorship ever needs
to be consensus-adjacent; it does not.

`npm run demo` generates a brand-new zero-balance account, signs an intent, and shows the
balance still zero afterwards.

## Tests

22 total, all passing.

- 16 unit (`pallets/meta-tx/src/tests.rs`): valid path and origin, wrong signer, call swapped
  after signing, deadline swapped after signing, replay, nonce ahead, expired, on-deadline
  boundary, nonce consumed on inner failure, `batch_all` all-or-nothing both ways, unsigned
  origin rejected, every payload field proven load-bearing, per-signer nonce independence.
- 6 integration (`integration-tests/src/meta_tx.rs`), through the **full fee pipeline** so the
  sponsorship claim is real: zero-balance signer fully sponsored, batching, replay, expiry,
  call filter respected, meta nonce independent of the system nonce.

## Known gaps — deliberate for a POC

- **Weights are a placeholder.** `weights.rs` is hand-set and needs `scripts/benchmarking.sh`
  before this carries value on mainnet. The benchmark currently measures the reject path.
- **Wallet UX.** There is no EIP-712 equivalent on Substrate, so a user signs an opaque 32-byte
  hash. Fine for a relayer-operated flow, not fine for arbitrary users. This may be the real
  blocker for production and is worth discussing.
- **No deferred execution** ("sign now, fire later"). Separate feature with its own storage,
  expiry and ordering questions. Not built pending confirmation it is wanted.
- **No call scoping beyond the existing `CallFilter`.** A signed call is a broad grant. A
  `ProxyType`-style filter is the obvious next step if that is a concern.
- **No revocation.** Bumping one's own meta-nonce would do it; cheap to add now, painful later.
- **Relayer is minimal** — in-memory rate limits, key from env, no auth. See its README.

## Questions

1. Is the Substrate gap the right target, given the EVM side already works?
2. Deferred execution — wanted, or out of scope?
3. Is opaque-hash signing acceptable, or does this need a readable-payload story first?
