### PR TITLE
test: lock in permit nonce consumption when the inner call reverts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13978,7 +13978,7 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "runtime-integration-tests"
-version = "1.107.1"
+version = "1.107.2"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "1.107.1"
+version = "1.107.2"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/src/evm_permit.rs
+++ b/integration-tests/src/evm_permit.rs
@@ -3227,6 +3227,107 @@ mod sponsored_paymaster {
 		});
 	}
 
+	// Regression lock for the design commitment documented in
+	// `pallets/transaction-multi-payment/src/lib.rs`, in `do_dispatch_permit_signed`:
+	// "Revert already consumed the nonce and charged gas; commit it like the
+	// unsigned path. Returning Err would roll the nonce back → replayable."
+	//
+	// The two halves are already covered separately: the nonce bump on revert by
+	// `signed_dispatch_permit_should_commit_and_consume_nonce_when_inner_call_reverts`,
+	// and the refusal of a spent nonce by
+	// `signed_dispatch_permit_should_fail_when_replayed_with_same_nonce` (on a permit
+	// that succeeded). This composes them on the revert path, which is the case the
+	// comment is about: the inner call had no effect, so a replay that got through
+	// would execute a call the signer authorized exactly once. It also pins that the
+	// refused replay does not advance the nonce a second time.
+	#[test]
+	fn permit_nonce_is_consumed_when_inner_call_reverts_and_replay_is_rejected() {
+		TestNet::reset();
+
+		Hydra::execute_with(|| {
+			init_omnipool_with_oracle_for_block_10();
+			let paymaster = paymaster_account();
+			assert_ok!(Balances::mint_into(&paymaster, 100 * UNITS));
+			let user_acc = MockAccount::new(alith_truncated_account());
+			assert_ok!(Currencies::update_balance(
+				RuntimeOrigin::root(),
+				user_acc.address(),
+				HDX,
+				(10 * UNITS) as i128,
+			));
+
+			let alith = alith_evm_address();
+			let nonce_before = pallet_evm_precompile_call_permit::NoncesStorage::get(alith);
+			let dai_before = user_acc.balance(DAI);
+
+			// Unachievable slippage — the inner call reverts inside the EVM.
+			let inner_call = RuntimeCall::Omnipool(pallet_omnipool::Call::<Runtime>::sell {
+				asset_in: HDX,
+				asset_out: DAI,
+				amount: 1_000_000_000,
+				min_buy_amount: u128::MAX,
+			});
+			let (from, data, gas_limit, deadline, v, r, s) =
+				build_permit_for_call(&inner_call, 1_000_000, U256::from(1_000_000_000_000u128));
+
+			// The extrinsic itself succeeds even though the inner call reverted.
+			assert_ok!(MultiTransactionPayment::dispatch_permit(
+				RuntimeOrigin::signed(paymaster.clone()),
+				from,
+				DISPATCH_ADDR,
+				U256::from(0),
+				data.clone(),
+				gas_limit,
+				deadline,
+				v,
+				r,
+				s,
+			));
+
+			assert_eq!(
+				user_acc.balance(DAI),
+				dai_before,
+				"reverted inner call MUST NOT have any effect",
+			);
+			assert_eq!(
+				pallet_evm_precompile_call_permit::NoncesStorage::get(alith),
+				nonce_before + U256::one(),
+				"revert MUST still consume the permit nonce — otherwise the permit is replayable",
+			);
+
+			// Replay the identical permit. The nonce it was signed against is spent,
+			// so signature recovery no longer yields `from` and the permit is refused
+			// before any execution.
+			let replay = MultiTransactionPayment::dispatch_permit(
+				RuntimeOrigin::signed(paymaster),
+				from,
+				DISPATCH_ADDR,
+				U256::from(0),
+				data,
+				gas_limit,
+				deadline,
+				v,
+				r,
+				s,
+			);
+			assert_eq!(
+				replay.expect_err("replay of a reverted permit must be refused").error,
+				pallet_transaction_multi_payment::Error::<Runtime>::EvmPermitInvalid.into(),
+			);
+			assert_eq!(
+				user_acc.balance(DAI),
+				dai_before,
+				"refused replay MUST NOT execute the inner call",
+			);
+			assert_eq!(
+				pallet_evm_precompile_call_permit::NoncesStorage::get(alith),
+				nonce_before + U256::one(),
+				"refused replay MUST NOT advance the nonce a second time",
+			);
+			assert_dispatch_permit_not_paused();
+		});
+	}
+
 	#[test]
 	fn unsigned_dispatch_permit_should_still_work_when_signed_branch_is_added() {
 		TestNet::reset();


### PR DESCRIPTION
Following up on the Discord conversation about the Call-Permit path: I offered to add a small regression test that locks in "nonce consumed on revert", and this is it. No production code is touched.

### What this pins

`do_dispatch_permit_signed` in `pallets/transaction-multi-payment/src/lib.rs` maps a reverting inner call to `Ok(post_info)` rather than `Err`, with this comment:

> Revert already consumed the nonce and charged gas; commit it like the unsigned path. Returning Err would roll the nonce back → replayable.

The new test, `permit_nonce_is_consumed_when_inner_call_reverts_and_replay_is_rejected`, exercises that end to end on the signed path:

1. the inner call reverts (unachievable `min_buy_amount`) and the extrinsic still returns `Ok`
2. the reverted call had no effect (the signer's DAI balance is unchanged)
3. the permit nonce advances by exactly one
4. re-submitting the byte-identical permit is refused with `EvmPermitInvalid`, before any execution
5. the refused replay does not advance the nonce a second time

### Why add it when coverage already exists

While writing it I found both halves already covered, and I would rather say so than oversell this:

* `signed_dispatch_permit_should_commit_and_consume_nonce_when_inner_call_reverts` pins the nonce bump on revert
* `signed_dispatch_permit_should_fail_when_replayed_with_same_nonce` pins that a spent nonce is refused, but on a permit that succeeded

What is not pinned anywhere is the composition, which is the property the comment is actually about. On the revert path the inner call had no effect, so a replay that got through would execute a call the signer authorized exactly once. Points 4 and 5 above are the part no existing test asserts. If you read this as redundant, I am happy for it to be closed; it seemed better to have the replay lock asserted directly than inferred from two separate tests.

### Batch variant

I looked at a two-permit batch variant (first leg reverts, second executes, first leg's replay refused) and left it out. The shared `build_permit_for_call` helper signs at nonce zero, so a second permit in the same batch would need a nonce parameter threaded through that helper and every existing call site. That is more churn than a regression test justifies.

### Verification

* `cargo test -p runtime-integration-tests evm_permit::` gives 43 passed, 0 failed
* mutation check 1: flipping the assertion to expect the nonce not consumed fails as it should (`left: 1, right: 0`)
* mutation check 2: locally changing `do_dispatch_permit_signed` to return `Err(e.error.into())` on revert, which is the rollback the comment warns about, turns this test red. Reverted afterwards
* `cargo fmt --all -- --check` is clean

### Notes

* Lives in `integration-tests/src/evm_permit.rs`, in the existing `sponsored_paymaster` module, reusing its `paymaster_account`, `build_permit_for_call` and `assert_dispatch_permit_not_paused` helpers. The pallet's own mock has no EVM, so this cannot live in the pallet's test module.
* `runtime-integration-tests` bumped to 1.107.2 to satisfy the crate version check.

Happy to rename the test, trim the comment, or drop the version bump if you handle that separately.