### PR TITLE
fix: NTT over-limit mint locks down the asset instead of reverting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13903,7 +13903,7 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "runtime-integration-tests"
-version = "1.107.0"
+version = "1.107.1"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5787,7 +5787,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "438.0.0"
+version = "439.0.0"
 dependencies = [
  "alloy-primitives 0.7.7",
  "alloy-sol-types 0.7.7",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "1.107.0"
+version = "1.107.1"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/src/evm.rs
+++ b/integration-tests/src/evm.rs
@@ -2271,12 +2271,11 @@ mod currency_precompile_ntt {
 
 		Hydra::execute_with(|| {
 			set_minter();
-			// per-period (1 day) issuance-increase budget = registry xcm_rate_limit
 			let limit = 1_000 * UNITS;
 			set_dai_mint_limit(limit);
 			let issuance_before = total_issuance(DAI);
 
-			// within budget: mints cleanly, nothing reserved, no lockdown
+			// within budget: clean mint
 			assert_eq!(
 				CurrencyPrecompile::execute(&mut mint_handle(minter(), evm_address2(), 600 * UNITS)),
 				empty_output()
@@ -2284,16 +2283,14 @@ mod currency_precompile_ntt {
 			assert_balance!(evm_account2(), DAI, 600 * UNITS);
 			assert_reserved_balance!(evm_account2(), DAI, 0);
 
-			// exceeding the remaining budget takes the same reserve-and-lockdown path as an
-			// over-limit XCM deposit: the mint lands in full, the excess (1100 minted vs the
-			// 1000 budget = 100) is reserved on the recipient, and the asset is locked down.
+			// over budget: mint lands, excess reserved, asset locked down
 			assert_eq!(
 				CurrencyPrecompile::execute(&mut mint_handle(minter(), evm_address2(), 500 * UNITS)),
 				empty_output()
 			);
 			assert_eq!(total_issuance(DAI), issuance_before + 1_100 * UNITS);
-			assert_balance!(evm_account2(), DAI, 1_000 * UNITS); // free = budget
-			assert_reserved_balance!(evm_account2(), DAI, 100 * UNITS); // excess locked
+			assert_balance!(evm_account2(), DAI, 1_000 * UNITS);
+			assert_reserved_balance!(evm_account2(), DAI, 100 * UNITS);
 			assert!(matches!(
 				pallet_circuit_breaker::AssetLockdownState::<hydradx_runtime::Runtime>::get(DAI),
 				Some(pallet_circuit_breaker::types::LockdownStatus::Locked(_))
@@ -2310,25 +2307,18 @@ mod currency_precompile_ntt {
 			let limit = 1_000 * UNITS;
 			set_dai_mint_limit(limit);
 
-			// mint within budget, to the manager itself
 			assert_eq!(
 				CurrencyPrecompile::execute(&mut mint_handle(minter(), minter(), 600 * UNITS)),
 				empty_output()
 			);
 
-			// burning refills the budget: the fuse measures NET issuance increase per period.
-			// This mirrors the current breaker semantics (see the ignored upstream test
-			// `rate_limit_should_not_be_bypassed_by_burning_tokens` in
-			// pallets/circuit-breaker/src/tests/deposit_limit.rs). For NTT this bounds net
-			// inflation per period, which is what the hub-escrow invariant cares about.
-			// If the breaker moves to gross accounting, this test must be updated.
+			// the fuse measures NET issuance increase per period, so burning refills the budget
 			assert_eq!(
 				CurrencyPrecompile::execute(&mut burn_handle(minter(), 400 * UNITS)),
 				empty_output()
 			);
 
-			// net increase is now 600 - 400 + 700 = 900 <= 1000, so this stays within budget:
-			// without the burn, 600 + 700 = 1300 would have reserved the excess and locked down.
+			// net increase 600 - 400 + 700 = 900 <= 1000, so no reserve/lockdown
 			assert_eq!(
 				CurrencyPrecompile::execute(&mut mint_handle(minter(), minter(), 700 * UNITS)),
 				empty_output()
@@ -2355,9 +2345,7 @@ mod currency_precompile_ntt {
 				hydradx_runtime::System::block_number() + 1_000,
 			));
 
-			// while the asset is locked down every incoming deposit — including an NTT mint —
-			// lands but is fully reserved on the recipient (LockdownActive path), rather than
-			// reverting and stranding the source-chain funds.
+			// mint into a locked-down asset lands but is fully reserved, rather than reverting
 			assert_eq!(
 				CurrencyPrecompile::execute(&mut mint_handle(minter(), evm_address2(), UNITS)),
 				empty_output()

--- a/integration-tests/src/evm.rs
+++ b/integration-tests/src/evm.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use crate::utils::executive::assert_executive_apply_signed_extrinsic;
-use crate::{assert_balance, polkadot_test_net::*};
+use crate::{assert_balance, assert_reserved_balance, polkadot_test_net::*};
 
 use fp_evm::{Context, Transfer};
 use fp_rpc::runtime_decl_for_ethereum_runtime_rpc_api::EthereumRuntimeRPCApi;
@@ -1939,6 +1939,7 @@ mod currency_precompile_ntt {
 	use fp_evm::ExitRevert::Reverted;
 	use fp_evm::PrecompileFailure;
 	use hydradx_runtime::{AssetRegistry, CircuitBreaker, EVMAccounts};
+	use orml_traits::MultiReservableCurrency;
 	use pallet_asset_registry::AssetType;
 	use pretty_assertions::assert_eq;
 
@@ -2265,7 +2266,7 @@ mod currency_precompile_ntt {
 	}
 
 	#[test]
-	fn mint_should_be_throttled_by_issuance_circuit_breaker() {
+	fn mint_over_the_limit_should_reserve_excess_and_lock_down_the_asset() {
 		TestNet::reset();
 
 		Hydra::execute_with(|| {
@@ -2275,47 +2276,28 @@ mod currency_precompile_ntt {
 			set_dai_mint_limit(limit);
 			let issuance_before = total_issuance(DAI);
 
-			// within budget
+			// within budget: mints cleanly, nothing reserved, no lockdown
 			assert_eq!(
 				CurrencyPrecompile::execute(&mut mint_handle(minter(), evm_address2(), 600 * UNITS)),
 				empty_output()
 			);
-
-			// exceeding the remaining budget reverts cleanly; no reserve-and-lockdown
-			let result = CurrencyPrecompile::execute(&mut mint_handle(minter(), evm_address2(), 500 * UNITS));
-			assert_eq!(
-				result,
-				Err(PrecompileFailure::Revert {
-					exit_status: Reverted,
-					output: custom_error(b"MintLimitReached()", &[]),
-				})
-			);
 			assert_balance!(evm_account2(), DAI, 600 * UNITS);
-			assert_eq!(total_issuance(DAI), issuance_before + 600 * UNITS);
-			// the asset must not be locked down by the failed EVM mint
-			assert_eq!(
-				pallet_circuit_breaker::AssetLockdownState::<hydradx_runtime::Runtime>::get(DAI),
-				Some(pallet_circuit_breaker::types::LockdownStatus::Unlocked((
-					hydradx_runtime::System::block_number(),
-					issuance_before,
-				)))
-			);
+			assert_reserved_balance!(evm_account2(), DAI, 0);
 
-			// exactly filling the remaining budget is fine
+			// exceeding the remaining budget takes the same reserve-and-lockdown path as an
+			// over-limit XCM deposit: the mint lands in full, the excess (1100 minted vs the
+			// 1000 budget = 100) is reserved on the recipient, and the asset is locked down.
 			assert_eq!(
-				CurrencyPrecompile::execute(&mut mint_handle(minter(), evm_address2(), 400 * UNITS)),
+				CurrencyPrecompile::execute(&mut mint_handle(minter(), evm_address2(), 500 * UNITS)),
 				empty_output()
 			);
-
-			// budget exhausted
-			let result = CurrencyPrecompile::execute(&mut mint_handle(minter(), evm_address2(), 1));
-			assert_eq!(
-				result,
-				Err(PrecompileFailure::Revert {
-					exit_status: Reverted,
-					output: custom_error(b"MintLimitReached()", &[]),
-				})
-			);
+			assert_eq!(total_issuance(DAI), issuance_before + 1_100 * UNITS);
+			assert_balance!(evm_account2(), DAI, 1_000 * UNITS); // free = budget
+			assert_reserved_balance!(evm_account2(), DAI, 100 * UNITS); // excess locked
+			assert!(matches!(
+				pallet_circuit_breaker::AssetLockdownState::<hydradx_runtime::Runtime>::get(DAI),
+				Some(pallet_circuit_breaker::types::LockdownStatus::Locked(_))
+			));
 		});
 	}
 
@@ -2328,17 +2310,10 @@ mod currency_precompile_ntt {
 			let limit = 1_000 * UNITS;
 			set_dai_mint_limit(limit);
 
-			// exhaust the budget, minting to the manager itself
+			// mint within budget, to the manager itself
 			assert_eq!(
-				CurrencyPrecompile::execute(&mut mint_handle(minter(), minter(), limit)),
+				CurrencyPrecompile::execute(&mut mint_handle(minter(), minter(), 600 * UNITS)),
 				empty_output()
-			);
-			assert_eq!(
-				CurrencyPrecompile::execute(&mut mint_handle(minter(), minter(), 1)),
-				Err(PrecompileFailure::Revert {
-					exit_status: Reverted,
-					output: custom_error(b"MintLimitReached()", &[]),
-				})
 			);
 
 			// burning refills the budget: the fuse measures NET issuance increase per period.
@@ -2351,15 +2326,23 @@ mod currency_precompile_ntt {
 				CurrencyPrecompile::execute(&mut burn_handle(minter(), 400 * UNITS)),
 				empty_output()
 			);
+
+			// net increase is now 600 - 400 + 700 = 900 <= 1000, so this stays within budget:
+			// without the burn, 600 + 700 = 1300 would have reserved the excess and locked down.
 			assert_eq!(
-				CurrencyPrecompile::execute(&mut mint_handle(minter(), minter(), 400 * UNITS)),
+				CurrencyPrecompile::execute(&mut mint_handle(minter(), minter(), 700 * UNITS)),
 				empty_output()
 			);
+			assert_reserved_balance!(minter_account(), DAI, 0);
+			assert!(matches!(
+				pallet_circuit_breaker::AssetLockdownState::<hydradx_runtime::Runtime>::get(DAI),
+				None | Some(pallet_circuit_breaker::types::LockdownStatus::Unlocked(_))
+			));
 		});
 	}
 
 	#[test]
-	fn mint_should_fail_when_asset_is_in_lockdown() {
+	fn mint_into_a_locked_down_asset_reserves_the_full_amount() {
 		TestNet::reset();
 
 		Hydra::execute_with(|| {
@@ -2372,15 +2355,19 @@ mod currency_precompile_ntt {
 				hydradx_runtime::System::block_number() + 1_000,
 			));
 
-			let result = CurrencyPrecompile::execute(&mut mint_handle(minter(), evm_address2(), UNITS));
-
+			// while the asset is locked down every incoming deposit — including an NTT mint —
+			// lands but is fully reserved on the recipient (LockdownActive path), rather than
+			// reverting and stranding the source-chain funds.
 			assert_eq!(
-				result,
-				Err(PrecompileFailure::Revert {
-					exit_status: Reverted,
-					output: custom_error(b"MintLimitReached()", &[]),
-				})
+				CurrencyPrecompile::execute(&mut mint_handle(minter(), evm_address2(), UNITS)),
+				empty_output()
 			);
+			assert_balance!(evm_account2(), DAI, 0);
+			assert_reserved_balance!(evm_account2(), DAI, UNITS);
+			assert!(matches!(
+				pallet_circuit_breaker::AssetLockdownState::<hydradx_runtime::Runtime>::get(DAI),
+				Some(pallet_circuit_breaker::types::LockdownStatus::Locked(_))
+			));
 		});
 	}
 

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "438.0.0"
+version = "439.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/evm/precompiles/multicurrency.rs
+++ b/runtime/hydradx/src/evm/precompiles/multicurrency.rs
@@ -39,7 +39,6 @@ use frame_support::traits::{ExistenceRequirement, IsType, OriginTrait};
 use hydradx_traits::evm::{Erc20Encoding, InspectEvmAccounts};
 use hydradx_traits::registry::Inspect as InspectRegistry;
 use orml_traits::{MultiCurrency as MultiCurrencyT, MultiCurrency};
-use pallet_circuit_breaker::fuses::issuance::IssuanceIncreaseFuse;
 use pallet_evm::{AddressMapping, ExitRevert, Precompile, PrecompileFailure, PrecompileHandle, PrecompileResult};
 use primitive_types::{H160, U256};
 use primitives::{AssetId, Balance};
@@ -344,8 +343,11 @@ where
 	}
 
 	/// INttToken mint: only the NTT minter bound to the asset can call it.
-	/// Throttled by the issuance circuit breaker: reverts instead of triggering the
-	/// reserve-and-lockdown path used by XCM deposits, so a rejected NTT delivery can be replayed.
+	/// The deposit routes through orml-tokens, whose `PostDeposit` hook is the issuance
+	/// circuit breaker (`IssuanceIncreaseFuse::on_deposit`). An over-limit mint therefore
+	/// lands, reserves the excess on the recipient and puts the asset into lockdown — the
+	/// same reserve-and-lockdown path an over-limit XCM deposit takes — rather than
+	/// reverting and leaving the source-chain funds stuck until the window rolls.
 	fn mint(asset_id: AssetId, handle: &mut impl PrecompileHandle) -> PrecompileResult {
 		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
 
@@ -357,10 +359,6 @@ where
 		let amount = input.read::<Balance>()?;
 
 		Self::ensure_ntt_minter(asset_id, handle.context().caller)?;
-
-		if !IssuanceIncreaseFuse::<Runtime>::can_mint(asset_id.into(), amount.into()) {
-			return Err(revert_custom_error("MintLimitReached()", &[]));
-		}
 
 		let to = ExtendedAddressMapping::into_account_id(to);
 

--- a/runtime/hydradx/src/evm/precompiles/multicurrency.rs
+++ b/runtime/hydradx/src/evm/precompiles/multicurrency.rs
@@ -342,12 +342,8 @@ where
 		Ok(succeed(EvmDataWriter::new().write(true).build()))
 	}
 
-	/// INttToken mint: only the NTT minter bound to the asset can call it.
-	/// The deposit routes through orml-tokens, whose `PostDeposit` hook is the issuance
-	/// circuit breaker (`IssuanceIncreaseFuse::on_deposit`). An over-limit mint therefore
-	/// lands, reserves the excess on the recipient and puts the asset into lockdown — the
-	/// same reserve-and-lockdown path an over-limit XCM deposit takes — rather than
-	/// reverting and leaving the source-chain funds stuck until the window rolls.
+	/// INttToken mint: only the NTT minter bound to the asset can call it. Over-limit mints take
+	/// the deposit's PostDeposit circuit-breaker path (reserve excess + lockdown), same as XCM.
 	fn mint(asset_id: AssetId, handle: &mut impl PrecompileHandle) -> PrecompileResult {
 		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
 

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -129,7 +129,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("hydradx"),
 	impl_name: Cow::Borrowed("hydradx"),
 	authoring_version: 1,
-	spec_version: 438,
+	spec_version: 439,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Fixes #1511.

An over-limit NTT `mint` on the currencies precompile now takes the same reserve-and-lockdown path as an over-limit XCM deposit, instead of reverting `MintLimitReached()` and stranding source-chain funds until the window rolls.

**Root cause** → the precompile did a read-only `IssuanceIncreaseFuse::can_mint` pre-check and reverted over the limit. But the deposit it performs already routes through `orml_tokens`, whose `PostDeposit` hook *is* the circuit breaker (`CurrencyHooks::PostDeposit = IssuanceIncreaseFuse`, `runtime/hydradx/src/assets.rs:130`; `orml_tokens` fires it in `do_deposit`). So the pre-check was a redundant guard that short-circuited *before* the breaker's own reserve-and-lockdown could engage.

**Fix** → drop the `can_mint` pre-check (+ its now-dead import) from `mint`. The `deposit` then behaves exactly like the XCM path:
- over the per-period budget → the mint lands, the excess is reserved on the recipient, the asset goes into `LockdownStatus::Locked(until)` and `AssetLockdown` is emitted;
- into an already-locked asset → the deposit lands but the full amount is reserved (`LockdownActive`);
- within budget → unchanged.

The VAA is consumed (no replay), the recipient's excess is reserved rather than stuck on the source chain, and the safety mechanism the limit exists for actually engages.

**Tests** (`integration-tests/src/evm.rs`, `currency_precompile_ntt`) — updated the three that asserted the old revert:
- `mint_over_the_limit_should_reserve_excess_and_lock_down_the_asset` — 600 clean, then 500 over the 1,000 budget → 1,100 minted, 100 reserved, asset `Locked`.
- `mint_into_a_locked_down_asset_reserves_the_full_amount` — mint into a locked asset succeeds but fully reserves.
- `burn_should_refill_mint_budget_within_period` — reframed to net accounting (600 mint, burn 400, 700 stays within 1,000, no lockdown).

`cargo test -p runtime-integration-tests currency_precompile_ntt` → 14 passed / 0 failed; `cargo fmt --check` clean.

Runtime `spec_version` bumped 438 → 439 (and `hydradx-runtime` crate to 439.0.0).
